### PR TITLE
docs: Update reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ auth.clientCredentialsFlow.fetchAccessToken().then(response => {
     npm run build-doc
 Then open the the file `docs/index.html`
 
-### [API Documentation](https://kkbox.gelato.io)
+### [API Documentation](https://docs-en.kkbox.codes/)
 
 ### License
 Copyright 2017 KKBOX Technologies Limited

--- a/docs/ast/source/api/AlbumFetcher.js.json
+++ b/docs/ast/source/api/AlbumFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2105,
+  "end": 2002,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2105,
+    "end": 2002,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n ",
+            "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n ",
             "start": 80,
-            "end": 196,
+            "end": 186,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 197,
-        "end": 2105,
+        "start": 187,
+        "end": 2002,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 212,
-          "end": 2105,
+          "start": 202,
+          "end": 2002,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 218,
-            "end": 230,
+            "start": 208,
+            "end": 220,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 239,
-            "end": 246,
+            "start": 229,
+            "end": 236,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 247,
-            "end": 2105,
+            "start": 237,
+            "end": 2002,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 288,
-                "end": 440,
+                "start": 278,
+                "end": 430,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 288,
-                  "end": 299,
+                  "start": 278,
+                  "end": 289,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 300,
-                    "end": 304,
+                    "start": 290,
+                    "end": 294,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 306,
-                    "end": 322,
+                    "start": 296,
+                    "end": 312,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 306,
-                      "end": 315,
+                      "start": 296,
+                      "end": 305,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 318,
-                      "end": 322,
+                      "start": 308,
+                      "end": 312,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 324,
-                  "end": 440,
+                  "start": 314,
+                  "end": 430,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 334,
-                      "end": 356,
+                      "start": 324,
+                      "end": 346,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 334,
-                        "end": 356,
+                        "start": 324,
+                        "end": 346,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 334,
-                          "end": 339,
+                          "start": 324,
+                          "end": 329,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 340,
-                            "end": 344,
+                            "start": 330,
+                            "end": 334,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 346,
-                            "end": 355,
+                            "start": 336,
+                            "end": 345,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 366,
-                          "end": 400,
+                          "start": 356,
+                          "end": 390,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 409,
-                      "end": 434,
+                      "start": 399,
+                      "end": 424,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 409,
-                        "end": 434,
+                        "start": 399,
+                        "end": 424,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 409,
-                          "end": 422,
+                          "start": 399,
+                          "end": 412,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 409,
-                            "end": 413,
+                            "start": 399,
+                            "end": 403,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 414,
-                            "end": 422,
+                            "start": 404,
+                            "end": 412,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 425,
-                          "end": 434,
+                          "start": 415,
+                          "end": 424,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 366,
-                          "end": 400,
+                          "start": 356,
+                          "end": 390,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 257,
-                    "end": 283,
+                    "start": 247,
+                    "end": 273,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-                    "start": 446,
-                    "end": 680,
+                    "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+                    "start": 436,
+                    "end": 639,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 685,
-                "end": 774,
+                "start": 644,
+                "end": 733,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 685,
-                  "end": 695,
+                  "start": 644,
+                  "end": 654,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 696,
-                    "end": 704,
+                    "start": 655,
+                    "end": 663,
                     "loc": {
                       "start": {
                         "line": 28,
@@ -724,8 +724,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 706,
-                  "end": 774,
+                  "start": 665,
+                  "end": 733,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -739,8 +739,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 716,
-                      "end": 740,
+                      "start": 675,
+                      "end": 699,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -753,8 +753,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 716,
-                        "end": 740,
+                        "start": 675,
+                        "end": 699,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -768,8 +768,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 716,
-                          "end": 729,
+                          "start": 675,
+                          "end": 688,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -782,8 +782,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 716,
-                            "end": 720,
+                            "start": 675,
+                            "end": 679,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -797,8 +797,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 721,
-                            "end": 729,
+                            "start": 680,
+                            "end": 688,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -816,8 +816,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 732,
-                          "end": 740,
+                          "start": 691,
+                          "end": 699,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -835,8 +835,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 757,
-                      "end": 768,
+                      "start": 716,
+                      "end": 727,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -849,8 +849,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 764,
-                        "end": 768,
+                        "start": 723,
+                        "end": 727,
                         "loc": {
                           "start": {
                             "line": 30,
@@ -870,9 +870,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-                    "start": 446,
-                    "end": 680,
+                    "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+                    "start": 436,
+                    "end": 639,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -888,9 +888,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-                    "start": 780,
-                    "end": 1054,
+                    "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+                    "start": 739,
+                    "end": 982,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -906,8 +906,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1059,
-                "end": 1166,
+                "start": 987,
+                "end": 1094,
                 "loc": {
                   "start": {
                     "line": 40,
@@ -921,8 +921,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1059,
-                  "end": 1072,
+                  "start": 987,
+                  "end": 1000,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -946,8 +946,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1075,
-                  "end": 1166,
+                  "start": 1003,
+                  "end": 1094,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -961,8 +961,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1085,
-                      "end": 1160,
+                      "start": 1013,
+                      "end": 1088,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -975,8 +975,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1092,
-                        "end": 1160,
+                        "start": 1020,
+                        "end": 1088,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -989,8 +989,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1092,
-                          "end": 1105,
+                          "start": 1020,
+                          "end": 1033,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1003,8 +1003,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1092,
-                            "end": 1101,
+                            "start": 1020,
+                            "end": 1029,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1017,8 +1017,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1092,
-                              "end": 1096,
+                              "start": 1020,
+                              "end": 1024,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1032,8 +1032,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1097,
-                              "end": 1101,
+                              "start": 1025,
+                              "end": 1029,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1051,8 +1051,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1102,
-                            "end": 1105,
+                            "start": 1030,
+                            "end": 1033,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1071,8 +1071,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1106,
-                            "end": 1130,
+                            "start": 1034,
+                            "end": 1058,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1085,8 +1085,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1106,
-                              "end": 1114,
+                              "start": 1034,
+                              "end": 1042,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1103,8 +1103,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1117,
-                              "end": 1130,
+                              "start": 1045,
+                              "end": 1058,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1117,8 +1117,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1117,
-                                "end": 1121,
+                                "start": 1045,
+                                "end": 1049,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1132,8 +1132,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1122,
-                                "end": 1130,
+                                "start": 1050,
+                                "end": 1058,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1152,8 +1152,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1132,
-                            "end": 1159,
+                            "start": 1060,
+                            "end": 1087,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1167,8 +1167,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1133,
-                                "end": 1158,
+                                "start": 1061,
+                                "end": 1086,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1184,8 +1184,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1133,
-                                  "end": 1142,
+                                  "start": 1061,
+                                  "end": 1070,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1201,8 +1201,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1144,
-                                  "end": 1158,
+                                  "start": 1072,
+                                  "end": 1086,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1215,8 +1215,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1144,
-                                    "end": 1148,
+                                    "start": 1072,
+                                    "end": 1076,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1230,8 +1230,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1149,
-                                    "end": 1158,
+                                    "start": 1077,
+                                    "end": 1086,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1260,9 +1260,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-                    "start": 780,
-                    "end": 1054,
+                    "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+                    "start": 739,
+                    "end": 982,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -1279,8 +1279,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     ",
-                    "start": 1172,
-                    "end": 1331,
+                    "start": 1100,
+                    "end": 1259,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1296,8 +1296,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1336,
-                "end": 1434,
+                "start": 1264,
+                "end": 1362,
                 "loc": {
                   "start": {
                     "line": 49,
@@ -1311,8 +1311,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1336,
-                  "end": 1348,
+                  "start": 1264,
+                  "end": 1276,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1336,8 +1336,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1350,
-                  "end": 1434,
+                  "start": 1278,
+                  "end": 1362,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1351,8 +1351,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1360,
-                      "end": 1428,
+                      "start": 1288,
+                      "end": 1356,
                       "loc": {
                         "start": {
                           "line": 50,
@@ -1365,8 +1365,8 @@
                       },
                       "argument": {
                         "type": "TemplateLiteral",
-                        "start": 1367,
-                        "end": 1428,
+                        "start": 1295,
+                        "end": 1356,
                         "loc": {
                           "start": {
                             "line": 50,
@@ -1380,8 +1380,8 @@
                         "expressions": [
                           {
                             "type": "MemberExpression",
-                            "start": 1402,
-                            "end": 1415,
+                            "start": 1330,
+                            "end": 1343,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1394,8 +1394,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1402,
-                              "end": 1406,
+                              "start": 1330,
+                              "end": 1334,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1409,8 +1409,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1407,
-                              "end": 1415,
+                              "start": 1335,
+                              "end": 1343,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1430,8 +1430,8 @@
                         "quasis": [
                           {
                             "type": "TemplateElement",
-                            "start": 1368,
-                            "end": 1400,
+                            "start": 1296,
+                            "end": 1328,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1450,8 +1450,8 @@
                           },
                           {
                             "type": "TemplateElement",
-                            "start": 1416,
-                            "end": 1427,
+                            "start": 1344,
+                            "end": 1355,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1479,8 +1479,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     ",
-                    "start": 1172,
-                    "end": 1331,
+                    "start": 1100,
+                    "end": 1259,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1496,9 +1496,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks\n     ",
-                    "start": 1440,
-                    "end": 1868,
+                    "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks\n     ",
+                    "start": 1368,
+                    "end": 1765,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -1514,8 +1514,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1873,
-                "end": 2103,
+                "start": 1770,
+                "end": 2000,
                 "loc": {
                   "start": {
                     "line": 62,
@@ -1529,8 +1529,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1873,
-                  "end": 1884,
+                  "start": 1770,
+                  "end": 1781,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1554,8 +1554,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 1885,
-                    "end": 1902,
+                    "start": 1782,
+                    "end": 1799,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1568,8 +1568,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1885,
-                      "end": 1890,
+                      "start": 1782,
+                      "end": 1787,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1585,8 +1585,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 1893,
-                      "end": 1902,
+                      "start": 1790,
+                      "end": 1799,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1603,8 +1603,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 1904,
-                    "end": 1922,
+                    "start": 1801,
+                    "end": 1819,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1617,8 +1617,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1904,
-                      "end": 1910,
+                      "start": 1801,
+                      "end": 1807,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1634,8 +1634,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 1913,
-                      "end": 1922,
+                      "start": 1810,
+                      "end": 1819,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1653,8 +1653,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1924,
-                  "end": 2103,
+                  "start": 1821,
+                  "end": 2000,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1668,8 +1668,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1934,
-                      "end": 2097,
+                      "start": 1831,
+                      "end": 1994,
                       "loc": {
                         "start": {
                           "line": 63,
@@ -1682,8 +1682,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1941,
-                        "end": 2097,
+                        "start": 1838,
+                        "end": 1994,
                         "loc": {
                           "start": {
                             "line": 63,
@@ -1696,8 +1696,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1941,
-                          "end": 1954,
+                          "start": 1838,
+                          "end": 1851,
                           "loc": {
                             "start": {
                               "line": 63,
@@ -1710,8 +1710,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1941,
-                            "end": 1950,
+                            "start": 1838,
+                            "end": 1847,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1724,8 +1724,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1941,
-                              "end": 1945,
+                              "start": 1838,
+                              "end": 1842,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1739,8 +1739,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1946,
-                              "end": 1950,
+                              "start": 1843,
+                              "end": 1847,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1758,8 +1758,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1951,
-                            "end": 1954,
+                            "start": 1848,
+                            "end": 1851,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1778,8 +1778,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1955,
-                            "end": 1991,
+                            "start": 1852,
+                            "end": 1888,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1792,8 +1792,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 1955,
-                              "end": 1979,
+                              "start": 1852,
+                              "end": 1876,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1806,8 +1806,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1955,
-                                "end": 1963,
+                                "start": 1852,
+                                "end": 1860,
                                 "loc": {
                                   "start": {
                                     "line": 63,
@@ -1824,8 +1824,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 1966,
-                                "end": 1979,
+                                "start": 1863,
+                                "end": 1876,
                                 "loc": {
                                   "start": {
                                     "line": 63,
@@ -1838,8 +1838,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 1966,
-                                  "end": 1970,
+                                  "start": 1863,
+                                  "end": 1867,
                                   "loc": {
                                     "start": {
                                       "line": 63,
@@ -1853,8 +1853,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 1971,
-                                  "end": 1979,
+                                  "start": 1868,
+                                  "end": 1876,
                                   "loc": {
                                     "start": {
                                       "line": 63,
@@ -1874,8 +1874,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 1982,
-                              "end": 1991,
+                              "start": 1879,
+                              "end": 1888,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1895,8 +1895,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1993,
-                            "end": 2096,
+                            "start": 1890,
+                            "end": 1993,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1910,8 +1910,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 2007,
-                                "end": 2032,
+                                "start": 1904,
+                                "end": 1929,
                                 "loc": {
                                   "start": {
                                     "line": 64,
@@ -1927,8 +1927,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2007,
-                                  "end": 2016,
+                                  "start": 1904,
+                                  "end": 1913,
                                   "loc": {
                                     "start": {
                                       "line": 64,
@@ -1944,8 +1944,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 2018,
-                                  "end": 2032,
+                                  "start": 1915,
+                                  "end": 1929,
                                   "loc": {
                                     "start": {
                                       "line": 64,
@@ -1958,8 +1958,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 2018,
-                                    "end": 2022,
+                                    "start": 1915,
+                                    "end": 1919,
                                     "loc": {
                                       "start": {
                                         "line": 64,
@@ -1973,8 +1973,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2023,
-                                    "end": 2032,
+                                    "start": 1920,
+                                    "end": 1929,
                                     "loc": {
                                       "start": {
                                         "line": 64,
@@ -1993,8 +1993,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2046,
-                                "end": 2058,
+                                "start": 1943,
+                                "end": 1955,
                                 "loc": {
                                   "start": {
                                     "line": 65,
@@ -2010,8 +2010,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2046,
-                                  "end": 2051,
+                                  "start": 1943,
+                                  "end": 1948,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -2027,8 +2027,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2053,
-                                  "end": 2058,
+                                  "start": 1950,
+                                  "end": 1955,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -2045,8 +2045,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2072,
-                                "end": 2086,
+                                "start": 1969,
+                                "end": 1983,
                                 "loc": {
                                   "start": {
                                     "line": 66,
@@ -2062,8 +2062,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2072,
-                                  "end": 2078,
+                                  "start": 1969,
+                                  "end": 1975,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2079,8 +2079,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2080,
-                                  "end": 2086,
+                                  "start": 1977,
+                                  "end": 1983,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2106,9 +2106,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks\n     ",
-                    "start": 1440,
-                    "end": 1868,
+                    "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks\n     ",
+                    "start": 1368,
+                    "end": 1765,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -2127,9 +2127,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n ",
+              "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n ",
               "start": 80,
-              "end": 196,
+              "end": 186,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2147,9 +2147,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n ",
+            "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n ",
             "start": 80,
-            "end": 196,
+            "end": 186,
             "loc": {
               "start": {
                 "line": 4,
@@ -2169,9 +2169,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n ",
+      "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n ",
       "start": 80,
-      "end": 196,
+      "end": 186,
       "loc": {
         "start": {
           "line": 4,
@@ -2186,8 +2186,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 257,
-      "end": 283,
+      "start": 247,
+      "end": 273,
       "loc": {
         "start": {
           "line": 9,
@@ -2202,8 +2202,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 366,
-      "end": 400,
+      "start": 356,
+      "end": 390,
       "loc": {
         "start": {
           "line": 15,
@@ -2217,9 +2217,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-      "start": 446,
-      "end": 680,
+      "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+      "start": 436,
+      "end": 639,
       "loc": {
         "start": {
           "line": 21,
@@ -2233,9 +2233,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-      "start": 780,
-      "end": 1054,
+      "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+      "start": 739,
+      "end": 982,
       "loc": {
         "start": {
           "line": 33,
@@ -2250,8 +2250,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     ",
-      "start": 1172,
-      "end": 1331,
+      "start": 1100,
+      "end": 1259,
       "loc": {
         "start": {
           "line": 44,
@@ -2265,9 +2265,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks\n     ",
-      "start": 1440,
-      "end": 1868,
+      "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks\n     ",
+      "start": 1368,
+      "end": 1765,
       "loc": {
         "start": {
           "line": 53,
@@ -2599,9 +2599,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n ",
+      "value": "*\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n ",
       "start": 80,
-      "end": 196,
+      "end": 186,
       "loc": {
         "start": {
           "line": 4,
@@ -2628,8 +2628,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 197,
-      "end": 203,
+      "start": 187,
+      "end": 193,
       "loc": {
         "start": {
           "line": 8,
@@ -2656,8 +2656,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 204,
-      "end": 211,
+      "start": 194,
+      "end": 201,
       "loc": {
         "start": {
           "line": 8,
@@ -2684,8 +2684,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 212,
-      "end": 217,
+      "start": 202,
+      "end": 207,
       "loc": {
         "start": {
           "line": 8,
@@ -2710,8 +2710,8 @@
         "binop": null
       },
       "value": "AlbumFetcher",
-      "start": 218,
-      "end": 230,
+      "start": 208,
+      "end": 220,
       "loc": {
         "start": {
           "line": 8,
@@ -2738,8 +2738,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 231,
-      "end": 238,
+      "start": 221,
+      "end": 228,
       "loc": {
         "start": {
           "line": 8,
@@ -2764,8 +2764,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 239,
-      "end": 246,
+      "start": 229,
+      "end": 236,
       "loc": {
         "start": {
           "line": 8,
@@ -2789,8 +2789,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 247,
-      "end": 248,
+      "start": 237,
+      "end": 238,
       "loc": {
         "start": {
           "line": 8,
@@ -2805,8 +2805,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 257,
-      "end": 283,
+      "start": 247,
+      "end": 273,
       "loc": {
         "start": {
           "line": 9,
@@ -2831,8 +2831,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 288,
-      "end": 299,
+      "start": 278,
+      "end": 289,
       "loc": {
         "start": {
           "line": 12,
@@ -2856,8 +2856,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 299,
-      "end": 300,
+      "start": 289,
+      "end": 290,
       "loc": {
         "start": {
           "line": 12,
@@ -2882,8 +2882,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 300,
-      "end": 304,
+      "start": 290,
+      "end": 294,
       "loc": {
         "start": {
           "line": 12,
@@ -2908,8 +2908,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 304,
-      "end": 305,
+      "start": 294,
+      "end": 295,
       "loc": {
         "start": {
           "line": 12,
@@ -2934,8 +2934,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 306,
-      "end": 315,
+      "start": 296,
+      "end": 305,
       "loc": {
         "start": {
           "line": 12,
@@ -2961,8 +2961,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 316,
-      "end": 317,
+      "start": 306,
+      "end": 307,
       "loc": {
         "start": {
           "line": 12,
@@ -2988,8 +2988,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 318,
-      "end": 322,
+      "start": 308,
+      "end": 312,
       "loc": {
         "start": {
           "line": 12,
@@ -3013,8 +3013,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 322,
-      "end": 323,
+      "start": 312,
+      "end": 313,
       "loc": {
         "start": {
           "line": 12,
@@ -3038,8 +3038,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 324,
-      "end": 325,
+      "start": 314,
+      "end": 315,
       "loc": {
         "start": {
           "line": 12,
@@ -3066,8 +3066,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 334,
-      "end": 339,
+      "start": 324,
+      "end": 329,
       "loc": {
         "start": {
           "line": 13,
@@ -3091,8 +3091,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 339,
-      "end": 340,
+      "start": 329,
+      "end": 330,
       "loc": {
         "start": {
           "line": 13,
@@ -3117,8 +3117,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 340,
-      "end": 344,
+      "start": 330,
+      "end": 334,
       "loc": {
         "start": {
           "line": 13,
@@ -3143,8 +3143,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 344,
-      "end": 345,
+      "start": 334,
+      "end": 335,
       "loc": {
         "start": {
           "line": 13,
@@ -3169,8 +3169,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 346,
-      "end": 355,
+      "start": 336,
+      "end": 345,
       "loc": {
         "start": {
           "line": 13,
@@ -3194,8 +3194,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 355,
-      "end": 356,
+      "start": 345,
+      "end": 346,
       "loc": {
         "start": {
           "line": 13,
@@ -3210,8 +3210,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 366,
-      "end": 400,
+      "start": 356,
+      "end": 390,
       "loc": {
         "start": {
           "line": 15,
@@ -3238,8 +3238,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 409,
-      "end": 413,
+      "start": 399,
+      "end": 403,
       "loc": {
         "start": {
           "line": 18,
@@ -3264,8 +3264,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 413,
-      "end": 414,
+      "start": 403,
+      "end": 404,
       "loc": {
         "start": {
           "line": 18,
@@ -3290,8 +3290,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 414,
-      "end": 422,
+      "start": 404,
+      "end": 412,
       "loc": {
         "start": {
           "line": 18,
@@ -3317,8 +3317,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 423,
-      "end": 424,
+      "start": 413,
+      "end": 414,
       "loc": {
         "start": {
           "line": 18,
@@ -3343,8 +3343,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 425,
-      "end": 434,
+      "start": 415,
+      "end": 424,
       "loc": {
         "start": {
           "line": 18,
@@ -3368,8 +3368,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 439,
-      "end": 440,
+      "start": 429,
+      "end": 430,
       "loc": {
         "start": {
           "line": 19,
@@ -3383,9 +3383,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-      "start": 446,
-      "end": 680,
+      "value": "*\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+      "start": 436,
+      "end": 639,
       "loc": {
         "start": {
           "line": 21,
@@ -3410,8 +3410,8 @@
         "binop": null
       },
       "value": "setAlbumID",
-      "start": 685,
-      "end": 695,
+      "start": 644,
+      "end": 654,
       "loc": {
         "start": {
           "line": 28,
@@ -3435,8 +3435,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 695,
-      "end": 696,
+      "start": 654,
+      "end": 655,
       "loc": {
         "start": {
           "line": 28,
@@ -3461,8 +3461,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 696,
-      "end": 704,
+      "start": 655,
+      "end": 663,
       "loc": {
         "start": {
           "line": 28,
@@ -3486,8 +3486,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 704,
-      "end": 705,
+      "start": 663,
+      "end": 664,
       "loc": {
         "start": {
           "line": 28,
@@ -3511,8 +3511,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 706,
-      "end": 707,
+      "start": 665,
+      "end": 666,
       "loc": {
         "start": {
           "line": 28,
@@ -3539,8 +3539,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 716,
-      "end": 720,
+      "start": 675,
+      "end": 679,
       "loc": {
         "start": {
           "line": 29,
@@ -3565,8 +3565,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 720,
-      "end": 721,
+      "start": 679,
+      "end": 680,
       "loc": {
         "start": {
           "line": 29,
@@ -3591,8 +3591,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 721,
-      "end": 729,
+      "start": 680,
+      "end": 688,
       "loc": {
         "start": {
           "line": 29,
@@ -3618,8 +3618,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 730,
-      "end": 731,
+      "start": 689,
+      "end": 690,
       "loc": {
         "start": {
           "line": 29,
@@ -3644,8 +3644,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 732,
-      "end": 740,
+      "start": 691,
+      "end": 699,
       "loc": {
         "start": {
           "line": 29,
@@ -3672,8 +3672,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 757,
-      "end": 763,
+      "start": 716,
+      "end": 722,
       "loc": {
         "start": {
           "line": 30,
@@ -3700,8 +3700,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 764,
-      "end": 768,
+      "start": 723,
+      "end": 727,
       "loc": {
         "start": {
           "line": 30,
@@ -3725,8 +3725,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 773,
-      "end": 774,
+      "start": 732,
+      "end": 733,
       "loc": {
         "start": {
           "line": 31,
@@ -3740,9 +3740,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     ",
-      "start": 780,
-      "end": 1054,
+      "value": "*\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     ",
+      "start": 739,
+      "end": 982,
       "loc": {
         "start": {
           "line": 33,
@@ -3767,8 +3767,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1059,
-      "end": 1072,
+      "start": 987,
+      "end": 1000,
       "loc": {
         "start": {
           "line": 40,
@@ -3792,8 +3792,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1072,
-      "end": 1073,
+      "start": 1000,
+      "end": 1001,
       "loc": {
         "start": {
           "line": 40,
@@ -3817,8 +3817,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1073,
-      "end": 1074,
+      "start": 1001,
+      "end": 1002,
       "loc": {
         "start": {
           "line": 40,
@@ -3842,8 +3842,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1075,
-      "end": 1076,
+      "start": 1003,
+      "end": 1004,
       "loc": {
         "start": {
           "line": 40,
@@ -3870,8 +3870,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1085,
-      "end": 1091,
+      "start": 1013,
+      "end": 1019,
       "loc": {
         "start": {
           "line": 41,
@@ -3898,8 +3898,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1092,
-      "end": 1096,
+      "start": 1020,
+      "end": 1024,
       "loc": {
         "start": {
           "line": 41,
@@ -3924,8 +3924,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1096,
-      "end": 1097,
+      "start": 1024,
+      "end": 1025,
       "loc": {
         "start": {
           "line": 41,
@@ -3950,8 +3950,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1097,
-      "end": 1101,
+      "start": 1025,
+      "end": 1029,
       "loc": {
         "start": {
           "line": 41,
@@ -3976,8 +3976,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1101,
-      "end": 1102,
+      "start": 1029,
+      "end": 1030,
       "loc": {
         "start": {
           "line": 41,
@@ -4002,8 +4002,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1102,
-      "end": 1105,
+      "start": 1030,
+      "end": 1033,
       "loc": {
         "start": {
           "line": 41,
@@ -4027,8 +4027,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1105,
-      "end": 1106,
+      "start": 1033,
+      "end": 1034,
       "loc": {
         "start": {
           "line": 41,
@@ -4053,8 +4053,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1106,
-      "end": 1114,
+      "start": 1034,
+      "end": 1042,
       "loc": {
         "start": {
           "line": 41,
@@ -4080,8 +4080,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1115,
-      "end": 1116,
+      "start": 1043,
+      "end": 1044,
       "loc": {
         "start": {
           "line": 41,
@@ -4108,8 +4108,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1117,
-      "end": 1121,
+      "start": 1045,
+      "end": 1049,
       "loc": {
         "start": {
           "line": 41,
@@ -4134,8 +4134,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1121,
-      "end": 1122,
+      "start": 1049,
+      "end": 1050,
       "loc": {
         "start": {
           "line": 41,
@@ -4160,8 +4160,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 1122,
-      "end": 1130,
+      "start": 1050,
+      "end": 1058,
       "loc": {
         "start": {
           "line": 41,
@@ -4186,8 +4186,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1130,
-      "end": 1131,
+      "start": 1058,
+      "end": 1059,
       "loc": {
         "start": {
           "line": 41,
@@ -4211,8 +4211,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1132,
-      "end": 1133,
+      "start": 1060,
+      "end": 1061,
       "loc": {
         "start": {
           "line": 41,
@@ -4237,8 +4237,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1133,
-      "end": 1142,
+      "start": 1061,
+      "end": 1070,
       "loc": {
         "start": {
           "line": 41,
@@ -4263,8 +4263,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1142,
-      "end": 1143,
+      "start": 1070,
+      "end": 1071,
       "loc": {
         "start": {
           "line": 41,
@@ -4291,8 +4291,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1144,
-      "end": 1148,
+      "start": 1072,
+      "end": 1076,
       "loc": {
         "start": {
           "line": 41,
@@ -4317,8 +4317,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1148,
-      "end": 1149,
+      "start": 1076,
+      "end": 1077,
       "loc": {
         "start": {
           "line": 41,
@@ -4343,8 +4343,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1149,
-      "end": 1158,
+      "start": 1077,
+      "end": 1086,
       "loc": {
         "start": {
           "line": 41,
@@ -4368,8 +4368,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1158,
-      "end": 1159,
+      "start": 1086,
+      "end": 1087,
       "loc": {
         "start": {
           "line": 41,
@@ -4393,8 +4393,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1159,
-      "end": 1160,
+      "start": 1087,
+      "end": 1088,
       "loc": {
         "start": {
           "line": 41,
@@ -4418,8 +4418,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1165,
-      "end": 1166,
+      "start": 1093,
+      "end": 1094,
       "loc": {
         "start": {
           "line": 42,
@@ -4434,8 +4434,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     ",
-      "start": 1172,
-      "end": 1331,
+      "start": 1100,
+      "end": 1259,
       "loc": {
         "start": {
           "line": 44,
@@ -4460,8 +4460,8 @@
         "binop": null
       },
       "value": "getWidgetUri",
-      "start": 1336,
-      "end": 1348,
+      "start": 1264,
+      "end": 1276,
       "loc": {
         "start": {
           "line": 49,
@@ -4485,8 +4485,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1348,
-      "end": 1349,
+      "start": 1276,
+      "end": 1277,
       "loc": {
         "start": {
           "line": 49,
@@ -4510,8 +4510,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1349,
-      "end": 1350,
+      "start": 1277,
+      "end": 1278,
       "loc": {
         "start": {
           "line": 49,
@@ -4535,8 +4535,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1350,
-      "end": 1351,
+      "start": 1278,
+      "end": 1279,
       "loc": {
         "start": {
           "line": 49,
@@ -4563,8 +4563,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1360,
-      "end": 1366,
+      "start": 1288,
+      "end": 1294,
       "loc": {
         "start": {
           "line": 50,
@@ -4588,8 +4588,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1367,
-      "end": 1368,
+      "start": 1295,
+      "end": 1296,
       "loc": {
         "start": {
           "line": 50,
@@ -4615,8 +4615,8 @@
         "updateContext": null
       },
       "value": "https://widget.kkbox.com/v1/?id=",
-      "start": 1368,
-      "end": 1400,
+      "start": 1296,
+      "end": 1328,
       "loc": {
         "start": {
           "line": 50,
@@ -4640,8 +4640,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1400,
-      "end": 1402,
+      "start": 1328,
+      "end": 1330,
       "loc": {
         "start": {
           "line": 50,
@@ -4668,8 +4668,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1402,
-      "end": 1406,
+      "start": 1330,
+      "end": 1334,
       "loc": {
         "start": {
           "line": 50,
@@ -4694,8 +4694,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1406,
-      "end": 1407,
+      "start": 1334,
+      "end": 1335,
       "loc": {
         "start": {
           "line": 50,
@@ -4720,8 +4720,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 1407,
-      "end": 1415,
+      "start": 1335,
+      "end": 1343,
       "loc": {
         "start": {
           "line": 50,
@@ -4745,8 +4745,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1415,
-      "end": 1416,
+      "start": 1343,
+      "end": 1344,
       "loc": {
         "start": {
           "line": 50,
@@ -4772,8 +4772,8 @@
         "updateContext": null
       },
       "value": "&type=album",
-      "start": 1416,
-      "end": 1427,
+      "start": 1344,
+      "end": 1355,
       "loc": {
         "start": {
           "line": 50,
@@ -4797,8 +4797,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1427,
-      "end": 1428,
+      "start": 1355,
+      "end": 1356,
       "loc": {
         "start": {
           "line": 50,
@@ -4822,8 +4822,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1433,
-      "end": 1434,
+      "start": 1361,
+      "end": 1362,
       "loc": {
         "start": {
           "line": 51,
@@ -4837,9 +4837,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks\n     ",
-      "start": 1440,
-      "end": 1868,
+      "value": "*\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks\n     ",
+      "start": 1368,
+      "end": 1765,
       "loc": {
         "start": {
           "line": 53,
@@ -4864,8 +4864,8 @@
         "binop": null
       },
       "value": "fetchTracks",
-      "start": 1873,
-      "end": 1884,
+      "start": 1770,
+      "end": 1781,
       "loc": {
         "start": {
           "line": 62,
@@ -4889,8 +4889,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1884,
-      "end": 1885,
+      "start": 1781,
+      "end": 1782,
       "loc": {
         "start": {
           "line": 62,
@@ -4915,8 +4915,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1885,
-      "end": 1890,
+      "start": 1782,
+      "end": 1787,
       "loc": {
         "start": {
           "line": 62,
@@ -4942,8 +4942,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1891,
-      "end": 1892,
+      "start": 1788,
+      "end": 1789,
       "loc": {
         "start": {
           "line": 62,
@@ -4968,8 +4968,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1893,
-      "end": 1902,
+      "start": 1790,
+      "end": 1799,
       "loc": {
         "start": {
           "line": 62,
@@ -4994,8 +4994,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1902,
-      "end": 1903,
+      "start": 1799,
+      "end": 1800,
       "loc": {
         "start": {
           "line": 62,
@@ -5020,8 +5020,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1904,
-      "end": 1910,
+      "start": 1801,
+      "end": 1807,
       "loc": {
         "start": {
           "line": 62,
@@ -5047,8 +5047,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1911,
-      "end": 1912,
+      "start": 1808,
+      "end": 1809,
       "loc": {
         "start": {
           "line": 62,
@@ -5073,8 +5073,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1913,
-      "end": 1922,
+      "start": 1810,
+      "end": 1819,
       "loc": {
         "start": {
           "line": 62,
@@ -5098,8 +5098,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1922,
-      "end": 1923,
+      "start": 1819,
+      "end": 1820,
       "loc": {
         "start": {
           "line": 62,
@@ -5123,8 +5123,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1924,
-      "end": 1925,
+      "start": 1821,
+      "end": 1822,
       "loc": {
         "start": {
           "line": 62,
@@ -5151,8 +5151,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1934,
-      "end": 1940,
+      "start": 1831,
+      "end": 1837,
       "loc": {
         "start": {
           "line": 63,
@@ -5179,8 +5179,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1941,
-      "end": 1945,
+      "start": 1838,
+      "end": 1842,
       "loc": {
         "start": {
           "line": 63,
@@ -5205,8 +5205,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1945,
-      "end": 1946,
+      "start": 1842,
+      "end": 1843,
       "loc": {
         "start": {
           "line": 63,
@@ -5231,8 +5231,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1946,
-      "end": 1950,
+      "start": 1843,
+      "end": 1847,
       "loc": {
         "start": {
           "line": 63,
@@ -5257,8 +5257,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1950,
-      "end": 1951,
+      "start": 1847,
+      "end": 1848,
       "loc": {
         "start": {
           "line": 63,
@@ -5283,8 +5283,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1951,
-      "end": 1954,
+      "start": 1848,
+      "end": 1851,
       "loc": {
         "start": {
           "line": 63,
@@ -5308,8 +5308,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1954,
-      "end": 1955,
+      "start": 1851,
+      "end": 1852,
       "loc": {
         "start": {
           "line": 63,
@@ -5334,8 +5334,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1955,
-      "end": 1963,
+      "start": 1852,
+      "end": 1860,
       "loc": {
         "start": {
           "line": 63,
@@ -5361,8 +5361,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1964,
-      "end": 1965,
+      "start": 1861,
+      "end": 1862,
       "loc": {
         "start": {
           "line": 63,
@@ -5389,8 +5389,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1966,
-      "end": 1970,
+      "start": 1863,
+      "end": 1867,
       "loc": {
         "start": {
           "line": 63,
@@ -5415,8 +5415,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1970,
-      "end": 1971,
+      "start": 1867,
+      "end": 1868,
       "loc": {
         "start": {
           "line": 63,
@@ -5441,8 +5441,8 @@
         "binop": null
       },
       "value": "album_id",
-      "start": 1971,
-      "end": 1979,
+      "start": 1868,
+      "end": 1876,
       "loc": {
         "start": {
           "line": 63,
@@ -5468,8 +5468,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1980,
-      "end": 1981,
+      "start": 1877,
+      "end": 1878,
       "loc": {
         "start": {
           "line": 63,
@@ -5495,8 +5495,8 @@
         "updateContext": null
       },
       "value": "/tracks",
-      "start": 1982,
-      "end": 1991,
+      "start": 1879,
+      "end": 1888,
       "loc": {
         "start": {
           "line": 63,
@@ -5521,8 +5521,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1991,
-      "end": 1992,
+      "start": 1888,
+      "end": 1889,
       "loc": {
         "start": {
           "line": 63,
@@ -5546,8 +5546,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1993,
-      "end": 1994,
+      "start": 1890,
+      "end": 1891,
       "loc": {
         "start": {
           "line": 63,
@@ -5572,8 +5572,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2007,
-      "end": 2016,
+      "start": 1904,
+      "end": 1913,
       "loc": {
         "start": {
           "line": 64,
@@ -5598,8 +5598,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2016,
-      "end": 2017,
+      "start": 1913,
+      "end": 1914,
       "loc": {
         "start": {
           "line": 64,
@@ -5626,8 +5626,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2018,
-      "end": 2022,
+      "start": 1915,
+      "end": 1919,
       "loc": {
         "start": {
           "line": 64,
@@ -5652,8 +5652,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2022,
-      "end": 2023,
+      "start": 1919,
+      "end": 1920,
       "loc": {
         "start": {
           "line": 64,
@@ -5678,8 +5678,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2023,
-      "end": 2032,
+      "start": 1920,
+      "end": 1929,
       "loc": {
         "start": {
           "line": 64,
@@ -5704,8 +5704,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2032,
-      "end": 2033,
+      "start": 1929,
+      "end": 1930,
       "loc": {
         "start": {
           "line": 64,
@@ -5730,8 +5730,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2046,
-      "end": 2051,
+      "start": 1943,
+      "end": 1948,
       "loc": {
         "start": {
           "line": 65,
@@ -5756,8 +5756,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2051,
-      "end": 2052,
+      "start": 1948,
+      "end": 1949,
       "loc": {
         "start": {
           "line": 65,
@@ -5782,8 +5782,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2053,
-      "end": 2058,
+      "start": 1950,
+      "end": 1955,
       "loc": {
         "start": {
           "line": 65,
@@ -5808,8 +5808,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2058,
-      "end": 2059,
+      "start": 1955,
+      "end": 1956,
       "loc": {
         "start": {
           "line": 65,
@@ -5834,8 +5834,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2072,
-      "end": 2078,
+      "start": 1969,
+      "end": 1975,
       "loc": {
         "start": {
           "line": 66,
@@ -5860,8 +5860,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2078,
-      "end": 2079,
+      "start": 1975,
+      "end": 1976,
       "loc": {
         "start": {
           "line": 66,
@@ -5886,8 +5886,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2080,
-      "end": 2086,
+      "start": 1977,
+      "end": 1983,
       "loc": {
         "start": {
           "line": 66,
@@ -5911,8 +5911,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2095,
-      "end": 2096,
+      "start": 1992,
+      "end": 1993,
       "loc": {
         "start": {
           "line": 67,
@@ -5936,8 +5936,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2096,
-      "end": 2097,
+      "start": 1993,
+      "end": 1994,
       "loc": {
         "start": {
           "line": 67,
@@ -5961,8 +5961,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2102,
-      "end": 2103,
+      "start": 1999,
+      "end": 2000,
       "loc": {
         "start": {
           "line": 68,
@@ -5986,8 +5986,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2104,
-      "end": 2105,
+      "start": 2001,
+      "end": 2002,
       "loc": {
         "start": {
           "line": 69,
@@ -6012,8 +6012,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2105,
-      "end": 2105,
+      "start": 2002,
+      "end": 2002,
       "loc": {
         "start": {
           "line": 69,

--- a/docs/ast/source/api/ArtistFetcher.js.json
+++ b/docs/ast/source/api/ArtistFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2448,
+  "end": 2309,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2448,
+    "end": 2309,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n ",
+            "value": "*\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n ",
             "start": 81,
-            "end": 181,
+            "end": 171,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 182,
-        "end": 2448,
+        "start": 172,
+        "end": 2309,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 197,
-          "end": 2448,
+          "start": 187,
+          "end": 2309,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 203,
-            "end": 216,
+            "start": 193,
+            "end": 206,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 225,
-            "end": 232,
+            "start": 215,
+            "end": 222,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 233,
-            "end": 2448,
+            "start": 223,
+            "end": 2309,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 270,
-                "end": 423,
+                "start": 260,
+                "end": 413,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 270,
-                  "end": 281,
+                  "start": 260,
+                  "end": 271,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 282,
-                    "end": 286,
+                    "start": 272,
+                    "end": 276,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 288,
-                    "end": 304,
+                    "start": 278,
+                    "end": 294,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 288,
-                      "end": 297,
+                      "start": 278,
+                      "end": 287,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 300,
-                      "end": 304,
+                      "start": 290,
+                      "end": 294,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 306,
-                  "end": 423,
+                  "start": 296,
+                  "end": 413,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 316,
-                      "end": 338,
+                      "start": 306,
+                      "end": 328,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 316,
-                        "end": 338,
+                        "start": 306,
+                        "end": 328,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 316,
-                          "end": 321,
+                          "start": 306,
+                          "end": 311,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 322,
-                            "end": 326,
+                            "start": 312,
+                            "end": 316,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 328,
-                            "end": 337,
+                            "start": 318,
+                            "end": 327,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 348,
-                          "end": 382,
+                          "start": 338,
+                          "end": 372,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 391,
-                      "end": 417,
+                      "start": 381,
+                      "end": 407,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 391,
-                        "end": 417,
+                        "start": 381,
+                        "end": 407,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 391,
-                          "end": 405,
+                          "start": 381,
+                          "end": 395,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 391,
-                            "end": 395,
+                            "start": 381,
+                            "end": 385,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 396,
-                            "end": 405,
+                            "start": 386,
+                            "end": 395,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 408,
-                          "end": 417,
+                          "start": 398,
+                          "end": 407,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 348,
-                          "end": 382,
+                          "start": 338,
+                          "end": 372,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 239,
-                    "end": 265,
+                    "start": 229,
+                    "end": 255,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-                    "start": 429,
-                    "end": 663,
+                    "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+                    "start": 419,
+                    "end": 621,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 668,
-                "end": 753,
+                "start": 626,
+                "end": 711,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 668,
-                  "end": 679,
+                  "start": 626,
+                  "end": 637,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 680,
-                    "end": 689,
+                    "start": 638,
+                    "end": 647,
                     "loc": {
                       "start": {
                         "line": 28,
@@ -724,8 +724,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 691,
-                  "end": 753,
+                  "start": 649,
+                  "end": 711,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -739,8 +739,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 701,
-                      "end": 727,
+                      "start": 659,
+                      "end": 685,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -753,8 +753,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 701,
-                        "end": 727,
+                        "start": 659,
+                        "end": 685,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -768,8 +768,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 701,
-                          "end": 715,
+                          "start": 659,
+                          "end": 673,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -782,8 +782,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 701,
-                            "end": 705,
+                            "start": 659,
+                            "end": 663,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -797,8 +797,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 706,
-                            "end": 715,
+                            "start": 664,
+                            "end": 673,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -816,8 +816,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 718,
-                          "end": 727,
+                          "start": 676,
+                          "end": 685,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -835,8 +835,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 736,
-                      "end": 747,
+                      "start": 694,
+                      "end": 705,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -849,8 +849,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 743,
-                        "end": 747,
+                        "start": 701,
+                        "end": 705,
                         "loc": {
                           "start": {
                             "line": 30,
@@ -870,9 +870,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-                    "start": 429,
-                    "end": 663,
+                    "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+                    "start": 419,
+                    "end": 621,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -888,9 +888,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-                    "start": 759,
-                    "end": 1030,
+                    "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+                    "start": 717,
+                    "end": 956,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -906,8 +906,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1035,
-                "end": 1143,
+                "start": 961,
+                "end": 1069,
                 "loc": {
                   "start": {
                     "line": 40,
@@ -921,8 +921,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1035,
-                  "end": 1048,
+                  "start": 961,
+                  "end": 974,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -946,8 +946,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1051,
-                  "end": 1143,
+                  "start": 977,
+                  "end": 1069,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -961,8 +961,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1061,
-                      "end": 1137,
+                      "start": 987,
+                      "end": 1063,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -975,8 +975,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1068,
-                        "end": 1137,
+                        "start": 994,
+                        "end": 1063,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -989,8 +989,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1068,
-                          "end": 1081,
+                          "start": 994,
+                          "end": 1007,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1003,8 +1003,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1068,
-                            "end": 1077,
+                            "start": 994,
+                            "end": 1003,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1017,8 +1017,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1068,
-                              "end": 1072,
+                              "start": 994,
+                              "end": 998,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1032,8 +1032,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1073,
-                              "end": 1077,
+                              "start": 999,
+                              "end": 1003,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1051,8 +1051,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1078,
-                            "end": 1081,
+                            "start": 1004,
+                            "end": 1007,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1071,8 +1071,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1082,
-                            "end": 1107,
+                            "start": 1008,
+                            "end": 1033,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1085,8 +1085,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1082,
-                              "end": 1090,
+                              "start": 1008,
+                              "end": 1016,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1103,8 +1103,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1093,
-                              "end": 1107,
+                              "start": 1019,
+                              "end": 1033,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1117,8 +1117,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1093,
-                                "end": 1097,
+                                "start": 1019,
+                                "end": 1023,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1132,8 +1132,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1098,
-                                "end": 1107,
+                                "start": 1024,
+                                "end": 1033,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1152,8 +1152,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1109,
-                            "end": 1136,
+                            "start": 1035,
+                            "end": 1062,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1167,8 +1167,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1110,
-                                "end": 1135,
+                                "start": 1036,
+                                "end": 1061,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1184,8 +1184,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1110,
-                                  "end": 1119,
+                                  "start": 1036,
+                                  "end": 1045,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1201,8 +1201,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1121,
-                                  "end": 1135,
+                                  "start": 1047,
+                                  "end": 1061,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1215,8 +1215,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1121,
-                                    "end": 1125,
+                                    "start": 1047,
+                                    "end": 1051,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1230,8 +1230,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1126,
-                                    "end": 1135,
+                                    "start": 1052,
+                                    "end": 1061,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1260,9 +1260,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-                    "start": 759,
-                    "end": 1030,
+                    "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+                    "start": 717,
+                    "end": 956,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -1278,9 +1278,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums\n     ",
-                    "start": 1149,
-                    "end": 1553,
+                    "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums\n     ",
+                    "start": 1075,
+                    "end": 1447,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1296,8 +1296,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1558,
-                "end": 1789,
+                "start": 1452,
+                "end": 1683,
                 "loc": {
                   "start": {
                     "line": 53,
@@ -1311,8 +1311,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1558,
-                  "end": 1569,
+                  "start": 1452,
+                  "end": 1463,
                   "loc": {
                     "start": {
                       "line": 53,
@@ -1336,8 +1336,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 1570,
-                    "end": 1587,
+                    "start": 1464,
+                    "end": 1481,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -1350,8 +1350,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1570,
-                      "end": 1575,
+                      "start": 1464,
+                      "end": 1469,
                       "loc": {
                         "start": {
                           "line": 53,
@@ -1367,8 +1367,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 1578,
-                      "end": 1587,
+                      "start": 1472,
+                      "end": 1481,
                       "loc": {
                         "start": {
                           "line": 53,
@@ -1385,8 +1385,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 1589,
-                    "end": 1607,
+                    "start": 1483,
+                    "end": 1501,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -1399,8 +1399,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1589,
-                      "end": 1595,
+                      "start": 1483,
+                      "end": 1489,
                       "loc": {
                         "start": {
                           "line": 53,
@@ -1416,8 +1416,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 1598,
-                      "end": 1607,
+                      "start": 1492,
+                      "end": 1501,
                       "loc": {
                         "start": {
                           "line": 53,
@@ -1435,8 +1435,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1609,
-                  "end": 1789,
+                  "start": 1503,
+                  "end": 1683,
                   "loc": {
                     "start": {
                       "line": 53,
@@ -1450,8 +1450,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1619,
-                      "end": 1783,
+                      "start": 1513,
+                      "end": 1677,
                       "loc": {
                         "start": {
                           "line": 54,
@@ -1464,8 +1464,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1626,
-                        "end": 1783,
+                        "start": 1520,
+                        "end": 1677,
                         "loc": {
                           "start": {
                             "line": 54,
@@ -1478,8 +1478,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1626,
-                          "end": 1639,
+                          "start": 1520,
+                          "end": 1533,
                           "loc": {
                             "start": {
                               "line": 54,
@@ -1492,8 +1492,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1626,
-                            "end": 1635,
+                            "start": 1520,
+                            "end": 1529,
                             "loc": {
                               "start": {
                                 "line": 54,
@@ -1506,8 +1506,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1626,
-                              "end": 1630,
+                              "start": 1520,
+                              "end": 1524,
                               "loc": {
                                 "start": {
                                   "line": 54,
@@ -1521,8 +1521,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1631,
-                              "end": 1635,
+                              "start": 1525,
+                              "end": 1529,
                               "loc": {
                                 "start": {
                                   "line": 54,
@@ -1540,8 +1540,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1636,
-                            "end": 1639,
+                            "start": 1530,
+                            "end": 1533,
                             "loc": {
                               "start": {
                                 "line": 54,
@@ -1560,8 +1560,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1640,
-                            "end": 1677,
+                            "start": 1534,
+                            "end": 1571,
                             "loc": {
                               "start": {
                                 "line": 54,
@@ -1574,8 +1574,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 1640,
-                              "end": 1665,
+                              "start": 1534,
+                              "end": 1559,
                               "loc": {
                                 "start": {
                                   "line": 54,
@@ -1588,8 +1588,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1640,
-                                "end": 1648,
+                                "start": 1534,
+                                "end": 1542,
                                 "loc": {
                                   "start": {
                                     "line": 54,
@@ -1606,8 +1606,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 1651,
-                                "end": 1665,
+                                "start": 1545,
+                                "end": 1559,
                                 "loc": {
                                   "start": {
                                     "line": 54,
@@ -1620,8 +1620,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 1651,
-                                  "end": 1655,
+                                  "start": 1545,
+                                  "end": 1549,
                                   "loc": {
                                     "start": {
                                       "line": 54,
@@ -1635,8 +1635,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 1656,
-                                  "end": 1665,
+                                  "start": 1550,
+                                  "end": 1559,
                                   "loc": {
                                     "start": {
                                       "line": 54,
@@ -1656,8 +1656,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 1668,
-                              "end": 1677,
+                              "start": 1562,
+                              "end": 1571,
                               "loc": {
                                 "start": {
                                   "line": 54,
@@ -1677,8 +1677,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1679,
-                            "end": 1782,
+                            "start": 1573,
+                            "end": 1676,
                             "loc": {
                               "start": {
                                 "line": 54,
@@ -1692,8 +1692,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1693,
-                                "end": 1718,
+                                "start": 1587,
+                                "end": 1612,
                                 "loc": {
                                   "start": {
                                     "line": 55,
@@ -1709,8 +1709,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1693,
-                                  "end": 1702,
+                                  "start": 1587,
+                                  "end": 1596,
                                   "loc": {
                                     "start": {
                                       "line": 55,
@@ -1726,8 +1726,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1704,
-                                  "end": 1718,
+                                  "start": 1598,
+                                  "end": 1612,
                                   "loc": {
                                     "start": {
                                       "line": 55,
@@ -1740,8 +1740,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1704,
-                                    "end": 1708,
+                                    "start": 1598,
+                                    "end": 1602,
                                     "loc": {
                                       "start": {
                                         "line": 55,
@@ -1755,8 +1755,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1709,
-                                    "end": 1718,
+                                    "start": 1603,
+                                    "end": 1612,
                                     "loc": {
                                       "start": {
                                         "line": 55,
@@ -1775,8 +1775,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1732,
-                                "end": 1744,
+                                "start": 1626,
+                                "end": 1638,
                                 "loc": {
                                   "start": {
                                     "line": 56,
@@ -1792,8 +1792,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1732,
-                                  "end": 1737,
+                                  "start": 1626,
+                                  "end": 1631,
                                   "loc": {
                                     "start": {
                                       "line": 56,
@@ -1809,8 +1809,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1739,
-                                  "end": 1744,
+                                  "start": 1633,
+                                  "end": 1638,
                                   "loc": {
                                     "start": {
                                       "line": 56,
@@ -1827,8 +1827,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1758,
-                                "end": 1772,
+                                "start": 1652,
+                                "end": 1666,
                                 "loc": {
                                   "start": {
                                     "line": 57,
@@ -1844,8 +1844,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1758,
-                                  "end": 1764,
+                                  "start": 1652,
+                                  "end": 1658,
                                   "loc": {
                                     "start": {
                                       "line": 57,
@@ -1861,8 +1861,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1766,
-                                  "end": 1772,
+                                  "start": 1660,
+                                  "end": 1666,
                                   "loc": {
                                     "start": {
                                       "line": 57,
@@ -1889,9 +1889,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums\n     ",
-                    "start": 1149,
-                    "end": 1553,
+                    "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums\n     ",
+                    "start": 1075,
+                    "end": 1447,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1907,9 +1907,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks\n     ",
-                    "start": 1795,
-                    "end": 2203,
+                    "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks\n     ",
+                    "start": 1689,
+                    "end": 2064,
                     "loc": {
                       "start": {
                         "line": 61,
@@ -1925,8 +1925,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 2208,
-                "end": 2446,
+                "start": 2069,
+                "end": 2307,
                 "loc": {
                   "start": {
                     "line": 70,
@@ -1940,8 +1940,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 2208,
-                  "end": 2222,
+                  "start": 2069,
+                  "end": 2083,
                   "loc": {
                     "start": {
                       "line": 70,
@@ -1965,8 +1965,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 2223,
-                    "end": 2240,
+                    "start": 2084,
+                    "end": 2101,
                     "loc": {
                       "start": {
                         "line": 70,
@@ -1979,8 +1979,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2223,
-                      "end": 2228,
+                      "start": 2084,
+                      "end": 2089,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -1996,8 +1996,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2231,
-                      "end": 2240,
+                      "start": 2092,
+                      "end": 2101,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -2014,8 +2014,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 2242,
-                    "end": 2260,
+                    "start": 2103,
+                    "end": 2121,
                     "loc": {
                       "start": {
                         "line": 70,
@@ -2028,8 +2028,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2242,
-                      "end": 2248,
+                      "start": 2103,
+                      "end": 2109,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -2045,8 +2045,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2251,
-                      "end": 2260,
+                      "start": 2112,
+                      "end": 2121,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -2064,8 +2064,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 2262,
-                  "end": 2446,
+                  "start": 2123,
+                  "end": 2307,
                   "loc": {
                     "start": {
                       "line": 70,
@@ -2079,8 +2079,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 2272,
-                      "end": 2440,
+                      "start": 2133,
+                      "end": 2301,
                       "loc": {
                         "start": {
                           "line": 71,
@@ -2093,8 +2093,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 2279,
-                        "end": 2440,
+                        "start": 2140,
+                        "end": 2301,
                         "loc": {
                           "start": {
                             "line": 71,
@@ -2107,8 +2107,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 2279,
-                          "end": 2292,
+                          "start": 2140,
+                          "end": 2153,
                           "loc": {
                             "start": {
                               "line": 71,
@@ -2121,8 +2121,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 2279,
-                            "end": 2288,
+                            "start": 2140,
+                            "end": 2149,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2135,8 +2135,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 2279,
-                              "end": 2283,
+                              "start": 2140,
+                              "end": 2144,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2150,8 +2150,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 2284,
-                              "end": 2288,
+                              "start": 2145,
+                              "end": 2149,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2169,8 +2169,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 2289,
-                            "end": 2292,
+                            "start": 2150,
+                            "end": 2153,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2189,8 +2189,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 2293,
-                            "end": 2334,
+                            "start": 2154,
+                            "end": 2195,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2203,8 +2203,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 2293,
-                              "end": 2318,
+                              "start": 2154,
+                              "end": 2179,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2217,8 +2217,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 2293,
-                                "end": 2301,
+                                "start": 2154,
+                                "end": 2162,
                                 "loc": {
                                   "start": {
                                     "line": 71,
@@ -2235,8 +2235,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 2304,
-                                "end": 2318,
+                                "start": 2165,
+                                "end": 2179,
                                 "loc": {
                                   "start": {
                                     "line": 71,
@@ -2249,8 +2249,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 2304,
-                                  "end": 2308,
+                                  "start": 2165,
+                                  "end": 2169,
                                   "loc": {
                                     "start": {
                                       "line": 71,
@@ -2264,8 +2264,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2309,
-                                  "end": 2318,
+                                  "start": 2170,
+                                  "end": 2179,
                                   "loc": {
                                     "start": {
                                       "line": 71,
@@ -2285,8 +2285,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 2321,
-                              "end": 2334,
+                              "start": 2182,
+                              "end": 2195,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2306,8 +2306,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 2336,
-                            "end": 2439,
+                            "start": 2197,
+                            "end": 2300,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2321,8 +2321,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 2350,
-                                "end": 2375,
+                                "start": 2211,
+                                "end": 2236,
                                 "loc": {
                                   "start": {
                                     "line": 72,
@@ -2338,8 +2338,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2350,
-                                  "end": 2359,
+                                  "start": 2211,
+                                  "end": 2220,
                                   "loc": {
                                     "start": {
                                       "line": 72,
@@ -2355,8 +2355,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 2361,
-                                  "end": 2375,
+                                  "start": 2222,
+                                  "end": 2236,
                                   "loc": {
                                     "start": {
                                       "line": 72,
@@ -2369,8 +2369,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 2361,
-                                    "end": 2365,
+                                    "start": 2222,
+                                    "end": 2226,
                                     "loc": {
                                       "start": {
                                         "line": 72,
@@ -2384,8 +2384,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2366,
-                                    "end": 2375,
+                                    "start": 2227,
+                                    "end": 2236,
                                     "loc": {
                                       "start": {
                                         "line": 72,
@@ -2404,8 +2404,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2389,
-                                "end": 2401,
+                                "start": 2250,
+                                "end": 2262,
                                 "loc": {
                                   "start": {
                                     "line": 73,
@@ -2421,8 +2421,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2389,
-                                  "end": 2394,
+                                  "start": 2250,
+                                  "end": 2255,
                                   "loc": {
                                     "start": {
                                       "line": 73,
@@ -2438,8 +2438,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2396,
-                                  "end": 2401,
+                                  "start": 2257,
+                                  "end": 2262,
                                   "loc": {
                                     "start": {
                                       "line": 73,
@@ -2456,8 +2456,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2415,
-                                "end": 2429,
+                                "start": 2276,
+                                "end": 2290,
                                 "loc": {
                                   "start": {
                                     "line": 74,
@@ -2473,8 +2473,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2415,
-                                  "end": 2421,
+                                  "start": 2276,
+                                  "end": 2282,
                                   "loc": {
                                     "start": {
                                       "line": 74,
@@ -2490,8 +2490,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2423,
-                                  "end": 2429,
+                                  "start": 2284,
+                                  "end": 2290,
                                   "loc": {
                                     "start": {
                                       "line": 74,
@@ -2517,9 +2517,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks\n     ",
-                    "start": 1795,
-                    "end": 2203,
+                    "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks\n     ",
+                    "start": 1689,
+                    "end": 2064,
                     "loc": {
                       "start": {
                         "line": 61,
@@ -2538,9 +2538,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n ",
+              "value": "*\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n ",
               "start": 81,
-              "end": 181,
+              "end": 171,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2558,9 +2558,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n ",
+            "value": "*\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n ",
             "start": 81,
-            "end": 181,
+            "end": 171,
             "loc": {
               "start": {
                 "line": 4,
@@ -2580,9 +2580,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n ",
+      "value": "*\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n ",
       "start": 81,
-      "end": 181,
+      "end": 171,
       "loc": {
         "start": {
           "line": 4,
@@ -2597,8 +2597,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 239,
-      "end": 265,
+      "start": 229,
+      "end": 255,
       "loc": {
         "start": {
           "line": 9,
@@ -2613,8 +2613,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 348,
-      "end": 382,
+      "start": 338,
+      "end": 372,
       "loc": {
         "start": {
           "line": 15,
@@ -2628,9 +2628,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-      "start": 429,
-      "end": 663,
+      "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+      "start": 419,
+      "end": 621,
       "loc": {
         "start": {
           "line": 21,
@@ -2644,9 +2644,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-      "start": 759,
-      "end": 1030,
+      "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+      "start": 717,
+      "end": 956,
       "loc": {
         "start": {
           "line": 33,
@@ -2660,9 +2660,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums\n     ",
-      "start": 1149,
-      "end": 1553,
+      "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums\n     ",
+      "start": 1075,
+      "end": 1447,
       "loc": {
         "start": {
           "line": 44,
@@ -2676,9 +2676,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks\n     ",
-      "start": 1795,
-      "end": 2203,
+      "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks\n     ",
+      "start": 1689,
+      "end": 2064,
       "loc": {
         "start": {
           "line": 61,
@@ -3010,9 +3010,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n ",
+      "value": "*\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n ",
       "start": 81,
-      "end": 181,
+      "end": 171,
       "loc": {
         "start": {
           "line": 4,
@@ -3039,8 +3039,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 182,
-      "end": 188,
+      "start": 172,
+      "end": 178,
       "loc": {
         "start": {
           "line": 8,
@@ -3067,8 +3067,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 189,
-      "end": 196,
+      "start": 179,
+      "end": 186,
       "loc": {
         "start": {
           "line": 8,
@@ -3095,8 +3095,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 197,
-      "end": 202,
+      "start": 187,
+      "end": 192,
       "loc": {
         "start": {
           "line": 8,
@@ -3121,8 +3121,8 @@
         "binop": null
       },
       "value": "ArtistFetcher",
-      "start": 203,
-      "end": 216,
+      "start": 193,
+      "end": 206,
       "loc": {
         "start": {
           "line": 8,
@@ -3149,8 +3149,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 217,
-      "end": 224,
+      "start": 207,
+      "end": 214,
       "loc": {
         "start": {
           "line": 8,
@@ -3175,8 +3175,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 225,
-      "end": 232,
+      "start": 215,
+      "end": 222,
       "loc": {
         "start": {
           "line": 8,
@@ -3200,8 +3200,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 233,
-      "end": 234,
+      "start": 223,
+      "end": 224,
       "loc": {
         "start": {
           "line": 8,
@@ -3216,8 +3216,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 239,
-      "end": 265,
+      "start": 229,
+      "end": 255,
       "loc": {
         "start": {
           "line": 9,
@@ -3242,8 +3242,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 270,
-      "end": 281,
+      "start": 260,
+      "end": 271,
       "loc": {
         "start": {
           "line": 12,
@@ -3267,8 +3267,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 281,
-      "end": 282,
+      "start": 271,
+      "end": 272,
       "loc": {
         "start": {
           "line": 12,
@@ -3293,8 +3293,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 282,
-      "end": 286,
+      "start": 272,
+      "end": 276,
       "loc": {
         "start": {
           "line": 12,
@@ -3319,8 +3319,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 286,
-      "end": 287,
+      "start": 276,
+      "end": 277,
       "loc": {
         "start": {
           "line": 12,
@@ -3345,8 +3345,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 288,
-      "end": 297,
+      "start": 278,
+      "end": 287,
       "loc": {
         "start": {
           "line": 12,
@@ -3372,8 +3372,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 298,
-      "end": 299,
+      "start": 288,
+      "end": 289,
       "loc": {
         "start": {
           "line": 12,
@@ -3399,8 +3399,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 300,
-      "end": 304,
+      "start": 290,
+      "end": 294,
       "loc": {
         "start": {
           "line": 12,
@@ -3424,8 +3424,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 304,
-      "end": 305,
+      "start": 294,
+      "end": 295,
       "loc": {
         "start": {
           "line": 12,
@@ -3449,8 +3449,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 306,
-      "end": 307,
+      "start": 296,
+      "end": 297,
       "loc": {
         "start": {
           "line": 12,
@@ -3477,8 +3477,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 316,
-      "end": 321,
+      "start": 306,
+      "end": 311,
       "loc": {
         "start": {
           "line": 13,
@@ -3502,8 +3502,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 321,
-      "end": 322,
+      "start": 311,
+      "end": 312,
       "loc": {
         "start": {
           "line": 13,
@@ -3528,8 +3528,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 322,
-      "end": 326,
+      "start": 312,
+      "end": 316,
       "loc": {
         "start": {
           "line": 13,
@@ -3554,8 +3554,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 326,
-      "end": 327,
+      "start": 316,
+      "end": 317,
       "loc": {
         "start": {
           "line": 13,
@@ -3580,8 +3580,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 328,
-      "end": 337,
+      "start": 318,
+      "end": 327,
       "loc": {
         "start": {
           "line": 13,
@@ -3605,8 +3605,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 337,
-      "end": 338,
+      "start": 327,
+      "end": 328,
       "loc": {
         "start": {
           "line": 13,
@@ -3621,8 +3621,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 348,
-      "end": 382,
+      "start": 338,
+      "end": 372,
       "loc": {
         "start": {
           "line": 15,
@@ -3649,8 +3649,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 391,
-      "end": 395,
+      "start": 381,
+      "end": 385,
       "loc": {
         "start": {
           "line": 18,
@@ -3675,8 +3675,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 395,
-      "end": 396,
+      "start": 385,
+      "end": 386,
       "loc": {
         "start": {
           "line": 18,
@@ -3701,8 +3701,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 396,
-      "end": 405,
+      "start": 386,
+      "end": 395,
       "loc": {
         "start": {
           "line": 18,
@@ -3728,8 +3728,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 406,
-      "end": 407,
+      "start": 396,
+      "end": 397,
       "loc": {
         "start": {
           "line": 18,
@@ -3754,8 +3754,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 408,
-      "end": 417,
+      "start": 398,
+      "end": 407,
       "loc": {
         "start": {
           "line": 18,
@@ -3779,8 +3779,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 422,
-      "end": 423,
+      "start": 412,
+      "end": 413,
       "loc": {
         "start": {
           "line": 19,
@@ -3794,9 +3794,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-      "start": 429,
-      "end": 663,
+      "value": "*\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+      "start": 419,
+      "end": 621,
       "loc": {
         "start": {
           "line": 21,
@@ -3821,8 +3821,8 @@
         "binop": null
       },
       "value": "setArtistID",
-      "start": 668,
-      "end": 679,
+      "start": 626,
+      "end": 637,
       "loc": {
         "start": {
           "line": 28,
@@ -3846,8 +3846,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 679,
-      "end": 680,
+      "start": 637,
+      "end": 638,
       "loc": {
         "start": {
           "line": 28,
@@ -3872,8 +3872,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 680,
-      "end": 689,
+      "start": 638,
+      "end": 647,
       "loc": {
         "start": {
           "line": 28,
@@ -3897,8 +3897,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 689,
-      "end": 690,
+      "start": 647,
+      "end": 648,
       "loc": {
         "start": {
           "line": 28,
@@ -3922,8 +3922,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 691,
-      "end": 692,
+      "start": 649,
+      "end": 650,
       "loc": {
         "start": {
           "line": 28,
@@ -3950,8 +3950,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 701,
-      "end": 705,
+      "start": 659,
+      "end": 663,
       "loc": {
         "start": {
           "line": 29,
@@ -3976,8 +3976,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 705,
-      "end": 706,
+      "start": 663,
+      "end": 664,
       "loc": {
         "start": {
           "line": 29,
@@ -4002,8 +4002,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 706,
-      "end": 715,
+      "start": 664,
+      "end": 673,
       "loc": {
         "start": {
           "line": 29,
@@ -4029,8 +4029,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 716,
-      "end": 717,
+      "start": 674,
+      "end": 675,
       "loc": {
         "start": {
           "line": 29,
@@ -4055,8 +4055,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 718,
-      "end": 727,
+      "start": 676,
+      "end": 685,
       "loc": {
         "start": {
           "line": 29,
@@ -4083,8 +4083,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 736,
-      "end": 742,
+      "start": 694,
+      "end": 700,
       "loc": {
         "start": {
           "line": 30,
@@ -4111,8 +4111,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 743,
-      "end": 747,
+      "start": 701,
+      "end": 705,
       "loc": {
         "start": {
           "line": 30,
@@ -4136,8 +4136,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 752,
-      "end": 753,
+      "start": 710,
+      "end": 711,
       "loc": {
         "start": {
           "line": 31,
@@ -4151,9 +4151,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     ",
-      "start": 759,
-      "end": 1030,
+      "value": "*\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     ",
+      "start": 717,
+      "end": 956,
       "loc": {
         "start": {
           "line": 33,
@@ -4178,8 +4178,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1035,
-      "end": 1048,
+      "start": 961,
+      "end": 974,
       "loc": {
         "start": {
           "line": 40,
@@ -4203,8 +4203,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1048,
-      "end": 1049,
+      "start": 974,
+      "end": 975,
       "loc": {
         "start": {
           "line": 40,
@@ -4228,8 +4228,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1049,
-      "end": 1050,
+      "start": 975,
+      "end": 976,
       "loc": {
         "start": {
           "line": 40,
@@ -4253,8 +4253,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1051,
-      "end": 1052,
+      "start": 977,
+      "end": 978,
       "loc": {
         "start": {
           "line": 40,
@@ -4281,8 +4281,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1061,
-      "end": 1067,
+      "start": 987,
+      "end": 993,
       "loc": {
         "start": {
           "line": 41,
@@ -4309,8 +4309,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1068,
-      "end": 1072,
+      "start": 994,
+      "end": 998,
       "loc": {
         "start": {
           "line": 41,
@@ -4335,8 +4335,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1072,
-      "end": 1073,
+      "start": 998,
+      "end": 999,
       "loc": {
         "start": {
           "line": 41,
@@ -4361,8 +4361,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1073,
-      "end": 1077,
+      "start": 999,
+      "end": 1003,
       "loc": {
         "start": {
           "line": 41,
@@ -4387,8 +4387,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1077,
-      "end": 1078,
+      "start": 1003,
+      "end": 1004,
       "loc": {
         "start": {
           "line": 41,
@@ -4413,8 +4413,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1078,
-      "end": 1081,
+      "start": 1004,
+      "end": 1007,
       "loc": {
         "start": {
           "line": 41,
@@ -4438,8 +4438,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1081,
-      "end": 1082,
+      "start": 1007,
+      "end": 1008,
       "loc": {
         "start": {
           "line": 41,
@@ -4464,8 +4464,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1082,
-      "end": 1090,
+      "start": 1008,
+      "end": 1016,
       "loc": {
         "start": {
           "line": 41,
@@ -4491,8 +4491,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1091,
-      "end": 1092,
+      "start": 1017,
+      "end": 1018,
       "loc": {
         "start": {
           "line": 41,
@@ -4519,8 +4519,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1093,
-      "end": 1097,
+      "start": 1019,
+      "end": 1023,
       "loc": {
         "start": {
           "line": 41,
@@ -4545,8 +4545,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1097,
-      "end": 1098,
+      "start": 1023,
+      "end": 1024,
       "loc": {
         "start": {
           "line": 41,
@@ -4571,8 +4571,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 1098,
-      "end": 1107,
+      "start": 1024,
+      "end": 1033,
       "loc": {
         "start": {
           "line": 41,
@@ -4597,8 +4597,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1107,
-      "end": 1108,
+      "start": 1033,
+      "end": 1034,
       "loc": {
         "start": {
           "line": 41,
@@ -4622,8 +4622,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1109,
-      "end": 1110,
+      "start": 1035,
+      "end": 1036,
       "loc": {
         "start": {
           "line": 41,
@@ -4648,8 +4648,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1110,
-      "end": 1119,
+      "start": 1036,
+      "end": 1045,
       "loc": {
         "start": {
           "line": 41,
@@ -4674,8 +4674,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1119,
-      "end": 1120,
+      "start": 1045,
+      "end": 1046,
       "loc": {
         "start": {
           "line": 41,
@@ -4702,8 +4702,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1121,
-      "end": 1125,
+      "start": 1047,
+      "end": 1051,
       "loc": {
         "start": {
           "line": 41,
@@ -4728,8 +4728,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1125,
-      "end": 1126,
+      "start": 1051,
+      "end": 1052,
       "loc": {
         "start": {
           "line": 41,
@@ -4754,8 +4754,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1126,
-      "end": 1135,
+      "start": 1052,
+      "end": 1061,
       "loc": {
         "start": {
           "line": 41,
@@ -4779,8 +4779,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1135,
-      "end": 1136,
+      "start": 1061,
+      "end": 1062,
       "loc": {
         "start": {
           "line": 41,
@@ -4804,8 +4804,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1136,
-      "end": 1137,
+      "start": 1062,
+      "end": 1063,
       "loc": {
         "start": {
           "line": 41,
@@ -4829,8 +4829,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1142,
-      "end": 1143,
+      "start": 1068,
+      "end": 1069,
       "loc": {
         "start": {
           "line": 42,
@@ -4844,9 +4844,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums\n     ",
-      "start": 1149,
-      "end": 1553,
+      "value": "*\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums\n     ",
+      "start": 1075,
+      "end": 1447,
       "loc": {
         "start": {
           "line": 44,
@@ -4871,8 +4871,8 @@
         "binop": null
       },
       "value": "fetchAlbums",
-      "start": 1558,
-      "end": 1569,
+      "start": 1452,
+      "end": 1463,
       "loc": {
         "start": {
           "line": 53,
@@ -4896,8 +4896,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1569,
-      "end": 1570,
+      "start": 1463,
+      "end": 1464,
       "loc": {
         "start": {
           "line": 53,
@@ -4922,8 +4922,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1570,
-      "end": 1575,
+      "start": 1464,
+      "end": 1469,
       "loc": {
         "start": {
           "line": 53,
@@ -4949,8 +4949,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1576,
-      "end": 1577,
+      "start": 1470,
+      "end": 1471,
       "loc": {
         "start": {
           "line": 53,
@@ -4975,8 +4975,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1578,
-      "end": 1587,
+      "start": 1472,
+      "end": 1481,
       "loc": {
         "start": {
           "line": 53,
@@ -5001,8 +5001,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1587,
-      "end": 1588,
+      "start": 1481,
+      "end": 1482,
       "loc": {
         "start": {
           "line": 53,
@@ -5027,8 +5027,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1589,
-      "end": 1595,
+      "start": 1483,
+      "end": 1489,
       "loc": {
         "start": {
           "line": 53,
@@ -5054,8 +5054,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1596,
-      "end": 1597,
+      "start": 1490,
+      "end": 1491,
       "loc": {
         "start": {
           "line": 53,
@@ -5080,8 +5080,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1598,
-      "end": 1607,
+      "start": 1492,
+      "end": 1501,
       "loc": {
         "start": {
           "line": 53,
@@ -5105,8 +5105,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1607,
-      "end": 1608,
+      "start": 1501,
+      "end": 1502,
       "loc": {
         "start": {
           "line": 53,
@@ -5130,8 +5130,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1609,
-      "end": 1610,
+      "start": 1503,
+      "end": 1504,
       "loc": {
         "start": {
           "line": 53,
@@ -5158,8 +5158,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1619,
-      "end": 1625,
+      "start": 1513,
+      "end": 1519,
       "loc": {
         "start": {
           "line": 54,
@@ -5186,8 +5186,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1626,
-      "end": 1630,
+      "start": 1520,
+      "end": 1524,
       "loc": {
         "start": {
           "line": 54,
@@ -5212,8 +5212,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1630,
-      "end": 1631,
+      "start": 1524,
+      "end": 1525,
       "loc": {
         "start": {
           "line": 54,
@@ -5238,8 +5238,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1631,
-      "end": 1635,
+      "start": 1525,
+      "end": 1529,
       "loc": {
         "start": {
           "line": 54,
@@ -5264,8 +5264,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1635,
-      "end": 1636,
+      "start": 1529,
+      "end": 1530,
       "loc": {
         "start": {
           "line": 54,
@@ -5290,8 +5290,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1636,
-      "end": 1639,
+      "start": 1530,
+      "end": 1533,
       "loc": {
         "start": {
           "line": 54,
@@ -5315,8 +5315,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1639,
-      "end": 1640,
+      "start": 1533,
+      "end": 1534,
       "loc": {
         "start": {
           "line": 54,
@@ -5341,8 +5341,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1640,
-      "end": 1648,
+      "start": 1534,
+      "end": 1542,
       "loc": {
         "start": {
           "line": 54,
@@ -5368,8 +5368,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1649,
-      "end": 1650,
+      "start": 1543,
+      "end": 1544,
       "loc": {
         "start": {
           "line": 54,
@@ -5396,8 +5396,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1651,
-      "end": 1655,
+      "start": 1545,
+      "end": 1549,
       "loc": {
         "start": {
           "line": 54,
@@ -5422,8 +5422,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1655,
-      "end": 1656,
+      "start": 1549,
+      "end": 1550,
       "loc": {
         "start": {
           "line": 54,
@@ -5448,8 +5448,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 1656,
-      "end": 1665,
+      "start": 1550,
+      "end": 1559,
       "loc": {
         "start": {
           "line": 54,
@@ -5475,8 +5475,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1666,
-      "end": 1667,
+      "start": 1560,
+      "end": 1561,
       "loc": {
         "start": {
           "line": 54,
@@ -5502,8 +5502,8 @@
         "updateContext": null
       },
       "value": "/albums",
-      "start": 1668,
-      "end": 1677,
+      "start": 1562,
+      "end": 1571,
       "loc": {
         "start": {
           "line": 54,
@@ -5528,8 +5528,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1677,
-      "end": 1678,
+      "start": 1571,
+      "end": 1572,
       "loc": {
         "start": {
           "line": 54,
@@ -5553,8 +5553,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1679,
-      "end": 1680,
+      "start": 1573,
+      "end": 1574,
       "loc": {
         "start": {
           "line": 54,
@@ -5579,8 +5579,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1693,
-      "end": 1702,
+      "start": 1587,
+      "end": 1596,
       "loc": {
         "start": {
           "line": 55,
@@ -5605,8 +5605,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1702,
-      "end": 1703,
+      "start": 1596,
+      "end": 1597,
       "loc": {
         "start": {
           "line": 55,
@@ -5633,8 +5633,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1704,
-      "end": 1708,
+      "start": 1598,
+      "end": 1602,
       "loc": {
         "start": {
           "line": 55,
@@ -5659,8 +5659,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1708,
-      "end": 1709,
+      "start": 1602,
+      "end": 1603,
       "loc": {
         "start": {
           "line": 55,
@@ -5685,8 +5685,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1709,
-      "end": 1718,
+      "start": 1603,
+      "end": 1612,
       "loc": {
         "start": {
           "line": 55,
@@ -5711,8 +5711,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1718,
-      "end": 1719,
+      "start": 1612,
+      "end": 1613,
       "loc": {
         "start": {
           "line": 55,
@@ -5737,8 +5737,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1732,
-      "end": 1737,
+      "start": 1626,
+      "end": 1631,
       "loc": {
         "start": {
           "line": 56,
@@ -5763,8 +5763,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1737,
-      "end": 1738,
+      "start": 1631,
+      "end": 1632,
       "loc": {
         "start": {
           "line": 56,
@@ -5789,8 +5789,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1739,
-      "end": 1744,
+      "start": 1633,
+      "end": 1638,
       "loc": {
         "start": {
           "line": 56,
@@ -5815,8 +5815,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1744,
-      "end": 1745,
+      "start": 1638,
+      "end": 1639,
       "loc": {
         "start": {
           "line": 56,
@@ -5841,8 +5841,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1758,
-      "end": 1764,
+      "start": 1652,
+      "end": 1658,
       "loc": {
         "start": {
           "line": 57,
@@ -5867,8 +5867,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1764,
-      "end": 1765,
+      "start": 1658,
+      "end": 1659,
       "loc": {
         "start": {
           "line": 57,
@@ -5893,8 +5893,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1766,
-      "end": 1772,
+      "start": 1660,
+      "end": 1666,
       "loc": {
         "start": {
           "line": 57,
@@ -5918,8 +5918,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1781,
-      "end": 1782,
+      "start": 1675,
+      "end": 1676,
       "loc": {
         "start": {
           "line": 58,
@@ -5943,8 +5943,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1782,
-      "end": 1783,
+      "start": 1676,
+      "end": 1677,
       "loc": {
         "start": {
           "line": 58,
@@ -5968,8 +5968,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1788,
-      "end": 1789,
+      "start": 1682,
+      "end": 1683,
       "loc": {
         "start": {
           "line": 59,
@@ -5983,9 +5983,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks\n     ",
-      "start": 1795,
-      "end": 2203,
+      "value": "*\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks\n     ",
+      "start": 1689,
+      "end": 2064,
       "loc": {
         "start": {
           "line": 61,
@@ -6010,8 +6010,8 @@
         "binop": null
       },
       "value": "fetchTopTracks",
-      "start": 2208,
-      "end": 2222,
+      "start": 2069,
+      "end": 2083,
       "loc": {
         "start": {
           "line": 70,
@@ -6035,8 +6035,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2222,
-      "end": 2223,
+      "start": 2083,
+      "end": 2084,
       "loc": {
         "start": {
           "line": 70,
@@ -6061,8 +6061,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2223,
-      "end": 2228,
+      "start": 2084,
+      "end": 2089,
       "loc": {
         "start": {
           "line": 70,
@@ -6088,8 +6088,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2229,
-      "end": 2230,
+      "start": 2090,
+      "end": 2091,
       "loc": {
         "start": {
           "line": 70,
@@ -6114,8 +6114,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2231,
-      "end": 2240,
+      "start": 2092,
+      "end": 2101,
       "loc": {
         "start": {
           "line": 70,
@@ -6140,8 +6140,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2240,
-      "end": 2241,
+      "start": 2101,
+      "end": 2102,
       "loc": {
         "start": {
           "line": 70,
@@ -6166,8 +6166,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2242,
-      "end": 2248,
+      "start": 2103,
+      "end": 2109,
       "loc": {
         "start": {
           "line": 70,
@@ -6193,8 +6193,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2249,
-      "end": 2250,
+      "start": 2110,
+      "end": 2111,
       "loc": {
         "start": {
           "line": 70,
@@ -6219,8 +6219,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2251,
-      "end": 2260,
+      "start": 2112,
+      "end": 2121,
       "loc": {
         "start": {
           "line": 70,
@@ -6244,8 +6244,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2260,
-      "end": 2261,
+      "start": 2121,
+      "end": 2122,
       "loc": {
         "start": {
           "line": 70,
@@ -6269,8 +6269,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2262,
-      "end": 2263,
+      "start": 2123,
+      "end": 2124,
       "loc": {
         "start": {
           "line": 70,
@@ -6297,8 +6297,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2272,
-      "end": 2278,
+      "start": 2133,
+      "end": 2139,
       "loc": {
         "start": {
           "line": 71,
@@ -6325,8 +6325,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2279,
-      "end": 2283,
+      "start": 2140,
+      "end": 2144,
       "loc": {
         "start": {
           "line": 71,
@@ -6351,8 +6351,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2283,
-      "end": 2284,
+      "start": 2144,
+      "end": 2145,
       "loc": {
         "start": {
           "line": 71,
@@ -6377,8 +6377,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 2284,
-      "end": 2288,
+      "start": 2145,
+      "end": 2149,
       "loc": {
         "start": {
           "line": 71,
@@ -6403,8 +6403,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2288,
-      "end": 2289,
+      "start": 2149,
+      "end": 2150,
       "loc": {
         "start": {
           "line": 71,
@@ -6429,8 +6429,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 2289,
-      "end": 2292,
+      "start": 2150,
+      "end": 2153,
       "loc": {
         "start": {
           "line": 71,
@@ -6454,8 +6454,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2292,
-      "end": 2293,
+      "start": 2153,
+      "end": 2154,
       "loc": {
         "start": {
           "line": 71,
@@ -6480,8 +6480,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 2293,
-      "end": 2301,
+      "start": 2154,
+      "end": 2162,
       "loc": {
         "start": {
           "line": 71,
@@ -6507,8 +6507,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2302,
-      "end": 2303,
+      "start": 2163,
+      "end": 2164,
       "loc": {
         "start": {
           "line": 71,
@@ -6535,8 +6535,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2304,
-      "end": 2308,
+      "start": 2165,
+      "end": 2169,
       "loc": {
         "start": {
           "line": 71,
@@ -6561,8 +6561,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2308,
-      "end": 2309,
+      "start": 2169,
+      "end": 2170,
       "loc": {
         "start": {
           "line": 71,
@@ -6587,8 +6587,8 @@
         "binop": null
       },
       "value": "artist_id",
-      "start": 2309,
-      "end": 2318,
+      "start": 2170,
+      "end": 2179,
       "loc": {
         "start": {
           "line": 71,
@@ -6614,8 +6614,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2319,
-      "end": 2320,
+      "start": 2180,
+      "end": 2181,
       "loc": {
         "start": {
           "line": 71,
@@ -6641,8 +6641,8 @@
         "updateContext": null
       },
       "value": "/top-tracks",
-      "start": 2321,
-      "end": 2334,
+      "start": 2182,
+      "end": 2195,
       "loc": {
         "start": {
           "line": 71,
@@ -6667,8 +6667,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2334,
-      "end": 2335,
+      "start": 2195,
+      "end": 2196,
       "loc": {
         "start": {
           "line": 71,
@@ -6692,8 +6692,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2336,
-      "end": 2337,
+      "start": 2197,
+      "end": 2198,
       "loc": {
         "start": {
           "line": 71,
@@ -6718,8 +6718,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2350,
-      "end": 2359,
+      "start": 2211,
+      "end": 2220,
       "loc": {
         "start": {
           "line": 72,
@@ -6744,8 +6744,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2359,
-      "end": 2360,
+      "start": 2220,
+      "end": 2221,
       "loc": {
         "start": {
           "line": 72,
@@ -6772,8 +6772,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2361,
-      "end": 2365,
+      "start": 2222,
+      "end": 2226,
       "loc": {
         "start": {
           "line": 72,
@@ -6798,8 +6798,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2365,
-      "end": 2366,
+      "start": 2226,
+      "end": 2227,
       "loc": {
         "start": {
           "line": 72,
@@ -6824,8 +6824,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2366,
-      "end": 2375,
+      "start": 2227,
+      "end": 2236,
       "loc": {
         "start": {
           "line": 72,
@@ -6850,8 +6850,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2375,
-      "end": 2376,
+      "start": 2236,
+      "end": 2237,
       "loc": {
         "start": {
           "line": 72,
@@ -6876,8 +6876,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2389,
-      "end": 2394,
+      "start": 2250,
+      "end": 2255,
       "loc": {
         "start": {
           "line": 73,
@@ -6902,8 +6902,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2394,
-      "end": 2395,
+      "start": 2255,
+      "end": 2256,
       "loc": {
         "start": {
           "line": 73,
@@ -6928,8 +6928,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2396,
-      "end": 2401,
+      "start": 2257,
+      "end": 2262,
       "loc": {
         "start": {
           "line": 73,
@@ -6954,8 +6954,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2401,
-      "end": 2402,
+      "start": 2262,
+      "end": 2263,
       "loc": {
         "start": {
           "line": 73,
@@ -6980,8 +6980,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2415,
-      "end": 2421,
+      "start": 2276,
+      "end": 2282,
       "loc": {
         "start": {
           "line": 74,
@@ -7006,8 +7006,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2421,
-      "end": 2422,
+      "start": 2282,
+      "end": 2283,
       "loc": {
         "start": {
           "line": 74,
@@ -7032,8 +7032,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2423,
-      "end": 2429,
+      "start": 2284,
+      "end": 2290,
       "loc": {
         "start": {
           "line": 74,
@@ -7057,8 +7057,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2438,
-      "end": 2439,
+      "start": 2299,
+      "end": 2300,
       "loc": {
         "start": {
           "line": 75,
@@ -7082,8 +7082,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2439,
-      "end": 2440,
+      "start": 2300,
+      "end": 2301,
       "loc": {
         "start": {
           "line": 75,
@@ -7107,8 +7107,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2445,
-      "end": 2446,
+      "start": 2306,
+      "end": 2307,
       "loc": {
         "start": {
           "line": 76,
@@ -7132,8 +7132,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2447,
-      "end": 2448,
+      "start": 2308,
+      "end": 2309,
       "loc": {
         "start": {
           "line": 77,
@@ -7158,8 +7158,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2448,
-      "end": 2448,
+      "start": 2309,
+      "end": 2309,
       "loc": {
         "start": {
           "line": 77,

--- a/docs/ast/source/api/ChartFetcher.js.json
+++ b/docs/ast/source/api/ChartFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 706,
+  "end": 669,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 706,
+    "end": 669,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n ",
+            "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n ",
             "start": 80,
-            "end": 201,
+            "end": 192,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 202,
-        "end": 706,
+        "start": 193,
+        "end": 669,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 217,
-          "end": 706,
+          "start": 208,
+          "end": 669,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 223,
-            "end": 235,
+            "start": 214,
+            "end": 226,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 244,
-            "end": 251,
+            "start": 235,
+            "end": 242,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 252,
-            "end": 706,
+            "start": 243,
+            "end": 669,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 289,
-                "end": 370,
+                "start": 280,
+                "end": 361,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 289,
-                  "end": 300,
+                  "start": 280,
+                  "end": 291,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 301,
-                    "end": 305,
+                    "start": 292,
+                    "end": 296,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 307,
-                    "end": 323,
+                    "start": 298,
+                    "end": 314,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 307,
-                      "end": 316,
+                      "start": 298,
+                      "end": 307,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 319,
-                      "end": 323,
+                      "start": 310,
+                      "end": 314,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 325,
-                  "end": 370,
+                  "start": 316,
+                  "end": 361,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 335,
-                      "end": 364,
+                      "start": 326,
+                      "end": 355,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 335,
-                        "end": 364,
+                        "start": 326,
+                        "end": 355,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 335,
-                          "end": 340,
+                          "start": 326,
+                          "end": 331,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 341,
-                            "end": 345,
+                            "start": 332,
+                            "end": 336,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "AssignmentExpression",
-                            "start": 347,
-                            "end": 363,
+                            "start": 338,
+                            "end": 354,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -484,8 +484,8 @@
                             "operator": "=",
                             "left": {
                               "type": "Identifier",
-                              "start": 347,
-                              "end": 356,
+                              "start": 338,
+                              "end": 347,
                               "loc": {
                                 "start": {
                                   "line": 13,
@@ -501,8 +501,8 @@
                             },
                             "right": {
                               "type": "StringLiteral",
-                              "start": 359,
-                              "end": 363,
+                              "start": 350,
+                              "end": 354,
                               "loc": {
                                 "start": {
                                   "line": 13,
@@ -531,8 +531,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 258,
-                    "end": 284,
+                    "start": 249,
+                    "end": 275,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -548,9 +548,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts\n     ",
-                    "start": 376,
-                    "end": 588,
+                    "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1\n     ",
+                    "start": 367,
+                    "end": 551,
                     "loc": {
                       "start": {
                         "line": 16,
@@ -566,8 +566,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 593,
-                "end": 704,
+                "start": 556,
+                "end": 667,
                 "loc": {
                   "start": {
                     "line": 23,
@@ -581,8 +581,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 593,
-                  "end": 604,
+                  "start": 556,
+                  "end": 567,
                   "loc": {
                     "start": {
                       "line": 23,
@@ -606,8 +606,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 607,
-                  "end": 704,
+                  "start": 570,
+                  "end": 667,
                   "loc": {
                     "start": {
                       "line": 23,
@@ -621,8 +621,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 617,
-                      "end": 698,
+                      "start": 580,
+                      "end": 661,
                       "loc": {
                         "start": {
                           "line": 24,
@@ -635,8 +635,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 624,
-                        "end": 698,
+                        "start": 587,
+                        "end": 661,
                         "loc": {
                           "start": {
                             "line": 24,
@@ -649,8 +649,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 624,
-                          "end": 637,
+                          "start": 587,
+                          "end": 600,
                           "loc": {
                             "start": {
                               "line": 24,
@@ -663,8 +663,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 624,
-                            "end": 633,
+                            "start": 587,
+                            "end": 596,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -677,8 +677,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 624,
-                              "end": 628,
+                              "start": 587,
+                              "end": 591,
                               "loc": {
                                 "start": {
                                   "line": 24,
@@ -692,8 +692,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 629,
-                              "end": 633,
+                              "start": 592,
+                              "end": 596,
                               "loc": {
                                 "start": {
                                   "line": 24,
@@ -711,8 +711,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 634,
-                            "end": 637,
+                            "start": 597,
+                            "end": 600,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -731,8 +731,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 638,
-                            "end": 646,
+                            "start": 601,
+                            "end": 609,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -748,8 +748,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 648,
-                            "end": 697,
+                            "start": 611,
+                            "end": 660,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -763,8 +763,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 662,
-                                "end": 687,
+                                "start": 625,
+                                "end": 650,
                                 "loc": {
                                   "start": {
                                     "line": 25,
@@ -780,8 +780,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 662,
-                                  "end": 671,
+                                  "start": 625,
+                                  "end": 634,
                                   "loc": {
                                     "start": {
                                       "line": 25,
@@ -797,8 +797,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 673,
-                                  "end": 687,
+                                  "start": 636,
+                                  "end": 650,
                                   "loc": {
                                     "start": {
                                       "line": 25,
@@ -811,8 +811,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 673,
-                                    "end": 677,
+                                    "start": 636,
+                                    "end": 640,
                                     "loc": {
                                       "start": {
                                         "line": 25,
@@ -826,8 +826,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 678,
-                                    "end": 687,
+                                    "start": 641,
+                                    "end": 650,
                                     "loc": {
                                       "start": {
                                         "line": 25,
@@ -855,9 +855,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts\n     ",
-                    "start": 376,
-                    "end": 588,
+                    "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1\n     ",
+                    "start": 367,
+                    "end": 551,
                     "loc": {
                       "start": {
                         "line": 16,
@@ -876,9 +876,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n ",
+              "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n ",
               "start": 80,
-              "end": 201,
+              "end": 192,
               "loc": {
                 "start": {
                   "line": 4,
@@ -896,9 +896,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n ",
+            "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n ",
             "start": 80,
-            "end": 201,
+            "end": 192,
             "loc": {
               "start": {
                 "line": 4,
@@ -918,9 +918,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n ",
+      "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n ",
       "start": 80,
-      "end": 201,
+      "end": 192,
       "loc": {
         "start": {
           "line": 4,
@@ -935,8 +935,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 258,
-      "end": 284,
+      "start": 249,
+      "end": 275,
       "loc": {
         "start": {
           "line": 9,
@@ -950,9 +950,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts\n     ",
-      "start": 376,
-      "end": 588,
+      "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1\n     ",
+      "start": 367,
+      "end": 551,
       "loc": {
         "start": {
           "line": 16,
@@ -1284,9 +1284,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n ",
+      "value": "*\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n ",
       "start": 80,
-      "end": 201,
+      "end": 192,
       "loc": {
         "start": {
           "line": 4,
@@ -1313,8 +1313,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 202,
-      "end": 208,
+      "start": 193,
+      "end": 199,
       "loc": {
         "start": {
           "line": 8,
@@ -1341,8 +1341,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 209,
-      "end": 216,
+      "start": 200,
+      "end": 207,
       "loc": {
         "start": {
           "line": 8,
@@ -1369,8 +1369,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 217,
-      "end": 222,
+      "start": 208,
+      "end": 213,
       "loc": {
         "start": {
           "line": 8,
@@ -1395,8 +1395,8 @@
         "binop": null
       },
       "value": "ChartFetcher",
-      "start": 223,
-      "end": 235,
+      "start": 214,
+      "end": 226,
       "loc": {
         "start": {
           "line": 8,
@@ -1423,8 +1423,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 236,
-      "end": 243,
+      "start": 227,
+      "end": 234,
       "loc": {
         "start": {
           "line": 8,
@@ -1449,8 +1449,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 244,
-      "end": 251,
+      "start": 235,
+      "end": 242,
       "loc": {
         "start": {
           "line": 8,
@@ -1474,8 +1474,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 252,
-      "end": 253,
+      "start": 243,
+      "end": 244,
       "loc": {
         "start": {
           "line": 8,
@@ -1490,8 +1490,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 258,
-      "end": 284,
+      "start": 249,
+      "end": 275,
       "loc": {
         "start": {
           "line": 9,
@@ -1516,8 +1516,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 289,
-      "end": 300,
+      "start": 280,
+      "end": 291,
       "loc": {
         "start": {
           "line": 12,
@@ -1541,8 +1541,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 300,
-      "end": 301,
+      "start": 291,
+      "end": 292,
       "loc": {
         "start": {
           "line": 12,
@@ -1567,8 +1567,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 301,
-      "end": 305,
+      "start": 292,
+      "end": 296,
       "loc": {
         "start": {
           "line": 12,
@@ -1593,8 +1593,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 305,
-      "end": 306,
+      "start": 296,
+      "end": 297,
       "loc": {
         "start": {
           "line": 12,
@@ -1619,8 +1619,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 307,
-      "end": 316,
+      "start": 298,
+      "end": 307,
       "loc": {
         "start": {
           "line": 12,
@@ -1646,8 +1646,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 317,
-      "end": 318,
+      "start": 308,
+      "end": 309,
       "loc": {
         "start": {
           "line": 12,
@@ -1673,8 +1673,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 319,
-      "end": 323,
+      "start": 310,
+      "end": 314,
       "loc": {
         "start": {
           "line": 12,
@@ -1698,8 +1698,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 323,
-      "end": 324,
+      "start": 314,
+      "end": 315,
       "loc": {
         "start": {
           "line": 12,
@@ -1723,8 +1723,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 325,
-      "end": 326,
+      "start": 316,
+      "end": 317,
       "loc": {
         "start": {
           "line": 12,
@@ -1751,8 +1751,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 335,
-      "end": 340,
+      "start": 326,
+      "end": 331,
       "loc": {
         "start": {
           "line": 13,
@@ -1776,8 +1776,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 340,
-      "end": 341,
+      "start": 331,
+      "end": 332,
       "loc": {
         "start": {
           "line": 13,
@@ -1802,8 +1802,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 341,
-      "end": 345,
+      "start": 332,
+      "end": 336,
       "loc": {
         "start": {
           "line": 13,
@@ -1828,8 +1828,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 345,
-      "end": 346,
+      "start": 336,
+      "end": 337,
       "loc": {
         "start": {
           "line": 13,
@@ -1854,8 +1854,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 347,
-      "end": 356,
+      "start": 338,
+      "end": 347,
       "loc": {
         "start": {
           "line": 13,
@@ -1881,8 +1881,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 357,
-      "end": 358,
+      "start": 348,
+      "end": 349,
       "loc": {
         "start": {
           "line": 13,
@@ -1908,8 +1908,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 359,
-      "end": 363,
+      "start": 350,
+      "end": 354,
       "loc": {
         "start": {
           "line": 13,
@@ -1933,8 +1933,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 363,
-      "end": 364,
+      "start": 354,
+      "end": 355,
       "loc": {
         "start": {
           "line": 13,
@@ -1958,8 +1958,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 369,
-      "end": 370,
+      "start": 360,
+      "end": 361,
       "loc": {
         "start": {
           "line": 14,
@@ -1973,9 +1973,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts\n     ",
-      "start": 376,
-      "end": 588,
+      "value": "*\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1\n     ",
+      "start": 367,
+      "end": 551,
       "loc": {
         "start": {
           "line": 16,
@@ -2000,8 +2000,8 @@
         "binop": null
       },
       "value": "fetchCharts",
-      "start": 593,
-      "end": 604,
+      "start": 556,
+      "end": 567,
       "loc": {
         "start": {
           "line": 23,
@@ -2025,8 +2025,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 604,
-      "end": 605,
+      "start": 567,
+      "end": 568,
       "loc": {
         "start": {
           "line": 23,
@@ -2050,8 +2050,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 605,
-      "end": 606,
+      "start": 568,
+      "end": 569,
       "loc": {
         "start": {
           "line": 23,
@@ -2075,8 +2075,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 607,
-      "end": 608,
+      "start": 570,
+      "end": 571,
       "loc": {
         "start": {
           "line": 23,
@@ -2103,8 +2103,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 617,
-      "end": 623,
+      "start": 580,
+      "end": 586,
       "loc": {
         "start": {
           "line": 24,
@@ -2131,8 +2131,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 624,
-      "end": 628,
+      "start": 587,
+      "end": 591,
       "loc": {
         "start": {
           "line": 24,
@@ -2157,8 +2157,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 628,
-      "end": 629,
+      "start": 591,
+      "end": 592,
       "loc": {
         "start": {
           "line": 24,
@@ -2183,8 +2183,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 629,
-      "end": 633,
+      "start": 592,
+      "end": 596,
       "loc": {
         "start": {
           "line": 24,
@@ -2209,8 +2209,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 633,
-      "end": 634,
+      "start": 596,
+      "end": 597,
       "loc": {
         "start": {
           "line": 24,
@@ -2235,8 +2235,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 634,
-      "end": 637,
+      "start": 597,
+      "end": 600,
       "loc": {
         "start": {
           "line": 24,
@@ -2260,8 +2260,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 637,
-      "end": 638,
+      "start": 600,
+      "end": 601,
       "loc": {
         "start": {
           "line": 24,
@@ -2286,8 +2286,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 638,
-      "end": 646,
+      "start": 601,
+      "end": 609,
       "loc": {
         "start": {
           "line": 24,
@@ -2312,8 +2312,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 646,
-      "end": 647,
+      "start": 609,
+      "end": 610,
       "loc": {
         "start": {
           "line": 24,
@@ -2337,8 +2337,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 648,
-      "end": 649,
+      "start": 611,
+      "end": 612,
       "loc": {
         "start": {
           "line": 24,
@@ -2363,8 +2363,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 662,
-      "end": 671,
+      "start": 625,
+      "end": 634,
       "loc": {
         "start": {
           "line": 25,
@@ -2389,8 +2389,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 671,
-      "end": 672,
+      "start": 634,
+      "end": 635,
       "loc": {
         "start": {
           "line": 25,
@@ -2417,8 +2417,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 673,
-      "end": 677,
+      "start": 636,
+      "end": 640,
       "loc": {
         "start": {
           "line": 25,
@@ -2443,8 +2443,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 677,
-      "end": 678,
+      "start": 640,
+      "end": 641,
       "loc": {
         "start": {
           "line": 25,
@@ -2469,8 +2469,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 678,
-      "end": 687,
+      "start": 641,
+      "end": 650,
       "loc": {
         "start": {
           "line": 25,
@@ -2494,8 +2494,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 696,
-      "end": 697,
+      "start": 659,
+      "end": 660,
       "loc": {
         "start": {
           "line": 26,
@@ -2519,8 +2519,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 697,
-      "end": 698,
+      "start": 660,
+      "end": 661,
       "loc": {
         "start": {
           "line": 26,
@@ -2544,8 +2544,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 703,
-      "end": 704,
+      "start": 666,
+      "end": 667,
       "loc": {
         "start": {
           "line": 27,
@@ -2569,8 +2569,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 705,
-      "end": 706,
+      "start": 668,
+      "end": 669,
       "loc": {
         "start": {
           "line": 28,
@@ -2595,8 +2595,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 706,
-      "end": 706,
+      "start": 669,
+      "end": 669,
       "loc": {
         "start": {
           "line": 28,

--- a/docs/ast/source/api/FeaturedPlaylistCategoryFetcher.js.json
+++ b/docs/ast/source/api/FeaturedPlaylistCategoryFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2628,
+  "end": 2398,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2628,
+    "end": 2398,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n ",
+            "value": "*\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n ",
             "start": 103,
-            "end": 238,
+            "end": 228,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 239,
-        "end": 2628,
+        "start": 229,
+        "end": 2398,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 254,
-          "end": 2628,
+          "start": 244,
+          "end": 2398,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 260,
-            "end": 291,
+            "start": 250,
+            "end": 281,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 300,
-            "end": 307,
+            "start": 290,
+            "end": 297,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 308,
-            "end": 2628,
+            "start": 298,
+            "end": 2398,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 345,
-                "end": 500,
+                "start": 335,
+                "end": 490,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 345,
-                  "end": 356,
+                  "start": 335,
+                  "end": 346,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 357,
-                    "end": 361,
+                    "start": 347,
+                    "end": 351,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 363,
-                    "end": 379,
+                    "start": 353,
+                    "end": 369,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 363,
-                      "end": 372,
+                      "start": 353,
+                      "end": 362,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 375,
-                      "end": 379,
+                      "start": 365,
+                      "end": 369,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 381,
-                  "end": 500,
+                  "start": 371,
+                  "end": 490,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 391,
-                      "end": 413,
+                      "start": 381,
+                      "end": 403,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 391,
-                        "end": 413,
+                        "start": 381,
+                        "end": 403,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 391,
-                          "end": 396,
+                          "start": 381,
+                          "end": 386,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 397,
-                            "end": 401,
+                            "start": 387,
+                            "end": 391,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 403,
-                            "end": 412,
+                            "start": 393,
+                            "end": 402,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 423,
-                          "end": 457,
+                          "start": 413,
+                          "end": 447,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 466,
-                      "end": 494,
+                      "start": 456,
+                      "end": 484,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 466,
-                        "end": 494,
+                        "start": 456,
+                        "end": 484,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 466,
-                          "end": 482,
+                          "start": 456,
+                          "end": 472,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 466,
-                            "end": 470,
+                            "start": 456,
+                            "end": 460,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 471,
-                            "end": 482,
+                            "start": 461,
+                            "end": 472,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 485,
-                          "end": 494,
+                          "start": 475,
+                          "end": 484,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 423,
-                          "end": 457,
+                          "start": 413,
+                          "end": 447,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 314,
-                    "end": 340,
+                    "start": 304,
+                    "end": 330,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories\n     ",
-                    "start": 506,
-                    "end": 822,
+                    "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories\n     ",
+                    "start": 496,
+                    "end": 757,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 827,
-                "end": 939,
+                "start": 762,
+                "end": 874,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 827,
-                  "end": 861,
+                  "start": 762,
+                  "end": 796,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 864,
-                  "end": 939,
+                  "start": 799,
+                  "end": 874,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -721,8 +721,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 874,
-                      "end": 933,
+                      "start": 809,
+                      "end": 868,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -735,8 +735,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 881,
-                        "end": 933,
+                        "start": 816,
+                        "end": 868,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -749,8 +749,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 881,
-                          "end": 894,
+                          "start": 816,
+                          "end": 829,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -763,8 +763,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 881,
-                            "end": 890,
+                            "start": 816,
+                            "end": 825,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -777,8 +777,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 881,
-                              "end": 885,
+                              "start": 816,
+                              "end": 820,
                               "loc": {
                                 "start": {
                                   "line": 29,
@@ -792,8 +792,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 886,
-                              "end": 890,
+                              "start": 821,
+                              "end": 825,
                               "loc": {
                                 "start": {
                                   "line": 29,
@@ -811,8 +811,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 891,
-                            "end": 894,
+                            "start": 826,
+                            "end": 829,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -831,8 +831,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 895,
-                            "end": 903,
+                            "start": 830,
+                            "end": 838,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -848,8 +848,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 905,
-                            "end": 932,
+                            "start": 840,
+                            "end": 867,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -863,8 +863,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 906,
-                                "end": 931,
+                                "start": 841,
+                                "end": 866,
                                 "loc": {
                                   "start": {
                                     "line": 29,
@@ -880,8 +880,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 906,
-                                  "end": 915,
+                                  "start": 841,
+                                  "end": 850,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -897,8 +897,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 917,
-                                  "end": 931,
+                                  "start": 852,
+                                  "end": 866,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -911,8 +911,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 917,
-                                    "end": 921,
+                                    "start": 852,
+                                    "end": 856,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -926,8 +926,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 922,
-                                    "end": 931,
+                                    "start": 857,
+                                    "end": 866,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -956,9 +956,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories\n     ",
-                    "start": 506,
-                    "end": 822,
+                    "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories\n     ",
+                    "start": 496,
+                    "end": 757,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -974,9 +974,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-                    "start": 945,
-                    "end": 1267,
+                    "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+                    "start": 880,
+                    "end": 1147,
                     "loc": {
                       "start": {
                         "line": 32,
@@ -992,8 +992,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1272,
-                "end": 1373,
+                "start": 1152,
+                "end": 1253,
                 "loc": {
                   "start": {
                     "line": 39,
@@ -1007,8 +1007,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1272,
-                  "end": 1285,
+                  "start": 1152,
+                  "end": 1165,
                   "loc": {
                     "start": {
                       "line": 39,
@@ -1032,8 +1032,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1286,
-                    "end": 1297,
+                    "start": 1166,
+                    "end": 1177,
                     "loc": {
                       "start": {
                         "line": 39,
@@ -1050,8 +1050,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1299,
-                  "end": 1373,
+                  "start": 1179,
+                  "end": 1253,
                   "loc": {
                     "start": {
                       "line": 39,
@@ -1065,8 +1065,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1309,
-                      "end": 1339,
+                      "start": 1189,
+                      "end": 1219,
                       "loc": {
                         "start": {
                           "line": 40,
@@ -1079,8 +1079,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1309,
-                        "end": 1339,
+                        "start": 1189,
+                        "end": 1219,
                         "loc": {
                           "start": {
                             "line": 40,
@@ -1094,8 +1094,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1309,
-                          "end": 1325,
+                          "start": 1189,
+                          "end": 1205,
                           "loc": {
                             "start": {
                               "line": 40,
@@ -1108,8 +1108,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1309,
-                            "end": 1313,
+                            "start": 1189,
+                            "end": 1193,
                             "loc": {
                               "start": {
                                 "line": 40,
@@ -1123,8 +1123,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1314,
-                            "end": 1325,
+                            "start": 1194,
+                            "end": 1205,
                             "loc": {
                               "start": {
                                 "line": 40,
@@ -1142,8 +1142,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1328,
-                          "end": 1339,
+                          "start": 1208,
+                          "end": 1219,
                           "loc": {
                             "start": {
                               "line": 40,
@@ -1161,8 +1161,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1356,
-                      "end": 1367,
+                      "start": 1236,
+                      "end": 1247,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -1175,8 +1175,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1363,
-                        "end": 1367,
+                        "start": 1243,
+                        "end": 1247,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -1196,9 +1196,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-                    "start": 945,
-                    "end": 1267,
+                    "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+                    "start": 880,
+                    "end": 1147,
                     "loc": {
                       "start": {
                         "line": 32,
@@ -1214,9 +1214,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-                    "start": 1379,
-                    "end": 1723,
+                    "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+                    "start": 1259,
+                    "end": 1548,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1232,8 +1232,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1728,
-                "end": 1838,
+                "start": 1553,
+                "end": 1663,
                 "loc": {
                   "start": {
                     "line": 51,
@@ -1247,8 +1247,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1728,
-                  "end": 1741,
+                  "start": 1553,
+                  "end": 1566,
                   "loc": {
                     "start": {
                       "line": 51,
@@ -1272,8 +1272,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1744,
-                  "end": 1838,
+                  "start": 1569,
+                  "end": 1663,
                   "loc": {
                     "start": {
                       "line": 51,
@@ -1287,8 +1287,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1754,
-                      "end": 1832,
+                      "start": 1579,
+                      "end": 1657,
                       "loc": {
                         "start": {
                           "line": 52,
@@ -1301,8 +1301,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1761,
-                        "end": 1832,
+                        "start": 1586,
+                        "end": 1657,
                         "loc": {
                           "start": {
                             "line": 52,
@@ -1315,8 +1315,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1761,
-                          "end": 1774,
+                          "start": 1586,
+                          "end": 1599,
                           "loc": {
                             "start": {
                               "line": 52,
@@ -1329,8 +1329,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1761,
-                            "end": 1770,
+                            "start": 1586,
+                            "end": 1595,
                             "loc": {
                               "start": {
                                 "line": 52,
@@ -1343,8 +1343,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1761,
-                              "end": 1765,
+                              "start": 1586,
+                              "end": 1590,
                               "loc": {
                                 "start": {
                                   "line": 52,
@@ -1358,8 +1358,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1766,
-                              "end": 1770,
+                              "start": 1591,
+                              "end": 1595,
                               "loc": {
                                 "start": {
                                   "line": 52,
@@ -1377,8 +1377,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1771,
-                            "end": 1774,
+                            "start": 1596,
+                            "end": 1599,
                             "loc": {
                               "start": {
                                 "line": 52,
@@ -1397,8 +1397,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1775,
-                            "end": 1802,
+                            "start": 1600,
+                            "end": 1627,
                             "loc": {
                               "start": {
                                 "line": 52,
@@ -1411,8 +1411,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1775,
-                              "end": 1783,
+                              "start": 1600,
+                              "end": 1608,
                               "loc": {
                                 "start": {
                                   "line": 52,
@@ -1429,8 +1429,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1786,
-                              "end": 1802,
+                              "start": 1611,
+                              "end": 1627,
                               "loc": {
                                 "start": {
                                   "line": 52,
@@ -1443,8 +1443,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1786,
-                                "end": 1790,
+                                "start": 1611,
+                                "end": 1615,
                                 "loc": {
                                   "start": {
                                     "line": 52,
@@ -1458,8 +1458,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1791,
-                                "end": 1802,
+                                "start": 1616,
+                                "end": 1627,
                                 "loc": {
                                   "start": {
                                     "line": 52,
@@ -1478,8 +1478,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1804,
-                            "end": 1831,
+                            "start": 1629,
+                            "end": 1656,
                             "loc": {
                               "start": {
                                 "line": 52,
@@ -1493,8 +1493,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1805,
-                                "end": 1830,
+                                "start": 1630,
+                                "end": 1655,
                                 "loc": {
                                   "start": {
                                     "line": 52,
@@ -1510,8 +1510,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1805,
-                                  "end": 1814,
+                                  "start": 1630,
+                                  "end": 1639,
                                   "loc": {
                                     "start": {
                                       "line": 52,
@@ -1527,8 +1527,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1816,
-                                  "end": 1830,
+                                  "start": 1641,
+                                  "end": 1655,
                                   "loc": {
                                     "start": {
                                       "line": 52,
@@ -1541,8 +1541,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1816,
-                                    "end": 1820,
+                                    "start": 1641,
+                                    "end": 1645,
                                     "loc": {
                                       "start": {
                                         "line": 52,
@@ -1556,8 +1556,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1821,
-                                    "end": 1830,
+                                    "start": 1646,
+                                    "end": 1655,
                                     "loc": {
                                       "start": {
                                         "line": 52,
@@ -1586,9 +1586,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-                    "start": 1379,
-                    "end": 1723,
+                    "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+                    "start": 1259,
+                    "end": 1548,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1604,9 +1604,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists\n     ",
-                    "start": 1844,
-                    "end": 2382,
+                    "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists\n     ",
+                    "start": 1669,
+                    "end": 2152,
                     "loc": {
                       "start": {
                         "line": 55,
@@ -1622,8 +1622,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 2387,
-                "end": 2626,
+                "start": 2157,
+                "end": 2396,
                 "loc": {
                   "start": {
                     "line": 64,
@@ -1637,8 +1637,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 2387,
-                  "end": 2401,
+                  "start": 2157,
+                  "end": 2171,
                   "loc": {
                     "start": {
                       "line": 64,
@@ -1662,8 +1662,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 2402,
-                    "end": 2419,
+                    "start": 2172,
+                    "end": 2189,
                     "loc": {
                       "start": {
                         "line": 64,
@@ -1676,8 +1676,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2402,
-                      "end": 2407,
+                      "start": 2172,
+                      "end": 2177,
                       "loc": {
                         "start": {
                           "line": 64,
@@ -1693,8 +1693,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2410,
-                      "end": 2419,
+                      "start": 2180,
+                      "end": 2189,
                       "loc": {
                         "start": {
                           "line": 64,
@@ -1711,8 +1711,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 2421,
-                    "end": 2439,
+                    "start": 2191,
+                    "end": 2209,
                     "loc": {
                       "start": {
                         "line": 64,
@@ -1725,8 +1725,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2421,
-                      "end": 2427,
+                      "start": 2191,
+                      "end": 2197,
                       "loc": {
                         "start": {
                           "line": 64,
@@ -1742,8 +1742,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2430,
-                      "end": 2439,
+                      "start": 2200,
+                      "end": 2209,
                       "loc": {
                         "start": {
                           "line": 64,
@@ -1761,8 +1761,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 2441,
-                  "end": 2626,
+                  "start": 2211,
+                  "end": 2396,
                   "loc": {
                     "start": {
                       "line": 64,
@@ -1776,8 +1776,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 2451,
-                      "end": 2620,
+                      "start": 2221,
+                      "end": 2390,
                       "loc": {
                         "start": {
                           "line": 65,
@@ -1790,8 +1790,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 2458,
-                        "end": 2620,
+                        "start": 2228,
+                        "end": 2390,
                         "loc": {
                           "start": {
                             "line": 65,
@@ -1804,8 +1804,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 2458,
-                          "end": 2471,
+                          "start": 2228,
+                          "end": 2241,
                           "loc": {
                             "start": {
                               "line": 65,
@@ -1818,8 +1818,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 2458,
-                            "end": 2467,
+                            "start": 2228,
+                            "end": 2237,
                             "loc": {
                               "start": {
                                 "line": 65,
@@ -1832,8 +1832,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 2458,
-                              "end": 2462,
+                              "start": 2228,
+                              "end": 2232,
                               "loc": {
                                 "start": {
                                   "line": 65,
@@ -1847,8 +1847,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 2463,
-                              "end": 2467,
+                              "start": 2233,
+                              "end": 2237,
                               "loc": {
                                 "start": {
                                   "line": 65,
@@ -1866,8 +1866,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 2468,
-                            "end": 2471,
+                            "start": 2238,
+                            "end": 2241,
                             "loc": {
                               "start": {
                                 "line": 65,
@@ -1886,8 +1886,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 2472,
-                            "end": 2514,
+                            "start": 2242,
+                            "end": 2284,
                             "loc": {
                               "start": {
                                 "line": 65,
@@ -1900,8 +1900,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 2472,
-                              "end": 2499,
+                              "start": 2242,
+                              "end": 2269,
                               "loc": {
                                 "start": {
                                   "line": 65,
@@ -1914,8 +1914,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 2472,
-                                "end": 2480,
+                                "start": 2242,
+                                "end": 2250,
                                 "loc": {
                                   "start": {
                                     "line": 65,
@@ -1932,8 +1932,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 2483,
-                                "end": 2499,
+                                "start": 2253,
+                                "end": 2269,
                                 "loc": {
                                   "start": {
                                     "line": 65,
@@ -1946,8 +1946,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 2483,
-                                  "end": 2487,
+                                  "start": 2253,
+                                  "end": 2257,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -1961,8 +1961,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2488,
-                                  "end": 2499,
+                                  "start": 2258,
+                                  "end": 2269,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -1982,8 +1982,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 2502,
-                              "end": 2514,
+                              "start": 2272,
+                              "end": 2284,
                               "loc": {
                                 "start": {
                                   "line": 65,
@@ -2003,8 +2003,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 2516,
-                            "end": 2619,
+                            "start": 2286,
+                            "end": 2389,
                             "loc": {
                               "start": {
                                 "line": 65,
@@ -2018,8 +2018,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 2530,
-                                "end": 2555,
+                                "start": 2300,
+                                "end": 2325,
                                 "loc": {
                                   "start": {
                                     "line": 66,
@@ -2035,8 +2035,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2530,
-                                  "end": 2539,
+                                  "start": 2300,
+                                  "end": 2309,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2052,8 +2052,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 2541,
-                                  "end": 2555,
+                                  "start": 2311,
+                                  "end": 2325,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2066,8 +2066,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 2541,
-                                    "end": 2545,
+                                    "start": 2311,
+                                    "end": 2315,
                                     "loc": {
                                       "start": {
                                         "line": 66,
@@ -2081,8 +2081,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2546,
-                                    "end": 2555,
+                                    "start": 2316,
+                                    "end": 2325,
                                     "loc": {
                                       "start": {
                                         "line": 66,
@@ -2101,8 +2101,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2569,
-                                "end": 2581,
+                                "start": 2339,
+                                "end": 2351,
                                 "loc": {
                                   "start": {
                                     "line": 67,
@@ -2118,8 +2118,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2569,
-                                  "end": 2574,
+                                  "start": 2339,
+                                  "end": 2344,
                                   "loc": {
                                     "start": {
                                       "line": 67,
@@ -2135,8 +2135,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2576,
-                                  "end": 2581,
+                                  "start": 2346,
+                                  "end": 2351,
                                   "loc": {
                                     "start": {
                                       "line": 67,
@@ -2153,8 +2153,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2595,
-                                "end": 2609,
+                                "start": 2365,
+                                "end": 2379,
                                 "loc": {
                                   "start": {
                                     "line": 68,
@@ -2170,8 +2170,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2595,
-                                  "end": 2601,
+                                  "start": 2365,
+                                  "end": 2371,
                                   "loc": {
                                     "start": {
                                       "line": 68,
@@ -2187,8 +2187,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2603,
-                                  "end": 2609,
+                                  "start": 2373,
+                                  "end": 2379,
                                   "loc": {
                                     "start": {
                                       "line": 68,
@@ -2214,9 +2214,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists\n     ",
-                    "start": 1844,
-                    "end": 2382,
+                    "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists\n     ",
+                    "start": 1669,
+                    "end": 2152,
                     "loc": {
                       "start": {
                         "line": 55,
@@ -2235,9 +2235,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n ",
+              "value": "*\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n ",
               "start": 103,
-              "end": 238,
+              "end": 228,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2255,9 +2255,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n ",
+            "value": "*\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n ",
             "start": 103,
-            "end": 238,
+            "end": 228,
             "loc": {
               "start": {
                 "line": 4,
@@ -2277,9 +2277,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n ",
+      "value": "*\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n ",
       "start": 103,
-      "end": 238,
+      "end": 228,
       "loc": {
         "start": {
           "line": 4,
@@ -2294,8 +2294,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 314,
-      "end": 340,
+      "start": 304,
+      "end": 330,
       "loc": {
         "start": {
           "line": 9,
@@ -2310,8 +2310,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 423,
-      "end": 457,
+      "start": 413,
+      "end": 447,
       "loc": {
         "start": {
           "line": 15,
@@ -2325,9 +2325,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories\n     ",
-      "start": 506,
-      "end": 822,
+      "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories\n     ",
+      "start": 496,
+      "end": 757,
       "loc": {
         "start": {
           "line": 21,
@@ -2341,9 +2341,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-      "start": 945,
-      "end": 1267,
+      "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+      "start": 880,
+      "end": 1147,
       "loc": {
         "start": {
           "line": 32,
@@ -2357,9 +2357,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-      "start": 1379,
-      "end": 1723,
+      "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+      "start": 1259,
+      "end": 1548,
       "loc": {
         "start": {
           "line": 44,
@@ -2373,9 +2373,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists\n     ",
-      "start": 1844,
-      "end": 2382,
+      "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists\n     ",
+      "start": 1669,
+      "end": 2152,
       "loc": {
         "start": {
           "line": 55,
@@ -2707,9 +2707,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n ",
+      "value": "*\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n ",
       "start": 103,
-      "end": 238,
+      "end": 228,
       "loc": {
         "start": {
           "line": 4,
@@ -2736,8 +2736,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 239,
-      "end": 245,
+      "start": 229,
+      "end": 235,
       "loc": {
         "start": {
           "line": 8,
@@ -2764,8 +2764,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 246,
-      "end": 253,
+      "start": 236,
+      "end": 243,
       "loc": {
         "start": {
           "line": 8,
@@ -2792,8 +2792,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 254,
-      "end": 259,
+      "start": 244,
+      "end": 249,
       "loc": {
         "start": {
           "line": 8,
@@ -2818,8 +2818,8 @@
         "binop": null
       },
       "value": "FeaturedPlaylistCategoryFetcher",
-      "start": 260,
-      "end": 291,
+      "start": 250,
+      "end": 281,
       "loc": {
         "start": {
           "line": 8,
@@ -2846,8 +2846,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 292,
-      "end": 299,
+      "start": 282,
+      "end": 289,
       "loc": {
         "start": {
           "line": 8,
@@ -2872,8 +2872,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 300,
-      "end": 307,
+      "start": 290,
+      "end": 297,
       "loc": {
         "start": {
           "line": 8,
@@ -2897,8 +2897,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 308,
-      "end": 309,
+      "start": 298,
+      "end": 299,
       "loc": {
         "start": {
           "line": 8,
@@ -2913,8 +2913,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 314,
-      "end": 340,
+      "start": 304,
+      "end": 330,
       "loc": {
         "start": {
           "line": 9,
@@ -2939,8 +2939,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 345,
-      "end": 356,
+      "start": 335,
+      "end": 346,
       "loc": {
         "start": {
           "line": 12,
@@ -2964,8 +2964,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 356,
-      "end": 357,
+      "start": 346,
+      "end": 347,
       "loc": {
         "start": {
           "line": 12,
@@ -2990,8 +2990,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 357,
-      "end": 361,
+      "start": 347,
+      "end": 351,
       "loc": {
         "start": {
           "line": 12,
@@ -3016,8 +3016,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 361,
-      "end": 362,
+      "start": 351,
+      "end": 352,
       "loc": {
         "start": {
           "line": 12,
@@ -3042,8 +3042,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 363,
-      "end": 372,
+      "start": 353,
+      "end": 362,
       "loc": {
         "start": {
           "line": 12,
@@ -3069,8 +3069,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 373,
-      "end": 374,
+      "start": 363,
+      "end": 364,
       "loc": {
         "start": {
           "line": 12,
@@ -3096,8 +3096,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 375,
-      "end": 379,
+      "start": 365,
+      "end": 369,
       "loc": {
         "start": {
           "line": 12,
@@ -3121,8 +3121,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 379,
-      "end": 380,
+      "start": 369,
+      "end": 370,
       "loc": {
         "start": {
           "line": 12,
@@ -3146,8 +3146,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 381,
-      "end": 382,
+      "start": 371,
+      "end": 372,
       "loc": {
         "start": {
           "line": 12,
@@ -3174,8 +3174,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 391,
-      "end": 396,
+      "start": 381,
+      "end": 386,
       "loc": {
         "start": {
           "line": 13,
@@ -3199,8 +3199,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 396,
-      "end": 397,
+      "start": 386,
+      "end": 387,
       "loc": {
         "start": {
           "line": 13,
@@ -3225,8 +3225,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 397,
-      "end": 401,
+      "start": 387,
+      "end": 391,
       "loc": {
         "start": {
           "line": 13,
@@ -3251,8 +3251,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 401,
-      "end": 402,
+      "start": 391,
+      "end": 392,
       "loc": {
         "start": {
           "line": 13,
@@ -3277,8 +3277,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 403,
-      "end": 412,
+      "start": 393,
+      "end": 402,
       "loc": {
         "start": {
           "line": 13,
@@ -3302,8 +3302,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 412,
-      "end": 413,
+      "start": 402,
+      "end": 403,
       "loc": {
         "start": {
           "line": 13,
@@ -3318,8 +3318,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 423,
-      "end": 457,
+      "start": 413,
+      "end": 447,
       "loc": {
         "start": {
           "line": 15,
@@ -3346,8 +3346,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 466,
-      "end": 470,
+      "start": 456,
+      "end": 460,
       "loc": {
         "start": {
           "line": 18,
@@ -3372,8 +3372,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 470,
-      "end": 471,
+      "start": 460,
+      "end": 461,
       "loc": {
         "start": {
           "line": 18,
@@ -3398,8 +3398,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 471,
-      "end": 482,
+      "start": 461,
+      "end": 472,
       "loc": {
         "start": {
           "line": 18,
@@ -3425,8 +3425,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 483,
-      "end": 484,
+      "start": 473,
+      "end": 474,
       "loc": {
         "start": {
           "line": 18,
@@ -3451,8 +3451,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 485,
-      "end": 494,
+      "start": 475,
+      "end": 484,
       "loc": {
         "start": {
           "line": 18,
@@ -3476,8 +3476,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 499,
-      "end": 500,
+      "start": 489,
+      "end": 490,
       "loc": {
         "start": {
           "line": 19,
@@ -3491,9 +3491,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories\n     ",
-      "start": 506,
-      "end": 822,
+      "value": "*\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories\n     ",
+      "start": 496,
+      "end": 757,
       "loc": {
         "start": {
           "line": 21,
@@ -3518,8 +3518,8 @@
         "binop": null
       },
       "value": "fetchAllFeaturedPlaylistCategories",
-      "start": 827,
-      "end": 861,
+      "start": 762,
+      "end": 796,
       "loc": {
         "start": {
           "line": 28,
@@ -3543,8 +3543,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 861,
-      "end": 862,
+      "start": 796,
+      "end": 797,
       "loc": {
         "start": {
           "line": 28,
@@ -3568,8 +3568,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 862,
-      "end": 863,
+      "start": 797,
+      "end": 798,
       "loc": {
         "start": {
           "line": 28,
@@ -3593,8 +3593,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 864,
-      "end": 865,
+      "start": 799,
+      "end": 800,
       "loc": {
         "start": {
           "line": 28,
@@ -3621,8 +3621,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 874,
-      "end": 880,
+      "start": 809,
+      "end": 815,
       "loc": {
         "start": {
           "line": 29,
@@ -3649,8 +3649,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 881,
-      "end": 885,
+      "start": 816,
+      "end": 820,
       "loc": {
         "start": {
           "line": 29,
@@ -3675,8 +3675,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 885,
-      "end": 886,
+      "start": 820,
+      "end": 821,
       "loc": {
         "start": {
           "line": 29,
@@ -3701,8 +3701,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 886,
-      "end": 890,
+      "start": 821,
+      "end": 825,
       "loc": {
         "start": {
           "line": 29,
@@ -3727,8 +3727,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 890,
-      "end": 891,
+      "start": 825,
+      "end": 826,
       "loc": {
         "start": {
           "line": 29,
@@ -3753,8 +3753,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 891,
-      "end": 894,
+      "start": 826,
+      "end": 829,
       "loc": {
         "start": {
           "line": 29,
@@ -3778,8 +3778,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 894,
-      "end": 895,
+      "start": 829,
+      "end": 830,
       "loc": {
         "start": {
           "line": 29,
@@ -3804,8 +3804,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 895,
-      "end": 903,
+      "start": 830,
+      "end": 838,
       "loc": {
         "start": {
           "line": 29,
@@ -3830,8 +3830,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 903,
-      "end": 904,
+      "start": 838,
+      "end": 839,
       "loc": {
         "start": {
           "line": 29,
@@ -3855,8 +3855,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 905,
-      "end": 906,
+      "start": 840,
+      "end": 841,
       "loc": {
         "start": {
           "line": 29,
@@ -3881,8 +3881,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 906,
-      "end": 915,
+      "start": 841,
+      "end": 850,
       "loc": {
         "start": {
           "line": 29,
@@ -3907,8 +3907,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 915,
-      "end": 916,
+      "start": 850,
+      "end": 851,
       "loc": {
         "start": {
           "line": 29,
@@ -3935,8 +3935,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 917,
-      "end": 921,
+      "start": 852,
+      "end": 856,
       "loc": {
         "start": {
           "line": 29,
@@ -3961,8 +3961,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 921,
-      "end": 922,
+      "start": 856,
+      "end": 857,
       "loc": {
         "start": {
           "line": 29,
@@ -3987,8 +3987,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 922,
-      "end": 931,
+      "start": 857,
+      "end": 866,
       "loc": {
         "start": {
           "line": 29,
@@ -4012,8 +4012,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 931,
-      "end": 932,
+      "start": 866,
+      "end": 867,
       "loc": {
         "start": {
           "line": 29,
@@ -4037,8 +4037,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 932,
-      "end": 933,
+      "start": 867,
+      "end": 868,
       "loc": {
         "start": {
           "line": 29,
@@ -4062,8 +4062,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 938,
-      "end": 939,
+      "start": 873,
+      "end": 874,
       "loc": {
         "start": {
           "line": 30,
@@ -4077,9 +4077,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-      "start": 945,
-      "end": 1267,
+      "value": "*\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+      "start": 880,
+      "end": 1147,
       "loc": {
         "start": {
           "line": 32,
@@ -4104,8 +4104,8 @@
         "binop": null
       },
       "value": "setCategoryID",
-      "start": 1272,
-      "end": 1285,
+      "start": 1152,
+      "end": 1165,
       "loc": {
         "start": {
           "line": 39,
@@ -4129,8 +4129,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1285,
-      "end": 1286,
+      "start": 1165,
+      "end": 1166,
       "loc": {
         "start": {
           "line": 39,
@@ -4155,8 +4155,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1286,
-      "end": 1297,
+      "start": 1166,
+      "end": 1177,
       "loc": {
         "start": {
           "line": 39,
@@ -4180,8 +4180,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1297,
-      "end": 1298,
+      "start": 1177,
+      "end": 1178,
       "loc": {
         "start": {
           "line": 39,
@@ -4205,8 +4205,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1299,
-      "end": 1300,
+      "start": 1179,
+      "end": 1180,
       "loc": {
         "start": {
           "line": 39,
@@ -4233,8 +4233,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1309,
-      "end": 1313,
+      "start": 1189,
+      "end": 1193,
       "loc": {
         "start": {
           "line": 40,
@@ -4259,8 +4259,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1313,
-      "end": 1314,
+      "start": 1193,
+      "end": 1194,
       "loc": {
         "start": {
           "line": 40,
@@ -4285,8 +4285,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1314,
-      "end": 1325,
+      "start": 1194,
+      "end": 1205,
       "loc": {
         "start": {
           "line": 40,
@@ -4312,8 +4312,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1326,
-      "end": 1327,
+      "start": 1206,
+      "end": 1207,
       "loc": {
         "start": {
           "line": 40,
@@ -4338,8 +4338,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1328,
-      "end": 1339,
+      "start": 1208,
+      "end": 1219,
       "loc": {
         "start": {
           "line": 40,
@@ -4366,8 +4366,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1356,
-      "end": 1362,
+      "start": 1236,
+      "end": 1242,
       "loc": {
         "start": {
           "line": 41,
@@ -4394,8 +4394,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1363,
-      "end": 1367,
+      "start": 1243,
+      "end": 1247,
       "loc": {
         "start": {
           "line": 41,
@@ -4419,8 +4419,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1372,
-      "end": 1373,
+      "start": 1252,
+      "end": 1253,
       "loc": {
         "start": {
           "line": 42,
@@ -4434,9 +4434,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     ",
-      "start": 1379,
-      "end": 1723,
+      "value": "*\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     ",
+      "start": 1259,
+      "end": 1548,
       "loc": {
         "start": {
           "line": 44,
@@ -4461,8 +4461,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1728,
-      "end": 1741,
+      "start": 1553,
+      "end": 1566,
       "loc": {
         "start": {
           "line": 51,
@@ -4486,8 +4486,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1741,
-      "end": 1742,
+      "start": 1566,
+      "end": 1567,
       "loc": {
         "start": {
           "line": 51,
@@ -4511,8 +4511,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1742,
-      "end": 1743,
+      "start": 1567,
+      "end": 1568,
       "loc": {
         "start": {
           "line": 51,
@@ -4536,8 +4536,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1744,
-      "end": 1745,
+      "start": 1569,
+      "end": 1570,
       "loc": {
         "start": {
           "line": 51,
@@ -4564,8 +4564,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1754,
-      "end": 1760,
+      "start": 1579,
+      "end": 1585,
       "loc": {
         "start": {
           "line": 52,
@@ -4592,8 +4592,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1761,
-      "end": 1765,
+      "start": 1586,
+      "end": 1590,
       "loc": {
         "start": {
           "line": 52,
@@ -4618,8 +4618,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1765,
-      "end": 1766,
+      "start": 1590,
+      "end": 1591,
       "loc": {
         "start": {
           "line": 52,
@@ -4644,8 +4644,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1766,
-      "end": 1770,
+      "start": 1591,
+      "end": 1595,
       "loc": {
         "start": {
           "line": 52,
@@ -4670,8 +4670,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1770,
-      "end": 1771,
+      "start": 1595,
+      "end": 1596,
       "loc": {
         "start": {
           "line": 52,
@@ -4696,8 +4696,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1771,
-      "end": 1774,
+      "start": 1596,
+      "end": 1599,
       "loc": {
         "start": {
           "line": 52,
@@ -4721,8 +4721,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1774,
-      "end": 1775,
+      "start": 1599,
+      "end": 1600,
       "loc": {
         "start": {
           "line": 52,
@@ -4747,8 +4747,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1775,
-      "end": 1783,
+      "start": 1600,
+      "end": 1608,
       "loc": {
         "start": {
           "line": 52,
@@ -4774,8 +4774,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1784,
-      "end": 1785,
+      "start": 1609,
+      "end": 1610,
       "loc": {
         "start": {
           "line": 52,
@@ -4802,8 +4802,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1786,
-      "end": 1790,
+      "start": 1611,
+      "end": 1615,
       "loc": {
         "start": {
           "line": 52,
@@ -4828,8 +4828,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1790,
-      "end": 1791,
+      "start": 1615,
+      "end": 1616,
       "loc": {
         "start": {
           "line": 52,
@@ -4854,8 +4854,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1791,
-      "end": 1802,
+      "start": 1616,
+      "end": 1627,
       "loc": {
         "start": {
           "line": 52,
@@ -4880,8 +4880,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1802,
-      "end": 1803,
+      "start": 1627,
+      "end": 1628,
       "loc": {
         "start": {
           "line": 52,
@@ -4905,8 +4905,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1804,
-      "end": 1805,
+      "start": 1629,
+      "end": 1630,
       "loc": {
         "start": {
           "line": 52,
@@ -4931,8 +4931,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1805,
-      "end": 1814,
+      "start": 1630,
+      "end": 1639,
       "loc": {
         "start": {
           "line": 52,
@@ -4957,8 +4957,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1814,
-      "end": 1815,
+      "start": 1639,
+      "end": 1640,
       "loc": {
         "start": {
           "line": 52,
@@ -4985,8 +4985,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1816,
-      "end": 1820,
+      "start": 1641,
+      "end": 1645,
       "loc": {
         "start": {
           "line": 52,
@@ -5011,8 +5011,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1820,
-      "end": 1821,
+      "start": 1645,
+      "end": 1646,
       "loc": {
         "start": {
           "line": 52,
@@ -5037,8 +5037,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1821,
-      "end": 1830,
+      "start": 1646,
+      "end": 1655,
       "loc": {
         "start": {
           "line": 52,
@@ -5062,8 +5062,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1830,
-      "end": 1831,
+      "start": 1655,
+      "end": 1656,
       "loc": {
         "start": {
           "line": 52,
@@ -5087,8 +5087,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1831,
-      "end": 1832,
+      "start": 1656,
+      "end": 1657,
       "loc": {
         "start": {
           "line": 52,
@@ -5112,8 +5112,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1837,
-      "end": 1838,
+      "start": 1662,
+      "end": 1663,
       "loc": {
         "start": {
           "line": 53,
@@ -5127,9 +5127,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists\n     ",
-      "start": 1844,
-      "end": 2382,
+      "value": "*\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists\n     ",
+      "start": 1669,
+      "end": 2152,
       "loc": {
         "start": {
           "line": 55,
@@ -5154,8 +5154,8 @@
         "binop": null
       },
       "value": "fetchPlaylists",
-      "start": 2387,
-      "end": 2401,
+      "start": 2157,
+      "end": 2171,
       "loc": {
         "start": {
           "line": 64,
@@ -5179,8 +5179,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2401,
-      "end": 2402,
+      "start": 2171,
+      "end": 2172,
       "loc": {
         "start": {
           "line": 64,
@@ -5205,8 +5205,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2402,
-      "end": 2407,
+      "start": 2172,
+      "end": 2177,
       "loc": {
         "start": {
           "line": 64,
@@ -5232,8 +5232,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2408,
-      "end": 2409,
+      "start": 2178,
+      "end": 2179,
       "loc": {
         "start": {
           "line": 64,
@@ -5258,8 +5258,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2410,
-      "end": 2419,
+      "start": 2180,
+      "end": 2189,
       "loc": {
         "start": {
           "line": 64,
@@ -5284,8 +5284,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2419,
-      "end": 2420,
+      "start": 2189,
+      "end": 2190,
       "loc": {
         "start": {
           "line": 64,
@@ -5310,8 +5310,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2421,
-      "end": 2427,
+      "start": 2191,
+      "end": 2197,
       "loc": {
         "start": {
           "line": 64,
@@ -5337,8 +5337,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2428,
-      "end": 2429,
+      "start": 2198,
+      "end": 2199,
       "loc": {
         "start": {
           "line": 64,
@@ -5363,8 +5363,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2430,
-      "end": 2439,
+      "start": 2200,
+      "end": 2209,
       "loc": {
         "start": {
           "line": 64,
@@ -5388,8 +5388,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2439,
-      "end": 2440,
+      "start": 2209,
+      "end": 2210,
       "loc": {
         "start": {
           "line": 64,
@@ -5413,8 +5413,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2441,
-      "end": 2442,
+      "start": 2211,
+      "end": 2212,
       "loc": {
         "start": {
           "line": 64,
@@ -5441,8 +5441,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2451,
-      "end": 2457,
+      "start": 2221,
+      "end": 2227,
       "loc": {
         "start": {
           "line": 65,
@@ -5469,8 +5469,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2458,
-      "end": 2462,
+      "start": 2228,
+      "end": 2232,
       "loc": {
         "start": {
           "line": 65,
@@ -5495,8 +5495,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2462,
-      "end": 2463,
+      "start": 2232,
+      "end": 2233,
       "loc": {
         "start": {
           "line": 65,
@@ -5521,8 +5521,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 2463,
-      "end": 2467,
+      "start": 2233,
+      "end": 2237,
       "loc": {
         "start": {
           "line": 65,
@@ -5547,8 +5547,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2467,
-      "end": 2468,
+      "start": 2237,
+      "end": 2238,
       "loc": {
         "start": {
           "line": 65,
@@ -5573,8 +5573,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 2468,
-      "end": 2471,
+      "start": 2238,
+      "end": 2241,
       "loc": {
         "start": {
           "line": 65,
@@ -5598,8 +5598,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2471,
-      "end": 2472,
+      "start": 2241,
+      "end": 2242,
       "loc": {
         "start": {
           "line": 65,
@@ -5624,8 +5624,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 2472,
-      "end": 2480,
+      "start": 2242,
+      "end": 2250,
       "loc": {
         "start": {
           "line": 65,
@@ -5651,8 +5651,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2481,
-      "end": 2482,
+      "start": 2251,
+      "end": 2252,
       "loc": {
         "start": {
           "line": 65,
@@ -5679,8 +5679,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2483,
-      "end": 2487,
+      "start": 2253,
+      "end": 2257,
       "loc": {
         "start": {
           "line": 65,
@@ -5705,8 +5705,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2487,
-      "end": 2488,
+      "start": 2257,
+      "end": 2258,
       "loc": {
         "start": {
           "line": 65,
@@ -5731,8 +5731,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 2488,
-      "end": 2499,
+      "start": 2258,
+      "end": 2269,
       "loc": {
         "start": {
           "line": 65,
@@ -5758,8 +5758,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2500,
-      "end": 2501,
+      "start": 2270,
+      "end": 2271,
       "loc": {
         "start": {
           "line": 65,
@@ -5785,8 +5785,8 @@
         "updateContext": null
       },
       "value": "/playlists",
-      "start": 2502,
-      "end": 2514,
+      "start": 2272,
+      "end": 2284,
       "loc": {
         "start": {
           "line": 65,
@@ -5811,8 +5811,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2514,
-      "end": 2515,
+      "start": 2284,
+      "end": 2285,
       "loc": {
         "start": {
           "line": 65,
@@ -5836,8 +5836,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2516,
-      "end": 2517,
+      "start": 2286,
+      "end": 2287,
       "loc": {
         "start": {
           "line": 65,
@@ -5862,8 +5862,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2530,
-      "end": 2539,
+      "start": 2300,
+      "end": 2309,
       "loc": {
         "start": {
           "line": 66,
@@ -5888,8 +5888,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2539,
-      "end": 2540,
+      "start": 2309,
+      "end": 2310,
       "loc": {
         "start": {
           "line": 66,
@@ -5916,8 +5916,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2541,
-      "end": 2545,
+      "start": 2311,
+      "end": 2315,
       "loc": {
         "start": {
           "line": 66,
@@ -5942,8 +5942,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2545,
-      "end": 2546,
+      "start": 2315,
+      "end": 2316,
       "loc": {
         "start": {
           "line": 66,
@@ -5968,8 +5968,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2546,
-      "end": 2555,
+      "start": 2316,
+      "end": 2325,
       "loc": {
         "start": {
           "line": 66,
@@ -5994,8 +5994,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2555,
-      "end": 2556,
+      "start": 2325,
+      "end": 2326,
       "loc": {
         "start": {
           "line": 66,
@@ -6020,8 +6020,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2569,
-      "end": 2574,
+      "start": 2339,
+      "end": 2344,
       "loc": {
         "start": {
           "line": 67,
@@ -6046,8 +6046,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2574,
-      "end": 2575,
+      "start": 2344,
+      "end": 2345,
       "loc": {
         "start": {
           "line": 67,
@@ -6072,8 +6072,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2576,
-      "end": 2581,
+      "start": 2346,
+      "end": 2351,
       "loc": {
         "start": {
           "line": 67,
@@ -6098,8 +6098,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2581,
-      "end": 2582,
+      "start": 2351,
+      "end": 2352,
       "loc": {
         "start": {
           "line": 67,
@@ -6124,8 +6124,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2595,
-      "end": 2601,
+      "start": 2365,
+      "end": 2371,
       "loc": {
         "start": {
           "line": 68,
@@ -6150,8 +6150,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2601,
-      "end": 2602,
+      "start": 2371,
+      "end": 2372,
       "loc": {
         "start": {
           "line": 68,
@@ -6176,8 +6176,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2603,
-      "end": 2609,
+      "start": 2373,
+      "end": 2379,
       "loc": {
         "start": {
           "line": 68,
@@ -6201,8 +6201,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2618,
-      "end": 2619,
+      "start": 2388,
+      "end": 2389,
       "loc": {
         "start": {
           "line": 69,
@@ -6226,8 +6226,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2619,
-      "end": 2620,
+      "start": 2389,
+      "end": 2390,
       "loc": {
         "start": {
           "line": 69,
@@ -6251,8 +6251,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2625,
-      "end": 2626,
+      "start": 2395,
+      "end": 2396,
       "loc": {
         "start": {
           "line": 70,
@@ -6276,8 +6276,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2627,
-      "end": 2628,
+      "start": 2397,
+      "end": 2398,
       "loc": {
         "start": {
           "line": 71,
@@ -6302,8 +6302,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2628,
-      "end": 2628,
+      "start": 2398,
+      "end": 2398,
       "loc": {
         "start": {
           "line": 71,

--- a/docs/ast/source/api/FeaturedPlaylistFetcher.js.json
+++ b/docs/ast/source/api/FeaturedPlaylistFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 1032,
+  "end": 978,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 1032,
+    "end": 978,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n ",
+            "value": "*\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n ",
             "start": 92,
-            "end": 211,
+            "end": 201,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 212,
-        "end": 1032,
+        "start": 202,
+        "end": 978,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 227,
-          "end": 1032,
+          "start": 217,
+          "end": 978,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 233,
-            "end": 256,
+            "start": 223,
+            "end": 246,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 265,
-            "end": 272,
+            "start": 255,
+            "end": 262,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 273,
-            "end": 1032,
+            "start": 263,
+            "end": 978,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 310,
-                "end": 384,
+                "start": 300,
+                "end": 374,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 310,
-                  "end": 321,
+                  "start": 300,
+                  "end": 311,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 322,
-                    "end": 326,
+                    "start": 312,
+                    "end": 316,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 328,
-                    "end": 344,
+                    "start": 318,
+                    "end": 334,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 328,
-                      "end": 337,
+                      "start": 318,
+                      "end": 327,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 340,
-                      "end": 344,
+                      "start": 330,
+                      "end": 334,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 346,
-                  "end": 384,
+                  "start": 336,
+                  "end": 374,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 356,
-                      "end": 378,
+                      "start": 346,
+                      "end": 368,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 356,
-                        "end": 378,
+                        "start": 346,
+                        "end": 368,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 356,
-                          "end": 361,
+                          "start": 346,
+                          "end": 351,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 362,
-                            "end": 366,
+                            "start": 352,
+                            "end": 356,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 368,
-                            "end": 377,
+                            "start": 358,
+                            "end": 367,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -495,8 +495,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 279,
-                    "end": 305,
+                    "start": 269,
+                    "end": 295,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -512,9 +512,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists\n     ",
-                    "start": 390,
-                    "end": 807,
+                    "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists\n     ",
+                    "start": 380,
+                    "end": 753,
                     "loc": {
                       "start": {
                         "line": 16,
@@ -530,8 +530,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 812,
-                "end": 1030,
+                "start": 758,
+                "end": 976,
                 "loc": {
                   "start": {
                     "line": 25,
@@ -545,8 +545,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 812,
-                  "end": 837,
+                  "start": 758,
+                  "end": 783,
                   "loc": {
                     "start": {
                       "line": 25,
@@ -570,8 +570,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 838,
-                    "end": 855,
+                    "start": 784,
+                    "end": 801,
                     "loc": {
                       "start": {
                         "line": 25,
@@ -584,8 +584,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 838,
-                      "end": 843,
+                      "start": 784,
+                      "end": 789,
                       "loc": {
                         "start": {
                           "line": 25,
@@ -601,8 +601,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 846,
-                      "end": 855,
+                      "start": 792,
+                      "end": 801,
                       "loc": {
                         "start": {
                           "line": 25,
@@ -619,8 +619,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 857,
-                    "end": 875,
+                    "start": 803,
+                    "end": 821,
                     "loc": {
                       "start": {
                         "line": 25,
@@ -633,8 +633,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 857,
-                      "end": 863,
+                      "start": 803,
+                      "end": 809,
                       "loc": {
                         "start": {
                           "line": 25,
@@ -650,8 +650,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 866,
-                      "end": 875,
+                      "start": 812,
+                      "end": 821,
                       "loc": {
                         "start": {
                           "line": 25,
@@ -669,8 +669,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 877,
-                  "end": 1030,
+                  "start": 823,
+                  "end": 976,
                   "loc": {
                     "start": {
                       "line": 25,
@@ -684,8 +684,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 887,
-                      "end": 1024,
+                      "start": 833,
+                      "end": 970,
                       "loc": {
                         "start": {
                           "line": 26,
@@ -698,8 +698,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 894,
-                        "end": 1024,
+                        "start": 840,
+                        "end": 970,
                         "loc": {
                           "start": {
                             "line": 26,
@@ -712,8 +712,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 894,
-                          "end": 907,
+                          "start": 840,
+                          "end": 853,
                           "loc": {
                             "start": {
                               "line": 26,
@@ -726,8 +726,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 894,
-                            "end": 903,
+                            "start": 840,
+                            "end": 849,
                             "loc": {
                               "start": {
                                 "line": 26,
@@ -740,8 +740,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 894,
-                              "end": 898,
+                              "start": 840,
+                              "end": 844,
                               "loc": {
                                 "start": {
                                   "line": 26,
@@ -755,8 +755,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 899,
-                              "end": 903,
+                              "start": 845,
+                              "end": 849,
                               "loc": {
                                 "start": {
                                   "line": 26,
@@ -774,8 +774,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 904,
-                            "end": 907,
+                            "start": 850,
+                            "end": 853,
                             "loc": {
                               "start": {
                                 "line": 26,
@@ -794,8 +794,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 908,
-                            "end": 916,
+                            "start": 854,
+                            "end": 862,
                             "loc": {
                               "start": {
                                 "line": 26,
@@ -811,8 +811,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 918,
-                            "end": 1023,
+                            "start": 864,
+                            "end": 969,
                             "loc": {
                               "start": {
                                 "line": 26,
@@ -826,8 +826,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 932,
-                                "end": 944,
+                                "start": 878,
+                                "end": 890,
                                 "loc": {
                                   "start": {
                                     "line": 27,
@@ -843,8 +843,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 932,
-                                  "end": 937,
+                                  "start": 878,
+                                  "end": 883,
                                   "loc": {
                                     "start": {
                                       "line": 27,
@@ -860,8 +860,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 939,
-                                  "end": 944,
+                                  "start": 885,
+                                  "end": 890,
                                   "loc": {
                                     "start": {
                                       "line": 27,
@@ -878,8 +878,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 959,
-                                "end": 973,
+                                "start": 905,
+                                "end": 919,
                                 "loc": {
                                   "start": {
                                     "line": 28,
@@ -895,8 +895,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 959,
-                                  "end": 965,
+                                  "start": 905,
+                                  "end": 911,
                                   "loc": {
                                     "start": {
                                       "line": 28,
@@ -912,8 +912,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 967,
-                                  "end": 973,
+                                  "start": 913,
+                                  "end": 919,
                                   "loc": {
                                     "start": {
                                       "line": 28,
@@ -930,8 +930,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 988,
-                                "end": 1013,
+                                "start": 934,
+                                "end": 959,
                                 "loc": {
                                   "start": {
                                     "line": 29,
@@ -947,8 +947,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 988,
-                                  "end": 997,
+                                  "start": 934,
+                                  "end": 943,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -964,8 +964,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 999,
-                                  "end": 1013,
+                                  "start": 945,
+                                  "end": 959,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -978,8 +978,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 999,
-                                    "end": 1003,
+                                    "start": 945,
+                                    "end": 949,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -993,8 +993,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1004,
-                                    "end": 1013,
+                                    "start": 950,
+                                    "end": 959,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -1022,9 +1022,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists\n     ",
-                    "start": 390,
-                    "end": 807,
+                    "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists\n     ",
+                    "start": 380,
+                    "end": 753,
                     "loc": {
                       "start": {
                         "line": 16,
@@ -1043,9 +1043,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n ",
+              "value": "*\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n ",
               "start": 92,
-              "end": 211,
+              "end": 201,
               "loc": {
                 "start": {
                   "line": 4,
@@ -1063,9 +1063,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n ",
+            "value": "*\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n ",
             "start": 92,
-            "end": 211,
+            "end": 201,
             "loc": {
               "start": {
                 "line": 4,
@@ -1085,9 +1085,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n ",
+      "value": "*\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n ",
       "start": 92,
-      "end": 211,
+      "end": 201,
       "loc": {
         "start": {
           "line": 4,
@@ -1102,8 +1102,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 279,
-      "end": 305,
+      "start": 269,
+      "end": 295,
       "loc": {
         "start": {
           "line": 9,
@@ -1117,9 +1117,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists\n     ",
-      "start": 390,
-      "end": 807,
+      "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists\n     ",
+      "start": 380,
+      "end": 753,
       "loc": {
         "start": {
           "line": 16,
@@ -1451,9 +1451,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n ",
+      "value": "*\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n ",
       "start": 92,
-      "end": 211,
+      "end": 201,
       "loc": {
         "start": {
           "line": 4,
@@ -1480,8 +1480,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 212,
-      "end": 218,
+      "start": 202,
+      "end": 208,
       "loc": {
         "start": {
           "line": 8,
@@ -1508,8 +1508,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 219,
-      "end": 226,
+      "start": 209,
+      "end": 216,
       "loc": {
         "start": {
           "line": 8,
@@ -1536,8 +1536,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 227,
-      "end": 232,
+      "start": 217,
+      "end": 222,
       "loc": {
         "start": {
           "line": 8,
@@ -1562,8 +1562,8 @@
         "binop": null
       },
       "value": "FeaturedPlaylistFetcher",
-      "start": 233,
-      "end": 256,
+      "start": 223,
+      "end": 246,
       "loc": {
         "start": {
           "line": 8,
@@ -1590,8 +1590,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 257,
-      "end": 264,
+      "start": 247,
+      "end": 254,
       "loc": {
         "start": {
           "line": 8,
@@ -1616,8 +1616,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 265,
-      "end": 272,
+      "start": 255,
+      "end": 262,
       "loc": {
         "start": {
           "line": 8,
@@ -1641,8 +1641,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 273,
-      "end": 274,
+      "start": 263,
+      "end": 264,
       "loc": {
         "start": {
           "line": 8,
@@ -1657,8 +1657,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 279,
-      "end": 305,
+      "start": 269,
+      "end": 295,
       "loc": {
         "start": {
           "line": 9,
@@ -1683,8 +1683,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 310,
-      "end": 321,
+      "start": 300,
+      "end": 311,
       "loc": {
         "start": {
           "line": 12,
@@ -1708,8 +1708,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 321,
-      "end": 322,
+      "start": 311,
+      "end": 312,
       "loc": {
         "start": {
           "line": 12,
@@ -1734,8 +1734,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 322,
-      "end": 326,
+      "start": 312,
+      "end": 316,
       "loc": {
         "start": {
           "line": 12,
@@ -1760,8 +1760,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 326,
-      "end": 327,
+      "start": 316,
+      "end": 317,
       "loc": {
         "start": {
           "line": 12,
@@ -1786,8 +1786,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 328,
-      "end": 337,
+      "start": 318,
+      "end": 327,
       "loc": {
         "start": {
           "line": 12,
@@ -1813,8 +1813,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 338,
-      "end": 339,
+      "start": 328,
+      "end": 329,
       "loc": {
         "start": {
           "line": 12,
@@ -1840,8 +1840,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 340,
-      "end": 344,
+      "start": 330,
+      "end": 334,
       "loc": {
         "start": {
           "line": 12,
@@ -1865,8 +1865,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 344,
-      "end": 345,
+      "start": 334,
+      "end": 335,
       "loc": {
         "start": {
           "line": 12,
@@ -1890,8 +1890,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 346,
-      "end": 347,
+      "start": 336,
+      "end": 337,
       "loc": {
         "start": {
           "line": 12,
@@ -1918,8 +1918,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 356,
-      "end": 361,
+      "start": 346,
+      "end": 351,
       "loc": {
         "start": {
           "line": 13,
@@ -1943,8 +1943,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 361,
-      "end": 362,
+      "start": 351,
+      "end": 352,
       "loc": {
         "start": {
           "line": 13,
@@ -1969,8 +1969,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 362,
-      "end": 366,
+      "start": 352,
+      "end": 356,
       "loc": {
         "start": {
           "line": 13,
@@ -1995,8 +1995,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 366,
-      "end": 367,
+      "start": 356,
+      "end": 357,
       "loc": {
         "start": {
           "line": 13,
@@ -2021,8 +2021,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 368,
-      "end": 377,
+      "start": 358,
+      "end": 367,
       "loc": {
         "start": {
           "line": 13,
@@ -2046,8 +2046,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 377,
-      "end": 378,
+      "start": 367,
+      "end": 368,
       "loc": {
         "start": {
           "line": 13,
@@ -2071,8 +2071,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 383,
-      "end": 384,
+      "start": 373,
+      "end": 374,
       "loc": {
         "start": {
           "line": 14,
@@ -2086,9 +2086,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists\n     ",
-      "start": 390,
-      "end": 807,
+      "value": "*\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists\n     ",
+      "start": 380,
+      "end": 753,
       "loc": {
         "start": {
           "line": 16,
@@ -2113,8 +2113,8 @@
         "binop": null
       },
       "value": "fetchAllFeaturedPlaylists",
-      "start": 812,
-      "end": 837,
+      "start": 758,
+      "end": 783,
       "loc": {
         "start": {
           "line": 25,
@@ -2138,8 +2138,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 837,
-      "end": 838,
+      "start": 783,
+      "end": 784,
       "loc": {
         "start": {
           "line": 25,
@@ -2164,8 +2164,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 838,
-      "end": 843,
+      "start": 784,
+      "end": 789,
       "loc": {
         "start": {
           "line": 25,
@@ -2191,8 +2191,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 844,
-      "end": 845,
+      "start": 790,
+      "end": 791,
       "loc": {
         "start": {
           "line": 25,
@@ -2217,8 +2217,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 846,
-      "end": 855,
+      "start": 792,
+      "end": 801,
       "loc": {
         "start": {
           "line": 25,
@@ -2243,8 +2243,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 855,
-      "end": 856,
+      "start": 801,
+      "end": 802,
       "loc": {
         "start": {
           "line": 25,
@@ -2269,8 +2269,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 857,
-      "end": 863,
+      "start": 803,
+      "end": 809,
       "loc": {
         "start": {
           "line": 25,
@@ -2296,8 +2296,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 864,
-      "end": 865,
+      "start": 810,
+      "end": 811,
       "loc": {
         "start": {
           "line": 25,
@@ -2322,8 +2322,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 866,
-      "end": 875,
+      "start": 812,
+      "end": 821,
       "loc": {
         "start": {
           "line": 25,
@@ -2347,8 +2347,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 875,
-      "end": 876,
+      "start": 821,
+      "end": 822,
       "loc": {
         "start": {
           "line": 25,
@@ -2372,8 +2372,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 877,
-      "end": 878,
+      "start": 823,
+      "end": 824,
       "loc": {
         "start": {
           "line": 25,
@@ -2400,8 +2400,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 887,
-      "end": 893,
+      "start": 833,
+      "end": 839,
       "loc": {
         "start": {
           "line": 26,
@@ -2428,8 +2428,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 894,
-      "end": 898,
+      "start": 840,
+      "end": 844,
       "loc": {
         "start": {
           "line": 26,
@@ -2454,8 +2454,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 898,
-      "end": 899,
+      "start": 844,
+      "end": 845,
       "loc": {
         "start": {
           "line": 26,
@@ -2480,8 +2480,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 899,
-      "end": 903,
+      "start": 845,
+      "end": 849,
       "loc": {
         "start": {
           "line": 26,
@@ -2506,8 +2506,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 903,
-      "end": 904,
+      "start": 849,
+      "end": 850,
       "loc": {
         "start": {
           "line": 26,
@@ -2532,8 +2532,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 904,
-      "end": 907,
+      "start": 850,
+      "end": 853,
       "loc": {
         "start": {
           "line": 26,
@@ -2557,8 +2557,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 907,
-      "end": 908,
+      "start": 853,
+      "end": 854,
       "loc": {
         "start": {
           "line": 26,
@@ -2583,8 +2583,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 908,
-      "end": 916,
+      "start": 854,
+      "end": 862,
       "loc": {
         "start": {
           "line": 26,
@@ -2609,8 +2609,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 916,
-      "end": 917,
+      "start": 862,
+      "end": 863,
       "loc": {
         "start": {
           "line": 26,
@@ -2634,8 +2634,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 918,
-      "end": 919,
+      "start": 864,
+      "end": 865,
       "loc": {
         "start": {
           "line": 26,
@@ -2660,8 +2660,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 932,
-      "end": 937,
+      "start": 878,
+      "end": 883,
       "loc": {
         "start": {
           "line": 27,
@@ -2686,8 +2686,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 937,
-      "end": 938,
+      "start": 883,
+      "end": 884,
       "loc": {
         "start": {
           "line": 27,
@@ -2712,8 +2712,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 939,
-      "end": 944,
+      "start": 885,
+      "end": 890,
       "loc": {
         "start": {
           "line": 27,
@@ -2738,8 +2738,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 944,
-      "end": 945,
+      "start": 890,
+      "end": 891,
       "loc": {
         "start": {
           "line": 27,
@@ -2764,8 +2764,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 959,
-      "end": 965,
+      "start": 905,
+      "end": 911,
       "loc": {
         "start": {
           "line": 28,
@@ -2790,8 +2790,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 965,
-      "end": 966,
+      "start": 911,
+      "end": 912,
       "loc": {
         "start": {
           "line": 28,
@@ -2816,8 +2816,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 967,
-      "end": 973,
+      "start": 913,
+      "end": 919,
       "loc": {
         "start": {
           "line": 28,
@@ -2842,8 +2842,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 973,
-      "end": 974,
+      "start": 919,
+      "end": 920,
       "loc": {
         "start": {
           "line": 28,
@@ -2868,8 +2868,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 988,
-      "end": 997,
+      "start": 934,
+      "end": 943,
       "loc": {
         "start": {
           "line": 29,
@@ -2894,8 +2894,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 997,
-      "end": 998,
+      "start": 943,
+      "end": 944,
       "loc": {
         "start": {
           "line": 29,
@@ -2922,8 +2922,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 999,
-      "end": 1003,
+      "start": 945,
+      "end": 949,
       "loc": {
         "start": {
           "line": 29,
@@ -2948,8 +2948,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1003,
-      "end": 1004,
+      "start": 949,
+      "end": 950,
       "loc": {
         "start": {
           "line": 29,
@@ -2974,8 +2974,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1004,
-      "end": 1013,
+      "start": 950,
+      "end": 959,
       "loc": {
         "start": {
           "line": 29,
@@ -2999,8 +2999,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1022,
-      "end": 1023,
+      "start": 968,
+      "end": 969,
       "loc": {
         "start": {
           "line": 30,
@@ -3024,8 +3024,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1023,
-      "end": 1024,
+      "start": 969,
+      "end": 970,
       "loc": {
         "start": {
           "line": 30,
@@ -3049,8 +3049,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1029,
-      "end": 1030,
+      "start": 975,
+      "end": 976,
       "loc": {
         "start": {
           "line": 31,
@@ -3074,8 +3074,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1031,
-      "end": 1032,
+      "start": 977,
+      "end": 978,
       "loc": {
         "start": {
           "line": 32,
@@ -3100,8 +3100,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1032,
-      "end": 1032,
+      "start": 978,
+      "end": 978,
       "loc": {
         "start": {
           "line": 32,

--- a/docs/ast/source/api/GenreStationFetcher.js.json
+++ b/docs/ast/source/api/GenreStationFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 1942,
+  "end": 1812,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 1942,
+    "end": 1812,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n ",
+            "value": "*\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n ",
             "start": 88,
-            "end": 194,
+            "end": 184,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 195,
-        "end": 1942,
+        "start": 185,
+        "end": 1812,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 210,
-          "end": 1942,
+          "start": 200,
+          "end": 1812,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 216,
-            "end": 235,
+            "start": 206,
+            "end": 225,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 244,
-            "end": 251,
+            "start": 234,
+            "end": 241,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 252,
-            "end": 1942,
+            "start": 242,
+            "end": 1812,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 289,
-                "end": 451,
+                "start": 279,
+                "end": 441,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 289,
-                  "end": 300,
+                  "start": 279,
+                  "end": 290,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 301,
-                    "end": 305,
+                    "start": 291,
+                    "end": 295,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 307,
-                    "end": 323,
+                    "start": 297,
+                    "end": 313,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 307,
-                      "end": 316,
+                      "start": 297,
+                      "end": 306,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 319,
-                      "end": 323,
+                      "start": 309,
+                      "end": 313,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 325,
-                  "end": 451,
+                  "start": 315,
+                  "end": 441,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 335,
-                      "end": 357,
+                      "start": 325,
+                      "end": 347,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 335,
-                        "end": 357,
+                        "start": 325,
+                        "end": 347,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 335,
-                          "end": 340,
+                          "start": 325,
+                          "end": 330,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 341,
-                            "end": 345,
+                            "start": 331,
+                            "end": 335,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 347,
-                            "end": 356,
+                            "start": 337,
+                            "end": 346,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         *  @ignore\n         ",
-                          "start": 367,
-                          "end": 402,
+                          "start": 357,
+                          "end": 392,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 411,
-                      "end": 444,
+                      "start": 401,
+                      "end": 434,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 411,
-                        "end": 444,
+                        "start": 401,
+                        "end": 434,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 411,
-                          "end": 432,
+                          "start": 401,
+                          "end": 422,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 411,
-                            "end": 415,
+                            "start": 401,
+                            "end": 405,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 416,
-                            "end": 432,
+                            "start": 406,
+                            "end": 422,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 435,
-                          "end": 444,
+                          "start": 425,
+                          "end": 434,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         *  @ignore\n         ",
-                          "start": 367,
-                          "end": 402,
+                          "start": 357,
+                          "end": 392,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 258,
-                    "end": 284,
+                    "start": 248,
+                    "end": 274,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations\n     ",
-                    "start": 457,
-                    "end": 851,
+                    "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations\n     ",
+                    "start": 447,
+                    "end": 801,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 856,
-                "end": 1080,
+                "start": 806,
+                "end": 1030,
                 "loc": {
                   "start": {
                     "line": 30,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 856,
-                  "end": 877,
+                  "start": 806,
+                  "end": 827,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 878,
-                    "end": 895,
+                    "start": 828,
+                    "end": 845,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -720,8 +720,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 878,
-                      "end": 883,
+                      "start": 828,
+                      "end": 833,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -737,8 +737,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 886,
-                      "end": 895,
+                      "start": 836,
+                      "end": 845,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -755,8 +755,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 897,
-                    "end": 915,
+                    "start": 847,
+                    "end": 865,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -769,8 +769,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 897,
-                      "end": 903,
+                      "start": 847,
+                      "end": 853,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -786,8 +786,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 906,
-                      "end": 915,
+                      "start": 856,
+                      "end": 865,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -805,8 +805,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 917,
-                  "end": 1080,
+                  "start": 867,
+                  "end": 1030,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -820,8 +820,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 927,
-                      "end": 1074,
+                      "start": 877,
+                      "end": 1024,
                       "loc": {
                         "start": {
                           "line": 31,
@@ -834,8 +834,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 934,
-                        "end": 1074,
+                        "start": 884,
+                        "end": 1024,
                         "loc": {
                           "start": {
                             "line": 31,
@@ -848,8 +848,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 934,
-                          "end": 947,
+                          "start": 884,
+                          "end": 897,
                           "loc": {
                             "start": {
                               "line": 31,
@@ -862,8 +862,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 934,
-                            "end": 943,
+                            "start": 884,
+                            "end": 893,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -876,8 +876,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 934,
-                              "end": 938,
+                              "start": 884,
+                              "end": 888,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -891,8 +891,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 939,
-                              "end": 943,
+                              "start": 889,
+                              "end": 893,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -910,8 +910,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 944,
-                            "end": 947,
+                            "start": 894,
+                            "end": 897,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -930,8 +930,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 948,
-                            "end": 956,
+                            "start": 898,
+                            "end": 906,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -947,8 +947,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 958,
-                            "end": 1073,
+                            "start": 908,
+                            "end": 1023,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -962,8 +962,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 972,
-                                "end": 997,
+                                "start": 922,
+                                "end": 947,
                                 "loc": {
                                   "start": {
                                     "line": 32,
@@ -979,8 +979,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 972,
-                                  "end": 981,
+                                  "start": 922,
+                                  "end": 931,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -996,8 +996,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 983,
-                                  "end": 997,
+                                  "start": 933,
+                                  "end": 947,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -1010,8 +1010,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 983,
-                                    "end": 987,
+                                    "start": 933,
+                                    "end": 937,
                                     "loc": {
                                       "start": {
                                         "line": 32,
@@ -1025,8 +1025,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 988,
-                                    "end": 997,
+                                    "start": 938,
+                                    "end": 947,
                                     "loc": {
                                       "start": {
                                         "line": 32,
@@ -1045,8 +1045,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1011,
-                                "end": 1023,
+                                "start": 961,
+                                "end": 973,
                                 "loc": {
                                   "start": {
                                     "line": 33,
@@ -1062,8 +1062,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1011,
-                                  "end": 1016,
+                                  "start": 961,
+                                  "end": 966,
                                   "loc": {
                                     "start": {
                                       "line": 33,
@@ -1079,8 +1079,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1018,
-                                  "end": 1023,
+                                  "start": 968,
+                                  "end": 973,
                                   "loc": {
                                     "start": {
                                       "line": 33,
@@ -1097,8 +1097,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1037,
-                                "end": 1051,
+                                "start": 987,
+                                "end": 1001,
                                 "loc": {
                                   "start": {
                                     "line": 34,
@@ -1114,8 +1114,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1037,
-                                  "end": 1043,
+                                  "start": 987,
+                                  "end": 993,
                                   "loc": {
                                     "start": {
                                       "line": 34,
@@ -1131,8 +1131,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1045,
-                                  "end": 1051,
+                                  "start": 995,
+                                  "end": 1001,
                                   "loc": {
                                     "start": {
                                       "line": 34,
@@ -1159,9 +1159,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations\n     ",
-                    "start": 457,
-                    "end": 851,
+                    "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations\n     ",
+                    "start": 447,
+                    "end": 801,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -1177,9 +1177,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-                    "start": 1086,
-                    "end": 1362,
+                    "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+                    "start": 1036,
+                    "end": 1272,
                     "loc": {
                       "start": {
                         "line": 38,
@@ -1195,8 +1195,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1367,
-                "end": 1487,
+                "start": 1277,
+                "end": 1397,
                 "loc": {
                   "start": {
                     "line": 45,
@@ -1210,8 +1210,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1367,
-                  "end": 1384,
+                  "start": 1277,
+                  "end": 1294,
                   "loc": {
                     "start": {
                       "line": 45,
@@ -1235,8 +1235,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1385,
-                    "end": 1401,
+                    "start": 1295,
+                    "end": 1311,
                     "loc": {
                       "start": {
                         "line": 45,
@@ -1253,8 +1253,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1403,
-                  "end": 1487,
+                  "start": 1313,
+                  "end": 1397,
                   "loc": {
                     "start": {
                       "line": 45,
@@ -1268,8 +1268,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1413,
-                      "end": 1453,
+                      "start": 1323,
+                      "end": 1363,
                       "loc": {
                         "start": {
                           "line": 46,
@@ -1282,8 +1282,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1413,
-                        "end": 1453,
+                        "start": 1323,
+                        "end": 1363,
                         "loc": {
                           "start": {
                             "line": 46,
@@ -1297,8 +1297,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1413,
-                          "end": 1434,
+                          "start": 1323,
+                          "end": 1344,
                           "loc": {
                             "start": {
                               "line": 46,
@@ -1311,8 +1311,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1413,
-                            "end": 1417,
+                            "start": 1323,
+                            "end": 1327,
                             "loc": {
                               "start": {
                                 "line": 46,
@@ -1326,8 +1326,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1418,
-                            "end": 1434,
+                            "start": 1328,
+                            "end": 1344,
                             "loc": {
                               "start": {
                                 "line": 46,
@@ -1345,8 +1345,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1437,
-                          "end": 1453,
+                          "start": 1347,
+                          "end": 1363,
                           "loc": {
                             "start": {
                               "line": 46,
@@ -1364,8 +1364,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1470,
-                      "end": 1481,
+                      "start": 1380,
+                      "end": 1391,
                       "loc": {
                         "start": {
                           "line": 47,
@@ -1378,8 +1378,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1477,
-                        "end": 1481,
+                        "start": 1387,
+                        "end": 1391,
                         "loc": {
                           "start": {
                             "line": 47,
@@ -1399,9 +1399,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-                    "start": 1086,
-                    "end": 1362,
+                    "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+                    "start": 1036,
+                    "end": 1272,
                     "loc": {
                       "start": {
                         "line": 38,
@@ -1417,9 +1417,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-                    "start": 1493,
-                    "end": 1820,
+                    "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+                    "start": 1403,
+                    "end": 1690,
                     "loc": {
                       "start": {
                         "line": 50,
@@ -1435,8 +1435,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1825,
-                "end": 1940,
+                "start": 1695,
+                "end": 1810,
                 "loc": {
                   "start": {
                     "line": 57,
@@ -1450,8 +1450,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1825,
-                  "end": 1838,
+                  "start": 1695,
+                  "end": 1708,
                   "loc": {
                     "start": {
                       "line": 57,
@@ -1475,8 +1475,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1841,
-                  "end": 1940,
+                  "start": 1711,
+                  "end": 1810,
                   "loc": {
                     "start": {
                       "line": 57,
@@ -1490,8 +1490,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1851,
-                      "end": 1934,
+                      "start": 1721,
+                      "end": 1804,
                       "loc": {
                         "start": {
                           "line": 58,
@@ -1504,8 +1504,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1858,
-                        "end": 1934,
+                        "start": 1728,
+                        "end": 1804,
                         "loc": {
                           "start": {
                             "line": 58,
@@ -1518,8 +1518,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1858,
-                          "end": 1871,
+                          "start": 1728,
+                          "end": 1741,
                           "loc": {
                             "start": {
                               "line": 58,
@@ -1532,8 +1532,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1858,
-                            "end": 1867,
+                            "start": 1728,
+                            "end": 1737,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1546,8 +1546,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1858,
-                              "end": 1862,
+                              "start": 1728,
+                              "end": 1732,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1561,8 +1561,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1863,
-                              "end": 1867,
+                              "start": 1733,
+                              "end": 1737,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1580,8 +1580,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1868,
-                            "end": 1871,
+                            "start": 1738,
+                            "end": 1741,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1600,8 +1600,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1872,
-                            "end": 1904,
+                            "start": 1742,
+                            "end": 1774,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1614,8 +1614,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1872,
-                              "end": 1880,
+                              "start": 1742,
+                              "end": 1750,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1632,8 +1632,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1883,
-                              "end": 1904,
+                              "start": 1753,
+                              "end": 1774,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1646,8 +1646,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1883,
-                                "end": 1887,
+                                "start": 1753,
+                                "end": 1757,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1661,8 +1661,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1888,
-                                "end": 1904,
+                                "start": 1758,
+                                "end": 1774,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1681,8 +1681,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1906,
-                            "end": 1933,
+                            "start": 1776,
+                            "end": 1803,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1696,8 +1696,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1907,
-                                "end": 1932,
+                                "start": 1777,
+                                "end": 1802,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1713,8 +1713,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1907,
-                                  "end": 1916,
+                                  "start": 1777,
+                                  "end": 1786,
                                   "loc": {
                                     "start": {
                                       "line": 58,
@@ -1730,8 +1730,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1918,
-                                  "end": 1932,
+                                  "start": 1788,
+                                  "end": 1802,
                                   "loc": {
                                     "start": {
                                       "line": 58,
@@ -1744,8 +1744,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1918,
-                                    "end": 1922,
+                                    "start": 1788,
+                                    "end": 1792,
                                     "loc": {
                                       "start": {
                                         "line": 58,
@@ -1759,8 +1759,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1923,
-                                    "end": 1932,
+                                    "start": 1793,
+                                    "end": 1802,
                                     "loc": {
                                       "start": {
                                         "line": 58,
@@ -1788,9 +1788,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-                    "start": 1493,
-                    "end": 1820,
+                    "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+                    "start": 1403,
+                    "end": 1690,
                     "loc": {
                       "start": {
                         "line": 50,
@@ -1809,9 +1809,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n ",
+              "value": "*\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n ",
               "start": 88,
-              "end": 194,
+              "end": 184,
               "loc": {
                 "start": {
                   "line": 4,
@@ -1829,9 +1829,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n ",
+            "value": "*\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n ",
             "start": 88,
-            "end": 194,
+            "end": 184,
             "loc": {
               "start": {
                 "line": 4,
@@ -1851,9 +1851,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n ",
+      "value": "*\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n ",
       "start": 88,
-      "end": 194,
+      "end": 184,
       "loc": {
         "start": {
           "line": 4,
@@ -1868,8 +1868,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 258,
-      "end": 284,
+      "start": 248,
+      "end": 274,
       "loc": {
         "start": {
           "line": 9,
@@ -1884,8 +1884,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         *  @ignore\n         ",
-      "start": 367,
-      "end": 402,
+      "start": 357,
+      "end": 392,
       "loc": {
         "start": {
           "line": 15,
@@ -1899,9 +1899,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations\n     ",
-      "start": 457,
-      "end": 851,
+      "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations\n     ",
+      "start": 447,
+      "end": 801,
       "loc": {
         "start": {
           "line": 21,
@@ -1915,9 +1915,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-      "start": 1086,
-      "end": 1362,
+      "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+      "start": 1036,
+      "end": 1272,
       "loc": {
         "start": {
           "line": 38,
@@ -1931,9 +1931,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-      "start": 1493,
-      "end": 1820,
+      "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+      "start": 1403,
+      "end": 1690,
       "loc": {
         "start": {
           "line": 50,
@@ -2265,9 +2265,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n ",
+      "value": "*\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n ",
       "start": 88,
-      "end": 194,
+      "end": 184,
       "loc": {
         "start": {
           "line": 4,
@@ -2294,8 +2294,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 195,
-      "end": 201,
+      "start": 185,
+      "end": 191,
       "loc": {
         "start": {
           "line": 8,
@@ -2322,8 +2322,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 202,
-      "end": 209,
+      "start": 192,
+      "end": 199,
       "loc": {
         "start": {
           "line": 8,
@@ -2350,8 +2350,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 210,
-      "end": 215,
+      "start": 200,
+      "end": 205,
       "loc": {
         "start": {
           "line": 8,
@@ -2376,8 +2376,8 @@
         "binop": null
       },
       "value": "GenreStationFetcher",
-      "start": 216,
-      "end": 235,
+      "start": 206,
+      "end": 225,
       "loc": {
         "start": {
           "line": 8,
@@ -2404,8 +2404,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 236,
-      "end": 243,
+      "start": 226,
+      "end": 233,
       "loc": {
         "start": {
           "line": 8,
@@ -2430,8 +2430,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 244,
-      "end": 251,
+      "start": 234,
+      "end": 241,
       "loc": {
         "start": {
           "line": 8,
@@ -2455,8 +2455,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 252,
-      "end": 253,
+      "start": 242,
+      "end": 243,
       "loc": {
         "start": {
           "line": 8,
@@ -2471,8 +2471,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 258,
-      "end": 284,
+      "start": 248,
+      "end": 274,
       "loc": {
         "start": {
           "line": 9,
@@ -2497,8 +2497,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 289,
-      "end": 300,
+      "start": 279,
+      "end": 290,
       "loc": {
         "start": {
           "line": 12,
@@ -2522,8 +2522,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 300,
-      "end": 301,
+      "start": 290,
+      "end": 291,
       "loc": {
         "start": {
           "line": 12,
@@ -2548,8 +2548,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 301,
-      "end": 305,
+      "start": 291,
+      "end": 295,
       "loc": {
         "start": {
           "line": 12,
@@ -2574,8 +2574,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 305,
-      "end": 306,
+      "start": 295,
+      "end": 296,
       "loc": {
         "start": {
           "line": 12,
@@ -2600,8 +2600,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 307,
-      "end": 316,
+      "start": 297,
+      "end": 306,
       "loc": {
         "start": {
           "line": 12,
@@ -2627,8 +2627,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 317,
-      "end": 318,
+      "start": 307,
+      "end": 308,
       "loc": {
         "start": {
           "line": 12,
@@ -2654,8 +2654,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 319,
-      "end": 323,
+      "start": 309,
+      "end": 313,
       "loc": {
         "start": {
           "line": 12,
@@ -2679,8 +2679,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 323,
-      "end": 324,
+      "start": 313,
+      "end": 314,
       "loc": {
         "start": {
           "line": 12,
@@ -2704,8 +2704,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 325,
-      "end": 326,
+      "start": 315,
+      "end": 316,
       "loc": {
         "start": {
           "line": 12,
@@ -2732,8 +2732,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 335,
-      "end": 340,
+      "start": 325,
+      "end": 330,
       "loc": {
         "start": {
           "line": 13,
@@ -2757,8 +2757,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 340,
-      "end": 341,
+      "start": 330,
+      "end": 331,
       "loc": {
         "start": {
           "line": 13,
@@ -2783,8 +2783,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 341,
-      "end": 345,
+      "start": 331,
+      "end": 335,
       "loc": {
         "start": {
           "line": 13,
@@ -2809,8 +2809,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 345,
-      "end": 346,
+      "start": 335,
+      "end": 336,
       "loc": {
         "start": {
           "line": 13,
@@ -2835,8 +2835,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 347,
-      "end": 356,
+      "start": 337,
+      "end": 346,
       "loc": {
         "start": {
           "line": 13,
@@ -2860,8 +2860,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 356,
-      "end": 357,
+      "start": 346,
+      "end": 347,
       "loc": {
         "start": {
           "line": 13,
@@ -2876,8 +2876,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         *  @ignore\n         ",
-      "start": 367,
-      "end": 402,
+      "start": 357,
+      "end": 392,
       "loc": {
         "start": {
           "line": 15,
@@ -2904,8 +2904,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 411,
-      "end": 415,
+      "start": 401,
+      "end": 405,
       "loc": {
         "start": {
           "line": 18,
@@ -2930,8 +2930,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 415,
-      "end": 416,
+      "start": 405,
+      "end": 406,
       "loc": {
         "start": {
           "line": 18,
@@ -2956,8 +2956,8 @@
         "binop": null
       },
       "value": "genre_station_id",
-      "start": 416,
-      "end": 432,
+      "start": 406,
+      "end": 422,
       "loc": {
         "start": {
           "line": 18,
@@ -2983,8 +2983,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 433,
-      "end": 434,
+      "start": 423,
+      "end": 424,
       "loc": {
         "start": {
           "line": 18,
@@ -3009,8 +3009,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 435,
-      "end": 444,
+      "start": 425,
+      "end": 434,
       "loc": {
         "start": {
           "line": 18,
@@ -3034,8 +3034,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 450,
-      "end": 451,
+      "start": 440,
+      "end": 441,
       "loc": {
         "start": {
           "line": 19,
@@ -3049,9 +3049,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations\n     ",
-      "start": 457,
-      "end": 851,
+      "value": "*\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations\n     ",
+      "start": 447,
+      "end": 801,
       "loc": {
         "start": {
           "line": 21,
@@ -3076,8 +3076,8 @@
         "binop": null
       },
       "value": "fetchAllGenreStations",
-      "start": 856,
-      "end": 877,
+      "start": 806,
+      "end": 827,
       "loc": {
         "start": {
           "line": 30,
@@ -3101,8 +3101,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 877,
-      "end": 878,
+      "start": 827,
+      "end": 828,
       "loc": {
         "start": {
           "line": 30,
@@ -3127,8 +3127,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 878,
-      "end": 883,
+      "start": 828,
+      "end": 833,
       "loc": {
         "start": {
           "line": 30,
@@ -3154,8 +3154,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 884,
-      "end": 885,
+      "start": 834,
+      "end": 835,
       "loc": {
         "start": {
           "line": 30,
@@ -3180,8 +3180,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 886,
-      "end": 895,
+      "start": 836,
+      "end": 845,
       "loc": {
         "start": {
           "line": 30,
@@ -3206,8 +3206,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 895,
-      "end": 896,
+      "start": 845,
+      "end": 846,
       "loc": {
         "start": {
           "line": 30,
@@ -3232,8 +3232,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 897,
-      "end": 903,
+      "start": 847,
+      "end": 853,
       "loc": {
         "start": {
           "line": 30,
@@ -3259,8 +3259,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 904,
-      "end": 905,
+      "start": 854,
+      "end": 855,
       "loc": {
         "start": {
           "line": 30,
@@ -3285,8 +3285,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 906,
-      "end": 915,
+      "start": 856,
+      "end": 865,
       "loc": {
         "start": {
           "line": 30,
@@ -3310,8 +3310,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 915,
-      "end": 916,
+      "start": 865,
+      "end": 866,
       "loc": {
         "start": {
           "line": 30,
@@ -3335,8 +3335,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 917,
-      "end": 918,
+      "start": 867,
+      "end": 868,
       "loc": {
         "start": {
           "line": 30,
@@ -3363,8 +3363,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 927,
-      "end": 933,
+      "start": 877,
+      "end": 883,
       "loc": {
         "start": {
           "line": 31,
@@ -3391,8 +3391,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 934,
-      "end": 938,
+      "start": 884,
+      "end": 888,
       "loc": {
         "start": {
           "line": 31,
@@ -3417,8 +3417,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 938,
-      "end": 939,
+      "start": 888,
+      "end": 889,
       "loc": {
         "start": {
           "line": 31,
@@ -3443,8 +3443,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 939,
-      "end": 943,
+      "start": 889,
+      "end": 893,
       "loc": {
         "start": {
           "line": 31,
@@ -3469,8 +3469,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 943,
-      "end": 944,
+      "start": 893,
+      "end": 894,
       "loc": {
         "start": {
           "line": 31,
@@ -3495,8 +3495,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 944,
-      "end": 947,
+      "start": 894,
+      "end": 897,
       "loc": {
         "start": {
           "line": 31,
@@ -3520,8 +3520,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 947,
-      "end": 948,
+      "start": 897,
+      "end": 898,
       "loc": {
         "start": {
           "line": 31,
@@ -3546,8 +3546,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 948,
-      "end": 956,
+      "start": 898,
+      "end": 906,
       "loc": {
         "start": {
           "line": 31,
@@ -3572,8 +3572,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 956,
-      "end": 957,
+      "start": 906,
+      "end": 907,
       "loc": {
         "start": {
           "line": 31,
@@ -3597,8 +3597,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 958,
-      "end": 959,
+      "start": 908,
+      "end": 909,
       "loc": {
         "start": {
           "line": 31,
@@ -3623,8 +3623,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 972,
-      "end": 981,
+      "start": 922,
+      "end": 931,
       "loc": {
         "start": {
           "line": 32,
@@ -3649,8 +3649,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 981,
-      "end": 982,
+      "start": 931,
+      "end": 932,
       "loc": {
         "start": {
           "line": 32,
@@ -3677,8 +3677,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 983,
-      "end": 987,
+      "start": 933,
+      "end": 937,
       "loc": {
         "start": {
           "line": 32,
@@ -3703,8 +3703,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 987,
-      "end": 988,
+      "start": 937,
+      "end": 938,
       "loc": {
         "start": {
           "line": 32,
@@ -3729,8 +3729,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 988,
-      "end": 997,
+      "start": 938,
+      "end": 947,
       "loc": {
         "start": {
           "line": 32,
@@ -3755,8 +3755,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 997,
-      "end": 998,
+      "start": 947,
+      "end": 948,
       "loc": {
         "start": {
           "line": 32,
@@ -3781,8 +3781,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1011,
-      "end": 1016,
+      "start": 961,
+      "end": 966,
       "loc": {
         "start": {
           "line": 33,
@@ -3807,8 +3807,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1016,
-      "end": 1017,
+      "start": 966,
+      "end": 967,
       "loc": {
         "start": {
           "line": 33,
@@ -3833,8 +3833,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1018,
-      "end": 1023,
+      "start": 968,
+      "end": 973,
       "loc": {
         "start": {
           "line": 33,
@@ -3859,8 +3859,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1023,
-      "end": 1024,
+      "start": 973,
+      "end": 974,
       "loc": {
         "start": {
           "line": 33,
@@ -3885,8 +3885,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1037,
-      "end": 1043,
+      "start": 987,
+      "end": 993,
       "loc": {
         "start": {
           "line": 34,
@@ -3911,8 +3911,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1043,
-      "end": 1044,
+      "start": 993,
+      "end": 994,
       "loc": {
         "start": {
           "line": 34,
@@ -3937,8 +3937,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1045,
-      "end": 1051,
+      "start": 995,
+      "end": 1001,
       "loc": {
         "start": {
           "line": 34,
@@ -3962,8 +3962,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1072,
-      "end": 1073,
+      "start": 1022,
+      "end": 1023,
       "loc": {
         "start": {
           "line": 35,
@@ -3987,8 +3987,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1073,
-      "end": 1074,
+      "start": 1023,
+      "end": 1024,
       "loc": {
         "start": {
           "line": 35,
@@ -4012,8 +4012,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1079,
-      "end": 1080,
+      "start": 1029,
+      "end": 1030,
       "loc": {
         "start": {
           "line": 36,
@@ -4027,9 +4027,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-      "start": 1086,
-      "end": 1362,
+      "value": "*\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+      "start": 1036,
+      "end": 1272,
       "loc": {
         "start": {
           "line": 38,
@@ -4054,8 +4054,8 @@
         "binop": null
       },
       "value": "setGenreStationID",
-      "start": 1367,
-      "end": 1384,
+      "start": 1277,
+      "end": 1294,
       "loc": {
         "start": {
           "line": 45,
@@ -4079,8 +4079,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1384,
-      "end": 1385,
+      "start": 1294,
+      "end": 1295,
       "loc": {
         "start": {
           "line": 45,
@@ -4105,8 +4105,8 @@
         "binop": null
       },
       "value": "genre_station_id",
-      "start": 1385,
-      "end": 1401,
+      "start": 1295,
+      "end": 1311,
       "loc": {
         "start": {
           "line": 45,
@@ -4130,8 +4130,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1401,
-      "end": 1402,
+      "start": 1311,
+      "end": 1312,
       "loc": {
         "start": {
           "line": 45,
@@ -4155,8 +4155,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1403,
-      "end": 1404,
+      "start": 1313,
+      "end": 1314,
       "loc": {
         "start": {
           "line": 45,
@@ -4183,8 +4183,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1413,
-      "end": 1417,
+      "start": 1323,
+      "end": 1327,
       "loc": {
         "start": {
           "line": 46,
@@ -4209,8 +4209,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1417,
-      "end": 1418,
+      "start": 1327,
+      "end": 1328,
       "loc": {
         "start": {
           "line": 46,
@@ -4235,8 +4235,8 @@
         "binop": null
       },
       "value": "genre_station_id",
-      "start": 1418,
-      "end": 1434,
+      "start": 1328,
+      "end": 1344,
       "loc": {
         "start": {
           "line": 46,
@@ -4262,8 +4262,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1435,
-      "end": 1436,
+      "start": 1345,
+      "end": 1346,
       "loc": {
         "start": {
           "line": 46,
@@ -4288,8 +4288,8 @@
         "binop": null
       },
       "value": "genre_station_id",
-      "start": 1437,
-      "end": 1453,
+      "start": 1347,
+      "end": 1363,
       "loc": {
         "start": {
           "line": 46,
@@ -4316,8 +4316,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1470,
-      "end": 1476,
+      "start": 1380,
+      "end": 1386,
       "loc": {
         "start": {
           "line": 47,
@@ -4344,8 +4344,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1477,
-      "end": 1481,
+      "start": 1387,
+      "end": 1391,
       "loc": {
         "start": {
           "line": 47,
@@ -4369,8 +4369,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1486,
-      "end": 1487,
+      "start": 1396,
+      "end": 1397,
       "loc": {
         "start": {
           "line": 48,
@@ -4384,9 +4384,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     ",
-      "start": 1493,
-      "end": 1820,
+      "value": "*\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     ",
+      "start": 1403,
+      "end": 1690,
       "loc": {
         "start": {
           "line": 50,
@@ -4411,8 +4411,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1825,
-      "end": 1838,
+      "start": 1695,
+      "end": 1708,
       "loc": {
         "start": {
           "line": 57,
@@ -4436,8 +4436,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1838,
-      "end": 1839,
+      "start": 1708,
+      "end": 1709,
       "loc": {
         "start": {
           "line": 57,
@@ -4461,8 +4461,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1839,
-      "end": 1840,
+      "start": 1709,
+      "end": 1710,
       "loc": {
         "start": {
           "line": 57,
@@ -4486,8 +4486,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1841,
-      "end": 1842,
+      "start": 1711,
+      "end": 1712,
       "loc": {
         "start": {
           "line": 57,
@@ -4514,8 +4514,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1851,
-      "end": 1857,
+      "start": 1721,
+      "end": 1727,
       "loc": {
         "start": {
           "line": 58,
@@ -4542,8 +4542,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1858,
-      "end": 1862,
+      "start": 1728,
+      "end": 1732,
       "loc": {
         "start": {
           "line": 58,
@@ -4568,8 +4568,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1862,
-      "end": 1863,
+      "start": 1732,
+      "end": 1733,
       "loc": {
         "start": {
           "line": 58,
@@ -4594,8 +4594,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1863,
-      "end": 1867,
+      "start": 1733,
+      "end": 1737,
       "loc": {
         "start": {
           "line": 58,
@@ -4620,8 +4620,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1867,
-      "end": 1868,
+      "start": 1737,
+      "end": 1738,
       "loc": {
         "start": {
           "line": 58,
@@ -4646,8 +4646,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1868,
-      "end": 1871,
+      "start": 1738,
+      "end": 1741,
       "loc": {
         "start": {
           "line": 58,
@@ -4671,8 +4671,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1871,
-      "end": 1872,
+      "start": 1741,
+      "end": 1742,
       "loc": {
         "start": {
           "line": 58,
@@ -4697,8 +4697,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1872,
-      "end": 1880,
+      "start": 1742,
+      "end": 1750,
       "loc": {
         "start": {
           "line": 58,
@@ -4724,8 +4724,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1881,
-      "end": 1882,
+      "start": 1751,
+      "end": 1752,
       "loc": {
         "start": {
           "line": 58,
@@ -4752,8 +4752,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1883,
-      "end": 1887,
+      "start": 1753,
+      "end": 1757,
       "loc": {
         "start": {
           "line": 58,
@@ -4778,8 +4778,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1887,
-      "end": 1888,
+      "start": 1757,
+      "end": 1758,
       "loc": {
         "start": {
           "line": 58,
@@ -4804,8 +4804,8 @@
         "binop": null
       },
       "value": "genre_station_id",
-      "start": 1888,
-      "end": 1904,
+      "start": 1758,
+      "end": 1774,
       "loc": {
         "start": {
           "line": 58,
@@ -4830,8 +4830,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1904,
-      "end": 1905,
+      "start": 1774,
+      "end": 1775,
       "loc": {
         "start": {
           "line": 58,
@@ -4855,8 +4855,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1906,
-      "end": 1907,
+      "start": 1776,
+      "end": 1777,
       "loc": {
         "start": {
           "line": 58,
@@ -4881,8 +4881,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1907,
-      "end": 1916,
+      "start": 1777,
+      "end": 1786,
       "loc": {
         "start": {
           "line": 58,
@@ -4907,8 +4907,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1916,
-      "end": 1917,
+      "start": 1786,
+      "end": 1787,
       "loc": {
         "start": {
           "line": 58,
@@ -4935,8 +4935,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1918,
-      "end": 1922,
+      "start": 1788,
+      "end": 1792,
       "loc": {
         "start": {
           "line": 58,
@@ -4961,8 +4961,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1922,
-      "end": 1923,
+      "start": 1792,
+      "end": 1793,
       "loc": {
         "start": {
           "line": 58,
@@ -4987,8 +4987,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1923,
-      "end": 1932,
+      "start": 1793,
+      "end": 1802,
       "loc": {
         "start": {
           "line": 58,
@@ -5012,8 +5012,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1932,
-      "end": 1933,
+      "start": 1802,
+      "end": 1803,
       "loc": {
         "start": {
           "line": 58,
@@ -5037,8 +5037,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1933,
-      "end": 1934,
+      "start": 1803,
+      "end": 1804,
       "loc": {
         "start": {
           "line": 58,
@@ -5062,8 +5062,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1939,
-      "end": 1940,
+      "start": 1809,
+      "end": 1810,
       "loc": {
         "start": {
           "line": 59,
@@ -5087,8 +5087,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1941,
-      "end": 1942,
+      "start": 1811,
+      "end": 1812,
       "loc": {
         "start": {
           "line": 60,
@@ -5113,8 +5113,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1942,
-      "end": 1942,
+      "start": 1812,
+      "end": 1812,
       "loc": {
         "start": {
           "line": 60,

--- a/docs/ast/source/api/MoodStationFetcher.js.json
+++ b/docs/ast/source/api/MoodStationFetcher.js.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 1650,
+  "end": 1644,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 55,
+      "line": 56,
       "column": 1
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 1650,
+    "end": 1644,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 55,
+        "line": 56,
         "column": 1
       }
     },
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n ",
+            "value": "*\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n ",
             "start": 87,
-            "end": 190,
+            "end": 181,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,36 +205,36 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 191,
-        "end": 1650,
+        "start": 182,
+        "end": 1644,
         "loc": {
           "start": {
             "line": 8,
             "column": 0
           },
           "end": {
-            "line": 55,
+            "line": 56,
             "column": 1
           }
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 206,
-          "end": 1650,
+          "start": 197,
+          "end": 1644,
           "loc": {
             "start": {
               "line": 8,
               "column": 15
             },
             "end": {
-              "line": 55,
+              "line": 56,
               "column": 1
             }
           },
           "id": {
             "type": "Identifier",
-            "start": 212,
-            "end": 230,
+            "start": 203,
+            "end": 221,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 239,
-            "end": 246,
+            "start": 230,
+            "end": 237,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,23 +268,23 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 247,
-            "end": 1650,
+            "start": 238,
+            "end": 1644,
             "loc": {
               "start": {
                 "line": 8,
                 "column": 56
               },
               "end": {
-                "line": 55,
+                "line": 56,
                 "column": 1
               }
             },
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 284,
-                "end": 443,
+                "start": 275,
+                "end": 434,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 284,
-                  "end": 295,
+                  "start": 275,
+                  "end": 286,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 296,
-                    "end": 300,
+                    "start": 287,
+                    "end": 291,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 302,
-                    "end": 318,
+                    "start": 293,
+                    "end": 309,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 302,
-                      "end": 311,
+                      "start": 293,
+                      "end": 302,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 314,
-                      "end": 318,
+                      "start": 305,
+                      "end": 309,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 320,
-                  "end": 443,
+                  "start": 311,
+                  "end": 434,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 330,
-                      "end": 352,
+                      "start": 321,
+                      "end": 343,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 330,
-                        "end": 352,
+                        "start": 321,
+                        "end": 343,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 330,
-                          "end": 335,
+                          "start": 321,
+                          "end": 326,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 336,
-                            "end": 340,
+                            "start": 327,
+                            "end": 331,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 342,
-                            "end": 351,
+                            "start": 333,
+                            "end": 342,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 362,
-                          "end": 396,
+                          "start": 353,
+                          "end": 387,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 405,
-                      "end": 437,
+                      "start": 396,
+                      "end": 428,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 405,
-                        "end": 437,
+                        "start": 396,
+                        "end": 428,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 405,
-                          "end": 425,
+                          "start": 396,
+                          "end": 416,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 405,
-                            "end": 409,
+                            "start": 396,
+                            "end": 400,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 410,
-                            "end": 425,
+                            "start": 401,
+                            "end": 416,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 428,
-                          "end": 437,
+                          "start": 419,
+                          "end": 428,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 362,
-                          "end": 396,
+                          "start": 353,
+                          "end": 387,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 253,
-                    "end": 279,
+                    "start": 244,
+                    "end": 270,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations\n     ",
-                    "start": 449,
-                    "end": 692,
+                    "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations\n     ",
+                    "start": 440,
+                    "end": 645,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 697,
-                "end": 795,
+                "start": 650,
+                "end": 748,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 697,
-                  "end": 717,
+                  "start": 650,
+                  "end": 670,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 720,
-                  "end": 795,
+                  "start": 673,
+                  "end": 748,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -721,8 +721,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 730,
-                      "end": 789,
+                      "start": 683,
+                      "end": 742,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -735,8 +735,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 737,
-                        "end": 789,
+                        "start": 690,
+                        "end": 742,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -749,8 +749,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 737,
-                          "end": 750,
+                          "start": 690,
+                          "end": 703,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -763,8 +763,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 737,
-                            "end": 746,
+                            "start": 690,
+                            "end": 699,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -777,8 +777,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 737,
-                              "end": 741,
+                              "start": 690,
+                              "end": 694,
                               "loc": {
                                 "start": {
                                   "line": 29,
@@ -792,8 +792,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 742,
-                              "end": 746,
+                              "start": 695,
+                              "end": 699,
                               "loc": {
                                 "start": {
                                   "line": 29,
@@ -811,8 +811,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 747,
-                            "end": 750,
+                            "start": 700,
+                            "end": 703,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -831,8 +831,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 751,
-                            "end": 759,
+                            "start": 704,
+                            "end": 712,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -848,8 +848,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 761,
-                            "end": 788,
+                            "start": 714,
+                            "end": 741,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -863,8 +863,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 762,
-                                "end": 787,
+                                "start": 715,
+                                "end": 740,
                                 "loc": {
                                   "start": {
                                     "line": 29,
@@ -880,8 +880,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 762,
-                                  "end": 771,
+                                  "start": 715,
+                                  "end": 724,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -897,8 +897,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 773,
-                                  "end": 787,
+                                  "start": 726,
+                                  "end": 740,
                                   "loc": {
                                     "start": {
                                       "line": 29,
@@ -911,8 +911,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 773,
-                                    "end": 777,
+                                    "start": 726,
+                                    "end": 730,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -926,8 +926,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 778,
-                                    "end": 787,
+                                    "start": 731,
+                                    "end": 740,
                                     "loc": {
                                       "start": {
                                         "line": 29,
@@ -956,9 +956,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations\n     ",
-                    "start": 449,
-                    "end": 692,
+                    "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations\n     ",
+                    "start": 440,
+                    "end": 645,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -974,9 +974,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id\n     ",
-                    "start": 801,
-                    "end": 1178,
+                    "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+                    "start": 754,
+                    "end": 1093,
                     "loc": {
                       "start": {
                         "line": 32,
@@ -992,8 +992,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1183,
-                "end": 1344,
+                "start": 1098,
+                "end": 1259,
                 "loc": {
                   "start": {
                     "line": 40,
@@ -1007,8 +1007,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1183,
-                  "end": 1199,
+                  "start": 1098,
+                  "end": 1114,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -1032,8 +1032,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1200,
-                    "end": 1215,
+                    "start": 1115,
+                    "end": 1130,
                     "loc": {
                       "start": {
                         "line": 40,
@@ -1049,8 +1049,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 1217,
-                    "end": 1233,
+                    "start": 1132,
+                    "end": 1148,
                     "loc": {
                       "start": {
                         "line": 40,
@@ -1063,8 +1063,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1217,
-                      "end": 1226,
+                      "start": 1132,
+                      "end": 1141,
                       "loc": {
                         "start": {
                           "line": 40,
@@ -1080,8 +1080,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 1229,
-                      "end": 1233,
+                      "start": 1144,
+                      "end": 1148,
                       "loc": {
                         "start": {
                           "line": 40,
@@ -1102,8 +1102,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1235,
-                  "end": 1344,
+                  "start": 1150,
+                  "end": 1259,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -1117,8 +1117,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1245,
-                      "end": 1283,
+                      "start": 1160,
+                      "end": 1198,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -1131,8 +1131,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1245,
-                        "end": 1283,
+                        "start": 1160,
+                        "end": 1198,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -1146,8 +1146,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1245,
-                          "end": 1265,
+                          "start": 1160,
+                          "end": 1180,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1160,8 +1160,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1245,
-                            "end": 1249,
+                            "start": 1160,
+                            "end": 1164,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1175,8 +1175,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1250,
-                            "end": 1265,
+                            "start": 1165,
+                            "end": 1180,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1194,8 +1194,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1268,
-                          "end": 1283,
+                          "start": 1183,
+                          "end": 1198,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1213,8 +1213,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 1292,
-                      "end": 1318,
+                      "start": 1207,
+                      "end": 1233,
                       "loc": {
                         "start": {
                           "line": 42,
@@ -1227,8 +1227,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1292,
-                        "end": 1318,
+                        "start": 1207,
+                        "end": 1233,
                         "loc": {
                           "start": {
                             "line": 42,
@@ -1242,8 +1242,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1292,
-                          "end": 1306,
+                          "start": 1207,
+                          "end": 1221,
                           "loc": {
                             "start": {
                               "line": 42,
@@ -1256,8 +1256,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1292,
-                            "end": 1296,
+                            "start": 1207,
+                            "end": 1211,
                             "loc": {
                               "start": {
                                 "line": 42,
@@ -1271,8 +1271,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1297,
-                            "end": 1306,
+                            "start": 1212,
+                            "end": 1221,
                             "loc": {
                               "start": {
                                 "line": 42,
@@ -1290,8 +1290,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1309,
-                          "end": 1318,
+                          "start": 1224,
+                          "end": 1233,
                           "loc": {
                             "start": {
                               "line": 42,
@@ -1309,8 +1309,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1327,
-                      "end": 1338,
+                      "start": 1242,
+                      "end": 1253,
                       "loc": {
                         "start": {
                           "line": 43,
@@ -1323,8 +1323,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1334,
-                        "end": 1338,
+                        "start": 1249,
+                        "end": 1253,
                         "loc": {
                           "start": {
                             "line": 43,
@@ -1344,9 +1344,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id\n     ",
-                    "start": 801,
-                    "end": 1178,
+                    "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+                    "start": 754,
+                    "end": 1093,
                     "loc": {
                       "start": {
                         "line": 32,
@@ -1362,16 +1362,16 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     ",
-                    "start": 1350,
-                    "end": 1529,
+                    "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+                    "start": 1265,
+                    "end": 1523,
                     "loc": {
                       "start": {
                         "line": 46,
                         "column": 4
                       },
                       "end": {
-                        "line": 51,
+                        "line": 52,
                         "column": 7
                       }
                     }
@@ -1380,30 +1380,30 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1534,
-                "end": 1648,
+                "start": 1528,
+                "end": 1642,
                 "loc": {
                   "start": {
-                    "line": 52,
+                    "line": 53,
                     "column": 4
                   },
                   "end": {
-                    "line": 54,
+                    "line": 55,
                     "column": 5
                   }
                 },
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1534,
-                  "end": 1547,
+                  "start": 1528,
+                  "end": 1541,
                   "loc": {
                     "start": {
-                      "line": 52,
+                      "line": 53,
                       "column": 4
                     },
                     "end": {
-                      "line": 52,
+                      "line": 53,
                       "column": 17
                     },
                     "identifierName": "fetchMetadata"
@@ -1420,101 +1420,101 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1550,
-                  "end": 1648,
+                  "start": 1544,
+                  "end": 1642,
                   "loc": {
                     "start": {
-                      "line": 52,
+                      "line": 53,
                       "column": 20
                     },
                     "end": {
-                      "line": 54,
+                      "line": 55,
                       "column": 5
                     }
                   },
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1560,
-                      "end": 1642,
+                      "start": 1554,
+                      "end": 1636,
                       "loc": {
                         "start": {
-                          "line": 53,
+                          "line": 54,
                           "column": 8
                         },
                         "end": {
-                          "line": 53,
+                          "line": 54,
                           "column": 90
                         }
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1567,
-                        "end": 1642,
+                        "start": 1561,
+                        "end": 1636,
                         "loc": {
                           "start": {
-                            "line": 53,
+                            "line": 54,
                             "column": 15
                           },
                           "end": {
-                            "line": 53,
+                            "line": 54,
                             "column": 90
                           }
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1567,
-                          "end": 1580,
+                          "start": 1561,
+                          "end": 1574,
                           "loc": {
                             "start": {
-                              "line": 53,
+                              "line": 54,
                               "column": 15
                             },
                             "end": {
-                              "line": 53,
+                              "line": 54,
                               "column": 28
                             }
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1567,
-                            "end": 1576,
+                            "start": 1561,
+                            "end": 1570,
                             "loc": {
                               "start": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 15
                               },
                               "end": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 24
                               }
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1567,
-                              "end": 1571,
+                              "start": 1561,
+                              "end": 1565,
                               "loc": {
                                 "start": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 15
                                 },
                                 "end": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 19
                                 }
                               }
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1572,
-                              "end": 1576,
+                              "start": 1566,
+                              "end": 1570,
                               "loc": {
                                 "start": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 20
                                 },
                                 "end": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 24
                                 },
                                 "identifierName": "http"
@@ -1525,15 +1525,15 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1577,
-                            "end": 1580,
+                            "start": 1571,
+                            "end": 1574,
                             "loc": {
                               "start": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 25
                               },
                               "end": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 28
                               },
                               "identifierName": "get"
@@ -1545,29 +1545,29 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1581,
-                            "end": 1612,
+                            "start": 1575,
+                            "end": 1606,
                             "loc": {
                               "start": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 29
                               },
                               "end": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 60
                               }
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1581,
-                              "end": 1589,
+                              "start": 1575,
+                              "end": 1583,
                               "loc": {
                                 "start": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 29
                                 },
                                 "end": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 37
                                 },
                                 "identifierName": "ENDPOINT"
@@ -1577,44 +1577,44 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1592,
-                              "end": 1612,
+                              "start": 1586,
+                              "end": 1606,
                               "loc": {
                                 "start": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 40
                                 },
                                 "end": {
-                                  "line": 53,
+                                  "line": 54,
                                   "column": 60
                                 }
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1592,
-                                "end": 1596,
+                                "start": 1586,
+                                "end": 1590,
                                 "loc": {
                                   "start": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 40
                                   },
                                   "end": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 44
                                   }
                                 }
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1597,
-                                "end": 1612,
+                                "start": 1591,
+                                "end": 1606,
                                 "loc": {
                                   "start": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 45
                                   },
                                   "end": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 60
                                   },
                                   "identifierName": "mood_station_id"
@@ -1626,30 +1626,30 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1614,
-                            "end": 1641,
+                            "start": 1608,
+                            "end": 1635,
                             "loc": {
                               "start": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 62
                               },
                               "end": {
-                                "line": 53,
+                                "line": 54,
                                 "column": 89
                               }
                             },
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1615,
-                                "end": 1640,
+                                "start": 1609,
+                                "end": 1634,
                                 "loc": {
                                   "start": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 63
                                   },
                                   "end": {
-                                    "line": 53,
+                                    "line": 54,
                                     "column": 88
                                   }
                                 },
@@ -1658,15 +1658,15 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1615,
-                                  "end": 1624,
+                                  "start": 1609,
+                                  "end": 1618,
                                   "loc": {
                                     "start": {
-                                      "line": 53,
+                                      "line": 54,
                                       "column": 63
                                     },
                                     "end": {
-                                      "line": 53,
+                                      "line": 54,
                                       "column": 72
                                     },
                                     "identifierName": "territory"
@@ -1675,44 +1675,44 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1626,
-                                  "end": 1640,
+                                  "start": 1620,
+                                  "end": 1634,
                                   "loc": {
                                     "start": {
-                                      "line": 53,
+                                      "line": 54,
                                       "column": 74
                                     },
                                     "end": {
-                                      "line": 53,
+                                      "line": 54,
                                       "column": 88
                                     }
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1626,
-                                    "end": 1630,
+                                    "start": 1620,
+                                    "end": 1624,
                                     "loc": {
                                       "start": {
-                                        "line": 53,
+                                        "line": 54,
                                         "column": 74
                                       },
                                       "end": {
-                                        "line": 53,
+                                        "line": 54,
                                         "column": 78
                                       }
                                     }
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1631,
-                                    "end": 1640,
+                                    "start": 1625,
+                                    "end": 1634,
                                     "loc": {
                                       "start": {
-                                        "line": 53,
+                                        "line": 54,
                                         "column": 79
                                       },
                                       "end": {
-                                        "line": 53,
+                                        "line": 54,
                                         "column": 88
                                       },
                                       "identifierName": "territory"
@@ -1733,16 +1733,16 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     ",
-                    "start": 1350,
-                    "end": 1529,
+                    "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+                    "start": 1265,
+                    "end": 1523,
                     "loc": {
                       "start": {
                         "line": 46,
                         "column": 4
                       },
                       "end": {
-                        "line": 51,
+                        "line": 52,
                         "column": 7
                       }
                     }
@@ -1754,9 +1754,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n ",
+              "value": "*\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n ",
               "start": 87,
-              "end": 190,
+              "end": 181,
               "loc": {
                 "start": {
                   "line": 4,
@@ -1774,9 +1774,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n ",
+            "value": "*\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n ",
             "start": 87,
-            "end": 190,
+            "end": 181,
             "loc": {
               "start": {
                 "line": 4,
@@ -1796,9 +1796,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n ",
+      "value": "*\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n ",
       "start": 87,
-      "end": 190,
+      "end": 181,
       "loc": {
         "start": {
           "line": 4,
@@ -1813,8 +1813,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 253,
-      "end": 279,
+      "start": 244,
+      "end": 270,
       "loc": {
         "start": {
           "line": 9,
@@ -1829,8 +1829,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 362,
-      "end": 396,
+      "start": 353,
+      "end": 387,
       "loc": {
         "start": {
           "line": 15,
@@ -1844,9 +1844,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations\n     ",
-      "start": 449,
-      "end": 692,
+      "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations\n     ",
+      "start": 440,
+      "end": 645,
       "loc": {
         "start": {
           "line": 21,
@@ -1860,9 +1860,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id\n     ",
-      "start": 801,
-      "end": 1178,
+      "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+      "start": 754,
+      "end": 1093,
       "loc": {
         "start": {
           "line": 32,
@@ -1876,16 +1876,16 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     ",
-      "start": 1350,
-      "end": 1529,
+      "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+      "start": 1265,
+      "end": 1523,
       "loc": {
         "start": {
           "line": 46,
           "column": 4
         },
         "end": {
-          "line": 51,
+          "line": 52,
           "column": 7
         }
       }
@@ -2210,9 +2210,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n ",
+      "value": "*\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n ",
       "start": 87,
-      "end": 190,
+      "end": 181,
       "loc": {
         "start": {
           "line": 4,
@@ -2239,8 +2239,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 191,
-      "end": 197,
+      "start": 182,
+      "end": 188,
       "loc": {
         "start": {
           "line": 8,
@@ -2267,8 +2267,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 198,
-      "end": 205,
+      "start": 189,
+      "end": 196,
       "loc": {
         "start": {
           "line": 8,
@@ -2295,8 +2295,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 206,
-      "end": 211,
+      "start": 197,
+      "end": 202,
       "loc": {
         "start": {
           "line": 8,
@@ -2321,8 +2321,8 @@
         "binop": null
       },
       "value": "MoodStationFetcher",
-      "start": 212,
-      "end": 230,
+      "start": 203,
+      "end": 221,
       "loc": {
         "start": {
           "line": 8,
@@ -2349,8 +2349,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 231,
-      "end": 238,
+      "start": 222,
+      "end": 229,
       "loc": {
         "start": {
           "line": 8,
@@ -2375,8 +2375,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 239,
-      "end": 246,
+      "start": 230,
+      "end": 237,
       "loc": {
         "start": {
           "line": 8,
@@ -2400,8 +2400,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 247,
-      "end": 248,
+      "start": 238,
+      "end": 239,
       "loc": {
         "start": {
           "line": 8,
@@ -2416,8 +2416,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 253,
-      "end": 279,
+      "start": 244,
+      "end": 270,
       "loc": {
         "start": {
           "line": 9,
@@ -2442,8 +2442,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 284,
-      "end": 295,
+      "start": 275,
+      "end": 286,
       "loc": {
         "start": {
           "line": 12,
@@ -2467,8 +2467,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 295,
-      "end": 296,
+      "start": 286,
+      "end": 287,
       "loc": {
         "start": {
           "line": 12,
@@ -2493,8 +2493,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 296,
-      "end": 300,
+      "start": 287,
+      "end": 291,
       "loc": {
         "start": {
           "line": 12,
@@ -2519,8 +2519,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 300,
-      "end": 301,
+      "start": 291,
+      "end": 292,
       "loc": {
         "start": {
           "line": 12,
@@ -2545,8 +2545,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 302,
-      "end": 311,
+      "start": 293,
+      "end": 302,
       "loc": {
         "start": {
           "line": 12,
@@ -2572,8 +2572,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 312,
-      "end": 313,
+      "start": 303,
+      "end": 304,
       "loc": {
         "start": {
           "line": 12,
@@ -2599,8 +2599,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 314,
-      "end": 318,
+      "start": 305,
+      "end": 309,
       "loc": {
         "start": {
           "line": 12,
@@ -2624,8 +2624,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 318,
-      "end": 319,
+      "start": 309,
+      "end": 310,
       "loc": {
         "start": {
           "line": 12,
@@ -2649,8 +2649,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 320,
-      "end": 321,
+      "start": 311,
+      "end": 312,
       "loc": {
         "start": {
           "line": 12,
@@ -2677,8 +2677,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 330,
-      "end": 335,
+      "start": 321,
+      "end": 326,
       "loc": {
         "start": {
           "line": 13,
@@ -2702,8 +2702,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 335,
-      "end": 336,
+      "start": 326,
+      "end": 327,
       "loc": {
         "start": {
           "line": 13,
@@ -2728,8 +2728,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 336,
-      "end": 340,
+      "start": 327,
+      "end": 331,
       "loc": {
         "start": {
           "line": 13,
@@ -2754,8 +2754,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 340,
-      "end": 341,
+      "start": 331,
+      "end": 332,
       "loc": {
         "start": {
           "line": 13,
@@ -2780,8 +2780,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 342,
-      "end": 351,
+      "start": 333,
+      "end": 342,
       "loc": {
         "start": {
           "line": 13,
@@ -2805,8 +2805,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 351,
-      "end": 352,
+      "start": 342,
+      "end": 343,
       "loc": {
         "start": {
           "line": 13,
@@ -2821,8 +2821,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 362,
-      "end": 396,
+      "start": 353,
+      "end": 387,
       "loc": {
         "start": {
           "line": 15,
@@ -2849,8 +2849,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 405,
-      "end": 409,
+      "start": 396,
+      "end": 400,
       "loc": {
         "start": {
           "line": 18,
@@ -2875,8 +2875,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 409,
-      "end": 410,
+      "start": 400,
+      "end": 401,
       "loc": {
         "start": {
           "line": 18,
@@ -2901,8 +2901,8 @@
         "binop": null
       },
       "value": "mood_station_id",
-      "start": 410,
-      "end": 425,
+      "start": 401,
+      "end": 416,
       "loc": {
         "start": {
           "line": 18,
@@ -2928,8 +2928,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 426,
-      "end": 427,
+      "start": 417,
+      "end": 418,
       "loc": {
         "start": {
           "line": 18,
@@ -2954,8 +2954,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 428,
-      "end": 437,
+      "start": 419,
+      "end": 428,
       "loc": {
         "start": {
           "line": 18,
@@ -2979,8 +2979,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 442,
-      "end": 443,
+      "start": 433,
+      "end": 434,
       "loc": {
         "start": {
           "line": 19,
@@ -2994,9 +2994,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations\n     ",
-      "start": 449,
-      "end": 692,
+      "value": "*\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations\n     ",
+      "start": 440,
+      "end": 645,
       "loc": {
         "start": {
           "line": 21,
@@ -3021,8 +3021,8 @@
         "binop": null
       },
       "value": "fetchAllMoodStations",
-      "start": 697,
-      "end": 717,
+      "start": 650,
+      "end": 670,
       "loc": {
         "start": {
           "line": 28,
@@ -3046,8 +3046,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 717,
-      "end": 718,
+      "start": 670,
+      "end": 671,
       "loc": {
         "start": {
           "line": 28,
@@ -3071,8 +3071,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 718,
-      "end": 719,
+      "start": 671,
+      "end": 672,
       "loc": {
         "start": {
           "line": 28,
@@ -3096,8 +3096,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 720,
-      "end": 721,
+      "start": 673,
+      "end": 674,
       "loc": {
         "start": {
           "line": 28,
@@ -3124,8 +3124,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 730,
-      "end": 736,
+      "start": 683,
+      "end": 689,
       "loc": {
         "start": {
           "line": 29,
@@ -3152,8 +3152,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 737,
-      "end": 741,
+      "start": 690,
+      "end": 694,
       "loc": {
         "start": {
           "line": 29,
@@ -3178,8 +3178,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 741,
-      "end": 742,
+      "start": 694,
+      "end": 695,
       "loc": {
         "start": {
           "line": 29,
@@ -3204,8 +3204,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 742,
-      "end": 746,
+      "start": 695,
+      "end": 699,
       "loc": {
         "start": {
           "line": 29,
@@ -3230,8 +3230,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 746,
-      "end": 747,
+      "start": 699,
+      "end": 700,
       "loc": {
         "start": {
           "line": 29,
@@ -3256,8 +3256,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 747,
-      "end": 750,
+      "start": 700,
+      "end": 703,
       "loc": {
         "start": {
           "line": 29,
@@ -3281,8 +3281,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 750,
-      "end": 751,
+      "start": 703,
+      "end": 704,
       "loc": {
         "start": {
           "line": 29,
@@ -3307,8 +3307,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 751,
-      "end": 759,
+      "start": 704,
+      "end": 712,
       "loc": {
         "start": {
           "line": 29,
@@ -3333,8 +3333,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 759,
-      "end": 760,
+      "start": 712,
+      "end": 713,
       "loc": {
         "start": {
           "line": 29,
@@ -3358,8 +3358,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 761,
-      "end": 762,
+      "start": 714,
+      "end": 715,
       "loc": {
         "start": {
           "line": 29,
@@ -3384,8 +3384,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 762,
-      "end": 771,
+      "start": 715,
+      "end": 724,
       "loc": {
         "start": {
           "line": 29,
@@ -3410,8 +3410,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 771,
-      "end": 772,
+      "start": 724,
+      "end": 725,
       "loc": {
         "start": {
           "line": 29,
@@ -3438,8 +3438,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 773,
-      "end": 777,
+      "start": 726,
+      "end": 730,
       "loc": {
         "start": {
           "line": 29,
@@ -3464,8 +3464,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 777,
-      "end": 778,
+      "start": 730,
+      "end": 731,
       "loc": {
         "start": {
           "line": 29,
@@ -3490,8 +3490,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 778,
-      "end": 787,
+      "start": 731,
+      "end": 740,
       "loc": {
         "start": {
           "line": 29,
@@ -3515,8 +3515,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 787,
-      "end": 788,
+      "start": 740,
+      "end": 741,
       "loc": {
         "start": {
           "line": 29,
@@ -3540,8 +3540,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 788,
-      "end": 789,
+      "start": 741,
+      "end": 742,
       "loc": {
         "start": {
           "line": 29,
@@ -3565,8 +3565,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 794,
-      "end": 795,
+      "start": 747,
+      "end": 748,
       "loc": {
         "start": {
           "line": 30,
@@ -3580,9 +3580,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id\n     ",
-      "start": 801,
-      "end": 1178,
+      "value": "*\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+      "start": 754,
+      "end": 1093,
       "loc": {
         "start": {
           "line": 32,
@@ -3607,8 +3607,8 @@
         "binop": null
       },
       "value": "setMoodStationID",
-      "start": 1183,
-      "end": 1199,
+      "start": 1098,
+      "end": 1114,
       "loc": {
         "start": {
           "line": 40,
@@ -3632,8 +3632,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1199,
-      "end": 1200,
+      "start": 1114,
+      "end": 1115,
       "loc": {
         "start": {
           "line": 40,
@@ -3658,8 +3658,8 @@
         "binop": null
       },
       "value": "mood_station_id",
-      "start": 1200,
-      "end": 1215,
+      "start": 1115,
+      "end": 1130,
       "loc": {
         "start": {
           "line": 40,
@@ -3684,8 +3684,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1215,
-      "end": 1216,
+      "start": 1130,
+      "end": 1131,
       "loc": {
         "start": {
           "line": 40,
@@ -3710,8 +3710,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1217,
-      "end": 1226,
+      "start": 1132,
+      "end": 1141,
       "loc": {
         "start": {
           "line": 40,
@@ -3737,8 +3737,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1227,
-      "end": 1228,
+      "start": 1142,
+      "end": 1143,
       "loc": {
         "start": {
           "line": 40,
@@ -3764,8 +3764,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 1229,
-      "end": 1233,
+      "start": 1144,
+      "end": 1148,
       "loc": {
         "start": {
           "line": 40,
@@ -3789,8 +3789,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1233,
-      "end": 1234,
+      "start": 1148,
+      "end": 1149,
       "loc": {
         "start": {
           "line": 40,
@@ -3814,8 +3814,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1235,
-      "end": 1236,
+      "start": 1150,
+      "end": 1151,
       "loc": {
         "start": {
           "line": 40,
@@ -3842,8 +3842,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1245,
-      "end": 1249,
+      "start": 1160,
+      "end": 1164,
       "loc": {
         "start": {
           "line": 41,
@@ -3868,8 +3868,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1249,
-      "end": 1250,
+      "start": 1164,
+      "end": 1165,
       "loc": {
         "start": {
           "line": 41,
@@ -3894,8 +3894,8 @@
         "binop": null
       },
       "value": "mood_station_id",
-      "start": 1250,
-      "end": 1265,
+      "start": 1165,
+      "end": 1180,
       "loc": {
         "start": {
           "line": 41,
@@ -3921,8 +3921,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1266,
-      "end": 1267,
+      "start": 1181,
+      "end": 1182,
       "loc": {
         "start": {
           "line": 41,
@@ -3947,8 +3947,8 @@
         "binop": null
       },
       "value": "mood_station_id",
-      "start": 1268,
-      "end": 1283,
+      "start": 1183,
+      "end": 1198,
       "loc": {
         "start": {
           "line": 41,
@@ -3975,8 +3975,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1292,
-      "end": 1296,
+      "start": 1207,
+      "end": 1211,
       "loc": {
         "start": {
           "line": 42,
@@ -4001,8 +4001,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1296,
-      "end": 1297,
+      "start": 1211,
+      "end": 1212,
       "loc": {
         "start": {
           "line": 42,
@@ -4027,8 +4027,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1297,
-      "end": 1306,
+      "start": 1212,
+      "end": 1221,
       "loc": {
         "start": {
           "line": 42,
@@ -4054,8 +4054,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1307,
-      "end": 1308,
+      "start": 1222,
+      "end": 1223,
       "loc": {
         "start": {
           "line": 42,
@@ -4080,8 +4080,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1309,
-      "end": 1318,
+      "start": 1224,
+      "end": 1233,
       "loc": {
         "start": {
           "line": 42,
@@ -4108,8 +4108,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1327,
-      "end": 1333,
+      "start": 1242,
+      "end": 1248,
       "loc": {
         "start": {
           "line": 43,
@@ -4136,8 +4136,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1334,
-      "end": 1338,
+      "start": 1249,
+      "end": 1253,
       "loc": {
         "start": {
           "line": 43,
@@ -4161,8 +4161,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1343,
-      "end": 1344,
+      "start": 1258,
+      "end": 1259,
       "loc": {
         "start": {
           "line": 44,
@@ -4176,16 +4176,16 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     ",
-      "start": 1350,
-      "end": 1529,
+      "value": "*\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     ",
+      "start": 1265,
+      "end": 1523,
       "loc": {
         "start": {
           "line": 46,
           "column": 4
         },
         "end": {
-          "line": 51,
+          "line": 52,
           "column": 7
         }
       }
@@ -4203,15 +4203,15 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1534,
-      "end": 1547,
+      "start": 1528,
+      "end": 1541,
       "loc": {
         "start": {
-          "line": 52,
+          "line": 53,
           "column": 4
         },
         "end": {
-          "line": 52,
+          "line": 53,
           "column": 17
         }
       }
@@ -4228,15 +4228,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1547,
-      "end": 1548,
+      "start": 1541,
+      "end": 1542,
       "loc": {
         "start": {
-          "line": 52,
+          "line": 53,
           "column": 17
         },
         "end": {
-          "line": 52,
+          "line": 53,
           "column": 18
         }
       }
@@ -4253,15 +4253,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1548,
-      "end": 1549,
+      "start": 1542,
+      "end": 1543,
       "loc": {
         "start": {
-          "line": 52,
+          "line": 53,
           "column": 18
         },
         "end": {
-          "line": 52,
+          "line": 53,
           "column": 19
         }
       }
@@ -4278,15 +4278,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1550,
-      "end": 1551,
+      "start": 1544,
+      "end": 1545,
       "loc": {
         "start": {
-          "line": 52,
+          "line": 53,
           "column": 20
         },
         "end": {
-          "line": 52,
+          "line": 53,
           "column": 21
         }
       }
@@ -4306,15 +4306,15 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1560,
-      "end": 1566,
+      "start": 1554,
+      "end": 1560,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 8
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 14
         }
       }
@@ -4334,15 +4334,15 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1567,
-      "end": 1571,
+      "start": 1561,
+      "end": 1565,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 15
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 19
         }
       }
@@ -4360,15 +4360,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1571,
-      "end": 1572,
+      "start": 1565,
+      "end": 1566,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 19
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 20
         }
       }
@@ -4386,15 +4386,15 @@
         "binop": null
       },
       "value": "http",
-      "start": 1572,
-      "end": 1576,
+      "start": 1566,
+      "end": 1570,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 20
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 24
         }
       }
@@ -4412,15 +4412,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1576,
-      "end": 1577,
+      "start": 1570,
+      "end": 1571,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 24
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 25
         }
       }
@@ -4438,15 +4438,15 @@
         "binop": null
       },
       "value": "get",
-      "start": 1577,
-      "end": 1580,
+      "start": 1571,
+      "end": 1574,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 25
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 28
         }
       }
@@ -4463,15 +4463,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1580,
-      "end": 1581,
+      "start": 1574,
+      "end": 1575,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 28
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 29
         }
       }
@@ -4489,15 +4489,15 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1581,
-      "end": 1589,
+      "start": 1575,
+      "end": 1583,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 29
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 37
         }
       }
@@ -4516,15 +4516,15 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1590,
-      "end": 1591,
+      "start": 1584,
+      "end": 1585,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 38
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 39
         }
       }
@@ -4544,15 +4544,15 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1592,
-      "end": 1596,
+      "start": 1586,
+      "end": 1590,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 40
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 44
         }
       }
@@ -4570,15 +4570,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1596,
-      "end": 1597,
+      "start": 1590,
+      "end": 1591,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 44
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 45
         }
       }
@@ -4596,15 +4596,15 @@
         "binop": null
       },
       "value": "mood_station_id",
-      "start": 1597,
-      "end": 1612,
+      "start": 1591,
+      "end": 1606,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 45
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 60
         }
       }
@@ -4622,15 +4622,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1612,
-      "end": 1613,
+      "start": 1606,
+      "end": 1607,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 60
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 61
         }
       }
@@ -4647,15 +4647,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1614,
-      "end": 1615,
+      "start": 1608,
+      "end": 1609,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 62
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 63
         }
       }
@@ -4673,15 +4673,15 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1615,
-      "end": 1624,
+      "start": 1609,
+      "end": 1618,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 63
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 72
         }
       }
@@ -4699,15 +4699,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1624,
-      "end": 1625,
+      "start": 1618,
+      "end": 1619,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 72
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 73
         }
       }
@@ -4727,15 +4727,15 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1626,
-      "end": 1630,
+      "start": 1620,
+      "end": 1624,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 74
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 78
         }
       }
@@ -4753,15 +4753,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1630,
-      "end": 1631,
+      "start": 1624,
+      "end": 1625,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 78
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 79
         }
       }
@@ -4779,15 +4779,15 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1631,
-      "end": 1640,
+      "start": 1625,
+      "end": 1634,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 79
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 88
         }
       }
@@ -4804,15 +4804,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1640,
-      "end": 1641,
+      "start": 1634,
+      "end": 1635,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 88
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 89
         }
       }
@@ -4829,15 +4829,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1641,
-      "end": 1642,
+      "start": 1635,
+      "end": 1636,
       "loc": {
         "start": {
-          "line": 53,
+          "line": 54,
           "column": 89
         },
         "end": {
-          "line": 53,
+          "line": 54,
           "column": 90
         }
       }
@@ -4854,15 +4854,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1647,
-      "end": 1648,
+      "start": 1641,
+      "end": 1642,
       "loc": {
         "start": {
-          "line": 54,
+          "line": 55,
           "column": 4
         },
         "end": {
-          "line": 54,
+          "line": 55,
           "column": 5
         }
       }
@@ -4879,15 +4879,15 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1649,
-      "end": 1650,
+      "start": 1643,
+      "end": 1644,
       "loc": {
         "start": {
-          "line": 55,
+          "line": 56,
           "column": 0
         },
         "end": {
-          "line": 55,
+          "line": 56,
           "column": 1
         }
       }
@@ -4905,15 +4905,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1650,
-      "end": 1650,
+      "start": 1644,
+      "end": 1644,
       "loc": {
         "start": {
-          "line": 55,
+          "line": 56,
           "column": 1
         },
         "end": {
-          "line": 55,
+          "line": 56,
           "column": 1
         }
       }

--- a/docs/ast/source/api/NewHitsPlaylistFetcher.js.json
+++ b/docs/ast/source/api/NewHitsPlaylistFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 1865,
+  "end": 1724,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 1865,
+    "end": 1724,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n ",
+            "value": "*\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n ",
             "start": 92,
-            "end": 206,
+            "end": 197,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 207,
-        "end": 1865,
+        "start": 198,
+        "end": 1724,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 222,
-          "end": 1865,
+          "start": 213,
+          "end": 1724,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 228,
-            "end": 250,
+            "start": 219,
+            "end": 241,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 259,
-            "end": 266,
+            "start": 250,
+            "end": 257,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 267,
-            "end": 1865,
+            "start": 258,
+            "end": 1724,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 304,
-                "end": 459,
+                "start": 295,
+                "end": 450,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 304,
-                  "end": 315,
+                  "start": 295,
+                  "end": 306,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 316,
-                    "end": 320,
+                    "start": 307,
+                    "end": 311,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 322,
-                    "end": 338,
+                    "start": 313,
+                    "end": 329,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 322,
-                      "end": 331,
+                      "start": 313,
+                      "end": 322,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 334,
-                      "end": 338,
+                      "start": 325,
+                      "end": 329,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 340,
-                  "end": 459,
+                  "start": 331,
+                  "end": 450,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 350,
-                      "end": 372,
+                      "start": 341,
+                      "end": 363,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 350,
-                        "end": 372,
+                        "start": 341,
+                        "end": 363,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 350,
-                          "end": 355,
+                          "start": 341,
+                          "end": 346,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 356,
-                            "end": 360,
+                            "start": 347,
+                            "end": 351,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 362,
-                            "end": 371,
+                            "start": 353,
+                            "end": 362,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 382,
-                          "end": 416,
+                          "start": 373,
+                          "end": 407,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 425,
-                      "end": 453,
+                      "start": 416,
+                      "end": 444,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 425,
-                        "end": 453,
+                        "start": 416,
+                        "end": 444,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 425,
-                          "end": 441,
+                          "start": 416,
+                          "end": 432,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 425,
-                            "end": 429,
+                            "start": 416,
+                            "end": 420,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 430,
-                            "end": 441,
+                            "start": 421,
+                            "end": 432,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 444,
-                          "end": 453,
+                          "start": 435,
+                          "end": 444,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 382,
-                          "end": 416,
+                          "start": 373,
+                          "end": 407,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 273,
-                    "end": 299,
+                    "start": 264,
+                    "end": 290,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists\n     ",
-                    "start": 465,
-                    "end": 856,
+                    "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists\n     ",
+                    "start": 456,
+                    "end": 803,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 861,
-                "end": 1022,
+                "start": 808,
+                "end": 969,
                 "loc": {
                   "start": {
                     "line": 30,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 861,
-                  "end": 885,
+                  "start": 808,
+                  "end": 832,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 886,
-                    "end": 903,
+                    "start": 833,
+                    "end": 850,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -720,8 +720,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 886,
-                      "end": 891,
+                      "start": 833,
+                      "end": 838,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -737,8 +737,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 894,
-                      "end": 903,
+                      "start": 841,
+                      "end": 850,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -755,8 +755,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 905,
-                    "end": 923,
+                    "start": 852,
+                    "end": 870,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -769,8 +769,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 905,
-                      "end": 911,
+                      "start": 852,
+                      "end": 858,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -786,8 +786,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 914,
-                      "end": 923,
+                      "start": 861,
+                      "end": 870,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -805,8 +805,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 925,
-                  "end": 1022,
+                  "start": 872,
+                  "end": 969,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -820,8 +820,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 935,
-                      "end": 1016,
+                      "start": 882,
+                      "end": 963,
                       "loc": {
                         "start": {
                           "line": 31,
@@ -834,8 +834,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 942,
-                        "end": 1016,
+                        "start": 889,
+                        "end": 963,
                         "loc": {
                           "start": {
                             "line": 31,
@@ -848,8 +848,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 942,
-                          "end": 955,
+                          "start": 889,
+                          "end": 902,
                           "loc": {
                             "start": {
                               "line": 31,
@@ -862,8 +862,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 942,
-                            "end": 951,
+                            "start": 889,
+                            "end": 898,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -876,8 +876,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 942,
-                              "end": 946,
+                              "start": 889,
+                              "end": 893,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -891,8 +891,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 947,
-                              "end": 951,
+                              "start": 894,
+                              "end": 898,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -910,8 +910,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 952,
-                            "end": 955,
+                            "start": 899,
+                            "end": 902,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -930,8 +930,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 956,
-                            "end": 964,
+                            "start": 903,
+                            "end": 911,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -947,8 +947,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 966,
-                            "end": 1015,
+                            "start": 913,
+                            "end": 962,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -962,8 +962,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 980,
-                                "end": 1005,
+                                "start": 927,
+                                "end": 952,
                                 "loc": {
                                   "start": {
                                     "line": 32,
@@ -979,8 +979,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 980,
-                                  "end": 989,
+                                  "start": 927,
+                                  "end": 936,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -996,8 +996,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 991,
-                                  "end": 1005,
+                                  "start": 938,
+                                  "end": 952,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -1010,8 +1010,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 991,
-                                    "end": 995,
+                                    "start": 938,
+                                    "end": 942,
                                     "loc": {
                                       "start": {
                                         "line": 32,
@@ -1025,8 +1025,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 996,
-                                    "end": 1005,
+                                    "start": 943,
+                                    "end": 952,
                                     "loc": {
                                       "start": {
                                         "line": 32,
@@ -1055,9 +1055,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists\n     ",
-                    "start": 465,
-                    "end": 856,
+                    "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists\n     ",
+                    "start": 456,
+                    "end": 803,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -1073,9 +1073,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-                    "start": 1028,
-                    "end": 1311,
+                    "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+                    "start": 975,
+                    "end": 1214,
                     "loc": {
                       "start": {
                         "line": 36,
@@ -1091,8 +1091,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1316,
-                "end": 1417,
+                "start": 1219,
+                "end": 1320,
                 "loc": {
                   "start": {
                     "line": 43,
@@ -1106,8 +1106,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1316,
-                  "end": 1329,
+                  "start": 1219,
+                  "end": 1232,
                   "loc": {
                     "start": {
                       "line": 43,
@@ -1131,8 +1131,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1330,
-                    "end": 1341,
+                    "start": 1233,
+                    "end": 1244,
                     "loc": {
                       "start": {
                         "line": 43,
@@ -1149,8 +1149,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1343,
-                  "end": 1417,
+                  "start": 1246,
+                  "end": 1320,
                   "loc": {
                     "start": {
                       "line": 43,
@@ -1164,8 +1164,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1353,
-                      "end": 1383,
+                      "start": 1256,
+                      "end": 1286,
                       "loc": {
                         "start": {
                           "line": 44,
@@ -1178,8 +1178,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1353,
-                        "end": 1383,
+                        "start": 1256,
+                        "end": 1286,
                         "loc": {
                           "start": {
                             "line": 44,
@@ -1193,8 +1193,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1353,
-                          "end": 1369,
+                          "start": 1256,
+                          "end": 1272,
                           "loc": {
                             "start": {
                               "line": 44,
@@ -1207,8 +1207,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1353,
-                            "end": 1357,
+                            "start": 1256,
+                            "end": 1260,
                             "loc": {
                               "start": {
                                 "line": 44,
@@ -1222,8 +1222,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1358,
-                            "end": 1369,
+                            "start": 1261,
+                            "end": 1272,
                             "loc": {
                               "start": {
                                 "line": 44,
@@ -1241,8 +1241,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1372,
-                          "end": 1383,
+                          "start": 1275,
+                          "end": 1286,
                           "loc": {
                             "start": {
                               "line": 44,
@@ -1260,8 +1260,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1400,
-                      "end": 1411,
+                      "start": 1303,
+                      "end": 1314,
                       "loc": {
                         "start": {
                           "line": 45,
@@ -1274,8 +1274,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1407,
-                        "end": 1411,
+                        "start": 1310,
+                        "end": 1314,
                         "loc": {
                           "start": {
                             "line": 45,
@@ -1295,9 +1295,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-                    "start": 1028,
-                    "end": 1311,
+                    "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+                    "start": 975,
+                    "end": 1214,
                     "loc": {
                       "start": {
                         "line": 36,
@@ -1313,9 +1313,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-                    "start": 1423,
-                    "end": 1748,
+                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+                    "start": 1326,
+                    "end": 1607,
                     "loc": {
                       "start": {
                         "line": 48,
@@ -1331,8 +1331,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1753,
-                "end": 1863,
+                "start": 1612,
+                "end": 1722,
                 "loc": {
                   "start": {
                     "line": 55,
@@ -1346,8 +1346,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1753,
-                  "end": 1766,
+                  "start": 1612,
+                  "end": 1625,
                   "loc": {
                     "start": {
                       "line": 55,
@@ -1371,8 +1371,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1769,
-                  "end": 1863,
+                  "start": 1628,
+                  "end": 1722,
                   "loc": {
                     "start": {
                       "line": 55,
@@ -1386,8 +1386,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1779,
-                      "end": 1857,
+                      "start": 1638,
+                      "end": 1716,
                       "loc": {
                         "start": {
                           "line": 56,
@@ -1400,8 +1400,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1786,
-                        "end": 1857,
+                        "start": 1645,
+                        "end": 1716,
                         "loc": {
                           "start": {
                             "line": 56,
@@ -1414,8 +1414,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1786,
-                          "end": 1799,
+                          "start": 1645,
+                          "end": 1658,
                           "loc": {
                             "start": {
                               "line": 56,
@@ -1428,8 +1428,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1786,
-                            "end": 1795,
+                            "start": 1645,
+                            "end": 1654,
                             "loc": {
                               "start": {
                                 "line": 56,
@@ -1442,8 +1442,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1786,
-                              "end": 1790,
+                              "start": 1645,
+                              "end": 1649,
                               "loc": {
                                 "start": {
                                   "line": 56,
@@ -1457,8 +1457,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1791,
-                              "end": 1795,
+                              "start": 1650,
+                              "end": 1654,
                               "loc": {
                                 "start": {
                                   "line": 56,
@@ -1476,8 +1476,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1796,
-                            "end": 1799,
+                            "start": 1655,
+                            "end": 1658,
                             "loc": {
                               "start": {
                                 "line": 56,
@@ -1496,8 +1496,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1800,
-                            "end": 1827,
+                            "start": 1659,
+                            "end": 1686,
                             "loc": {
                               "start": {
                                 "line": 56,
@@ -1510,8 +1510,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1800,
-                              "end": 1808,
+                              "start": 1659,
+                              "end": 1667,
                               "loc": {
                                 "start": {
                                   "line": 56,
@@ -1528,8 +1528,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1811,
-                              "end": 1827,
+                              "start": 1670,
+                              "end": 1686,
                               "loc": {
                                 "start": {
                                   "line": 56,
@@ -1542,8 +1542,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1811,
-                                "end": 1815,
+                                "start": 1670,
+                                "end": 1674,
                                 "loc": {
                                   "start": {
                                     "line": 56,
@@ -1557,8 +1557,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1816,
-                                "end": 1827,
+                                "start": 1675,
+                                "end": 1686,
                                 "loc": {
                                   "start": {
                                     "line": 56,
@@ -1577,8 +1577,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1829,
-                            "end": 1856,
+                            "start": 1688,
+                            "end": 1715,
                             "loc": {
                               "start": {
                                 "line": 56,
@@ -1592,8 +1592,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1830,
-                                "end": 1855,
+                                "start": 1689,
+                                "end": 1714,
                                 "loc": {
                                   "start": {
                                     "line": 56,
@@ -1609,8 +1609,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1830,
-                                  "end": 1839,
+                                  "start": 1689,
+                                  "end": 1698,
                                   "loc": {
                                     "start": {
                                       "line": 56,
@@ -1626,8 +1626,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1841,
-                                  "end": 1855,
+                                  "start": 1700,
+                                  "end": 1714,
                                   "loc": {
                                     "start": {
                                       "line": 56,
@@ -1640,8 +1640,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1841,
-                                    "end": 1845,
+                                    "start": 1700,
+                                    "end": 1704,
                                     "loc": {
                                       "start": {
                                         "line": 56,
@@ -1655,8 +1655,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1846,
-                                    "end": 1855,
+                                    "start": 1705,
+                                    "end": 1714,
                                     "loc": {
                                       "start": {
                                         "line": 56,
@@ -1684,9 +1684,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-                    "start": 1423,
-                    "end": 1748,
+                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+                    "start": 1326,
+                    "end": 1607,
                     "loc": {
                       "start": {
                         "line": 48,
@@ -1705,9 +1705,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n ",
+              "value": "*\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n ",
               "start": 92,
-              "end": 206,
+              "end": 197,
               "loc": {
                 "start": {
                   "line": 4,
@@ -1725,9 +1725,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n ",
+            "value": "*\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n ",
             "start": 92,
-            "end": 206,
+            "end": 197,
             "loc": {
               "start": {
                 "line": 4,
@@ -1747,9 +1747,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n ",
+      "value": "*\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n ",
       "start": 92,
-      "end": 206,
+      "end": 197,
       "loc": {
         "start": {
           "line": 4,
@@ -1764,8 +1764,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 273,
-      "end": 299,
+      "start": 264,
+      "end": 290,
       "loc": {
         "start": {
           "line": 9,
@@ -1780,8 +1780,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 382,
-      "end": 416,
+      "start": 373,
+      "end": 407,
       "loc": {
         "start": {
           "line": 15,
@@ -1795,9 +1795,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists\n     ",
-      "start": 465,
-      "end": 856,
+      "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists\n     ",
+      "start": 456,
+      "end": 803,
       "loc": {
         "start": {
           "line": 21,
@@ -1811,9 +1811,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-      "start": 1028,
-      "end": 1311,
+      "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+      "start": 975,
+      "end": 1214,
       "loc": {
         "start": {
           "line": 36,
@@ -1827,9 +1827,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-      "start": 1423,
-      "end": 1748,
+      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+      "start": 1326,
+      "end": 1607,
       "loc": {
         "start": {
           "line": 48,
@@ -2161,9 +2161,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n ",
+      "value": "*\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n ",
       "start": 92,
-      "end": 206,
+      "end": 197,
       "loc": {
         "start": {
           "line": 4,
@@ -2190,8 +2190,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 207,
-      "end": 213,
+      "start": 198,
+      "end": 204,
       "loc": {
         "start": {
           "line": 8,
@@ -2218,8 +2218,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 214,
-      "end": 221,
+      "start": 205,
+      "end": 212,
       "loc": {
         "start": {
           "line": 8,
@@ -2246,8 +2246,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 222,
-      "end": 227,
+      "start": 213,
+      "end": 218,
       "loc": {
         "start": {
           "line": 8,
@@ -2272,8 +2272,8 @@
         "binop": null
       },
       "value": "NewHitsPlaylistFetcher",
-      "start": 228,
-      "end": 250,
+      "start": 219,
+      "end": 241,
       "loc": {
         "start": {
           "line": 8,
@@ -2300,8 +2300,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 251,
-      "end": 258,
+      "start": 242,
+      "end": 249,
       "loc": {
         "start": {
           "line": 8,
@@ -2326,8 +2326,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 259,
-      "end": 266,
+      "start": 250,
+      "end": 257,
       "loc": {
         "start": {
           "line": 8,
@@ -2351,8 +2351,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 267,
-      "end": 268,
+      "start": 258,
+      "end": 259,
       "loc": {
         "start": {
           "line": 8,
@@ -2367,8 +2367,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 273,
-      "end": 299,
+      "start": 264,
+      "end": 290,
       "loc": {
         "start": {
           "line": 9,
@@ -2393,8 +2393,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 304,
-      "end": 315,
+      "start": 295,
+      "end": 306,
       "loc": {
         "start": {
           "line": 12,
@@ -2418,8 +2418,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 315,
-      "end": 316,
+      "start": 306,
+      "end": 307,
       "loc": {
         "start": {
           "line": 12,
@@ -2444,8 +2444,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 316,
-      "end": 320,
+      "start": 307,
+      "end": 311,
       "loc": {
         "start": {
           "line": 12,
@@ -2470,8 +2470,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 320,
-      "end": 321,
+      "start": 311,
+      "end": 312,
       "loc": {
         "start": {
           "line": 12,
@@ -2496,8 +2496,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 322,
-      "end": 331,
+      "start": 313,
+      "end": 322,
       "loc": {
         "start": {
           "line": 12,
@@ -2523,8 +2523,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 332,
-      "end": 333,
+      "start": 323,
+      "end": 324,
       "loc": {
         "start": {
           "line": 12,
@@ -2550,8 +2550,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 334,
-      "end": 338,
+      "start": 325,
+      "end": 329,
       "loc": {
         "start": {
           "line": 12,
@@ -2575,8 +2575,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 338,
-      "end": 339,
+      "start": 329,
+      "end": 330,
       "loc": {
         "start": {
           "line": 12,
@@ -2600,8 +2600,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 340,
-      "end": 341,
+      "start": 331,
+      "end": 332,
       "loc": {
         "start": {
           "line": 12,
@@ -2628,8 +2628,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 350,
-      "end": 355,
+      "start": 341,
+      "end": 346,
       "loc": {
         "start": {
           "line": 13,
@@ -2653,8 +2653,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 355,
-      "end": 356,
+      "start": 346,
+      "end": 347,
       "loc": {
         "start": {
           "line": 13,
@@ -2679,8 +2679,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 356,
-      "end": 360,
+      "start": 347,
+      "end": 351,
       "loc": {
         "start": {
           "line": 13,
@@ -2705,8 +2705,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 360,
-      "end": 361,
+      "start": 351,
+      "end": 352,
       "loc": {
         "start": {
           "line": 13,
@@ -2731,8 +2731,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 362,
-      "end": 371,
+      "start": 353,
+      "end": 362,
       "loc": {
         "start": {
           "line": 13,
@@ -2756,8 +2756,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 371,
-      "end": 372,
+      "start": 362,
+      "end": 363,
       "loc": {
         "start": {
           "line": 13,
@@ -2772,8 +2772,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 382,
-      "end": 416,
+      "start": 373,
+      "end": 407,
       "loc": {
         "start": {
           "line": 15,
@@ -2800,8 +2800,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 425,
-      "end": 429,
+      "start": 416,
+      "end": 420,
       "loc": {
         "start": {
           "line": 18,
@@ -2826,8 +2826,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 429,
-      "end": 430,
+      "start": 420,
+      "end": 421,
       "loc": {
         "start": {
           "line": 18,
@@ -2852,8 +2852,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 430,
-      "end": 441,
+      "start": 421,
+      "end": 432,
       "loc": {
         "start": {
           "line": 18,
@@ -2879,8 +2879,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 442,
-      "end": 443,
+      "start": 433,
+      "end": 434,
       "loc": {
         "start": {
           "line": 18,
@@ -2905,8 +2905,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 444,
-      "end": 453,
+      "start": 435,
+      "end": 444,
       "loc": {
         "start": {
           "line": 18,
@@ -2930,8 +2930,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 458,
-      "end": 459,
+      "start": 449,
+      "end": 450,
       "loc": {
         "start": {
           "line": 19,
@@ -2945,9 +2945,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists\n     ",
-      "start": 465,
-      "end": 856,
+      "value": "*\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists\n     ",
+      "start": 456,
+      "end": 803,
       "loc": {
         "start": {
           "line": 21,
@@ -2972,8 +2972,8 @@
         "binop": null
       },
       "value": "fetchAllNewHitsPlaylists",
-      "start": 861,
-      "end": 885,
+      "start": 808,
+      "end": 832,
       "loc": {
         "start": {
           "line": 30,
@@ -2997,8 +2997,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 885,
-      "end": 886,
+      "start": 832,
+      "end": 833,
       "loc": {
         "start": {
           "line": 30,
@@ -3023,8 +3023,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 886,
-      "end": 891,
+      "start": 833,
+      "end": 838,
       "loc": {
         "start": {
           "line": 30,
@@ -3050,8 +3050,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 892,
-      "end": 893,
+      "start": 839,
+      "end": 840,
       "loc": {
         "start": {
           "line": 30,
@@ -3076,8 +3076,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 894,
-      "end": 903,
+      "start": 841,
+      "end": 850,
       "loc": {
         "start": {
           "line": 30,
@@ -3102,8 +3102,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 903,
-      "end": 904,
+      "start": 850,
+      "end": 851,
       "loc": {
         "start": {
           "line": 30,
@@ -3128,8 +3128,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 905,
-      "end": 911,
+      "start": 852,
+      "end": 858,
       "loc": {
         "start": {
           "line": 30,
@@ -3155,8 +3155,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 912,
-      "end": 913,
+      "start": 859,
+      "end": 860,
       "loc": {
         "start": {
           "line": 30,
@@ -3181,8 +3181,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 914,
-      "end": 923,
+      "start": 861,
+      "end": 870,
       "loc": {
         "start": {
           "line": 30,
@@ -3206,8 +3206,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 923,
-      "end": 924,
+      "start": 870,
+      "end": 871,
       "loc": {
         "start": {
           "line": 30,
@@ -3231,8 +3231,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 925,
-      "end": 926,
+      "start": 872,
+      "end": 873,
       "loc": {
         "start": {
           "line": 30,
@@ -3259,8 +3259,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 935,
-      "end": 941,
+      "start": 882,
+      "end": 888,
       "loc": {
         "start": {
           "line": 31,
@@ -3287,8 +3287,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 942,
-      "end": 946,
+      "start": 889,
+      "end": 893,
       "loc": {
         "start": {
           "line": 31,
@@ -3313,8 +3313,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 946,
-      "end": 947,
+      "start": 893,
+      "end": 894,
       "loc": {
         "start": {
           "line": 31,
@@ -3339,8 +3339,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 947,
-      "end": 951,
+      "start": 894,
+      "end": 898,
       "loc": {
         "start": {
           "line": 31,
@@ -3365,8 +3365,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 951,
-      "end": 952,
+      "start": 898,
+      "end": 899,
       "loc": {
         "start": {
           "line": 31,
@@ -3391,8 +3391,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 952,
-      "end": 955,
+      "start": 899,
+      "end": 902,
       "loc": {
         "start": {
           "line": 31,
@@ -3416,8 +3416,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 955,
-      "end": 956,
+      "start": 902,
+      "end": 903,
       "loc": {
         "start": {
           "line": 31,
@@ -3442,8 +3442,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 956,
-      "end": 964,
+      "start": 903,
+      "end": 911,
       "loc": {
         "start": {
           "line": 31,
@@ -3468,8 +3468,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 964,
-      "end": 965,
+      "start": 911,
+      "end": 912,
       "loc": {
         "start": {
           "line": 31,
@@ -3493,8 +3493,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 966,
-      "end": 967,
+      "start": 913,
+      "end": 914,
       "loc": {
         "start": {
           "line": 31,
@@ -3519,8 +3519,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 980,
-      "end": 989,
+      "start": 927,
+      "end": 936,
       "loc": {
         "start": {
           "line": 32,
@@ -3545,8 +3545,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 989,
-      "end": 990,
+      "start": 936,
+      "end": 937,
       "loc": {
         "start": {
           "line": 32,
@@ -3573,8 +3573,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 991,
-      "end": 995,
+      "start": 938,
+      "end": 942,
       "loc": {
         "start": {
           "line": 32,
@@ -3599,8 +3599,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 995,
-      "end": 996,
+      "start": 942,
+      "end": 943,
       "loc": {
         "start": {
           "line": 32,
@@ -3625,8 +3625,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 996,
-      "end": 1005,
+      "start": 943,
+      "end": 952,
       "loc": {
         "start": {
           "line": 32,
@@ -3650,8 +3650,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1014,
-      "end": 1015,
+      "start": 961,
+      "end": 962,
       "loc": {
         "start": {
           "line": 33,
@@ -3675,8 +3675,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1015,
-      "end": 1016,
+      "start": 962,
+      "end": 963,
       "loc": {
         "start": {
           "line": 33,
@@ -3700,8 +3700,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1021,
-      "end": 1022,
+      "start": 968,
+      "end": 969,
       "loc": {
         "start": {
           "line": 34,
@@ -3715,9 +3715,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-      "start": 1028,
-      "end": 1311,
+      "value": "*\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+      "start": 975,
+      "end": 1214,
       "loc": {
         "start": {
           "line": 36,
@@ -3742,8 +3742,8 @@
         "binop": null
       },
       "value": "setPlaylistID",
-      "start": 1316,
-      "end": 1329,
+      "start": 1219,
+      "end": 1232,
       "loc": {
         "start": {
           "line": 43,
@@ -3767,8 +3767,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1329,
-      "end": 1330,
+      "start": 1232,
+      "end": 1233,
       "loc": {
         "start": {
           "line": 43,
@@ -3793,8 +3793,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1330,
-      "end": 1341,
+      "start": 1233,
+      "end": 1244,
       "loc": {
         "start": {
           "line": 43,
@@ -3818,8 +3818,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1341,
-      "end": 1342,
+      "start": 1244,
+      "end": 1245,
       "loc": {
         "start": {
           "line": 43,
@@ -3843,8 +3843,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1343,
-      "end": 1344,
+      "start": 1246,
+      "end": 1247,
       "loc": {
         "start": {
           "line": 43,
@@ -3871,8 +3871,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1353,
-      "end": 1357,
+      "start": 1256,
+      "end": 1260,
       "loc": {
         "start": {
           "line": 44,
@@ -3897,8 +3897,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1357,
-      "end": 1358,
+      "start": 1260,
+      "end": 1261,
       "loc": {
         "start": {
           "line": 44,
@@ -3923,8 +3923,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1358,
-      "end": 1369,
+      "start": 1261,
+      "end": 1272,
       "loc": {
         "start": {
           "line": 44,
@@ -3950,8 +3950,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1370,
-      "end": 1371,
+      "start": 1273,
+      "end": 1274,
       "loc": {
         "start": {
           "line": 44,
@@ -3976,8 +3976,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1372,
-      "end": 1383,
+      "start": 1275,
+      "end": 1286,
       "loc": {
         "start": {
           "line": 44,
@@ -4004,8 +4004,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1400,
-      "end": 1406,
+      "start": 1303,
+      "end": 1309,
       "loc": {
         "start": {
           "line": 45,
@@ -4032,8 +4032,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1407,
-      "end": 1411,
+      "start": 1310,
+      "end": 1314,
       "loc": {
         "start": {
           "line": 45,
@@ -4057,8 +4057,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1416,
-      "end": 1417,
+      "start": 1319,
+      "end": 1320,
       "loc": {
         "start": {
           "line": 46,
@@ -4072,9 +4072,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     ",
-      "start": 1423,
-      "end": 1748,
+      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     ",
+      "start": 1326,
+      "end": 1607,
       "loc": {
         "start": {
           "line": 48,
@@ -4099,8 +4099,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1753,
-      "end": 1766,
+      "start": 1612,
+      "end": 1625,
       "loc": {
         "start": {
           "line": 55,
@@ -4124,8 +4124,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1766,
-      "end": 1767,
+      "start": 1625,
+      "end": 1626,
       "loc": {
         "start": {
           "line": 55,
@@ -4149,8 +4149,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1767,
-      "end": 1768,
+      "start": 1626,
+      "end": 1627,
       "loc": {
         "start": {
           "line": 55,
@@ -4174,8 +4174,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1769,
-      "end": 1770,
+      "start": 1628,
+      "end": 1629,
       "loc": {
         "start": {
           "line": 55,
@@ -4202,8 +4202,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1779,
-      "end": 1785,
+      "start": 1638,
+      "end": 1644,
       "loc": {
         "start": {
           "line": 56,
@@ -4230,8 +4230,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1786,
-      "end": 1790,
+      "start": 1645,
+      "end": 1649,
       "loc": {
         "start": {
           "line": 56,
@@ -4256,8 +4256,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1790,
-      "end": 1791,
+      "start": 1649,
+      "end": 1650,
       "loc": {
         "start": {
           "line": 56,
@@ -4282,8 +4282,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1791,
-      "end": 1795,
+      "start": 1650,
+      "end": 1654,
       "loc": {
         "start": {
           "line": 56,
@@ -4308,8 +4308,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1795,
-      "end": 1796,
+      "start": 1654,
+      "end": 1655,
       "loc": {
         "start": {
           "line": 56,
@@ -4334,8 +4334,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1796,
-      "end": 1799,
+      "start": 1655,
+      "end": 1658,
       "loc": {
         "start": {
           "line": 56,
@@ -4359,8 +4359,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1799,
-      "end": 1800,
+      "start": 1658,
+      "end": 1659,
       "loc": {
         "start": {
           "line": 56,
@@ -4385,8 +4385,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1800,
-      "end": 1808,
+      "start": 1659,
+      "end": 1667,
       "loc": {
         "start": {
           "line": 56,
@@ -4412,8 +4412,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1809,
-      "end": 1810,
+      "start": 1668,
+      "end": 1669,
       "loc": {
         "start": {
           "line": 56,
@@ -4440,8 +4440,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1811,
-      "end": 1815,
+      "start": 1670,
+      "end": 1674,
       "loc": {
         "start": {
           "line": 56,
@@ -4466,8 +4466,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1815,
-      "end": 1816,
+      "start": 1674,
+      "end": 1675,
       "loc": {
         "start": {
           "line": 56,
@@ -4492,8 +4492,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1816,
-      "end": 1827,
+      "start": 1675,
+      "end": 1686,
       "loc": {
         "start": {
           "line": 56,
@@ -4518,8 +4518,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1827,
-      "end": 1828,
+      "start": 1686,
+      "end": 1687,
       "loc": {
         "start": {
           "line": 56,
@@ -4543,8 +4543,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1829,
-      "end": 1830,
+      "start": 1688,
+      "end": 1689,
       "loc": {
         "start": {
           "line": 56,
@@ -4569,8 +4569,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1830,
-      "end": 1839,
+      "start": 1689,
+      "end": 1698,
       "loc": {
         "start": {
           "line": 56,
@@ -4595,8 +4595,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1839,
-      "end": 1840,
+      "start": 1698,
+      "end": 1699,
       "loc": {
         "start": {
           "line": 56,
@@ -4623,8 +4623,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1841,
-      "end": 1845,
+      "start": 1700,
+      "end": 1704,
       "loc": {
         "start": {
           "line": 56,
@@ -4649,8 +4649,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1845,
-      "end": 1846,
+      "start": 1704,
+      "end": 1705,
       "loc": {
         "start": {
           "line": 56,
@@ -4675,8 +4675,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1846,
-      "end": 1855,
+      "start": 1705,
+      "end": 1714,
       "loc": {
         "start": {
           "line": 56,
@@ -4700,8 +4700,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1855,
-      "end": 1856,
+      "start": 1714,
+      "end": 1715,
       "loc": {
         "start": {
           "line": 56,
@@ -4725,8 +4725,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1856,
-      "end": 1857,
+      "start": 1715,
+      "end": 1716,
       "loc": {
         "start": {
           "line": 56,
@@ -4750,8 +4750,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1862,
-      "end": 1863,
+      "start": 1721,
+      "end": 1722,
       "loc": {
         "start": {
           "line": 57,
@@ -4775,8 +4775,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1864,
-      "end": 1865,
+      "start": 1723,
+      "end": 1724,
       "loc": {
         "start": {
           "line": 58,
@@ -4801,8 +4801,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1865,
-      "end": 1865,
+      "start": 1724,
+      "end": 1724,
       "loc": {
         "start": {
           "line": 58,

--- a/docs/ast/source/api/NewReleaseCategoryFetcher.js.json
+++ b/docs/ast/source/api/NewReleaseCategoryFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2749,
+  "end": 2548,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2749,
+    "end": 2548,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n ",
+            "value": "*\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n ",
             "start": 96,
-            "end": 228,
+            "end": 219,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 229,
-        "end": 2749,
+        "start": 220,
+        "end": 2548,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 244,
-          "end": 2749,
+          "start": 235,
+          "end": 2548,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 250,
-            "end": 275,
+            "start": 241,
+            "end": 266,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 284,
-            "end": 291,
+            "start": 275,
+            "end": 282,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 292,
-            "end": 2749,
+            "start": 283,
+            "end": 2548,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 329,
-                "end": 484,
+                "start": 320,
+                "end": 475,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 329,
-                  "end": 340,
+                  "start": 320,
+                  "end": 331,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 341,
-                    "end": 345,
+                    "start": 332,
+                    "end": 336,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 347,
-                    "end": 363,
+                    "start": 338,
+                    "end": 354,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 347,
-                      "end": 356,
+                      "start": 338,
+                      "end": 347,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 359,
-                      "end": 363,
+                      "start": 350,
+                      "end": 354,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 365,
-                  "end": 484,
+                  "start": 356,
+                  "end": 475,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 375,
-                      "end": 397,
+                      "start": 366,
+                      "end": 388,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 375,
-                        "end": 397,
+                        "start": 366,
+                        "end": 388,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 375,
-                          "end": 380,
+                          "start": 366,
+                          "end": 371,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 381,
-                            "end": 385,
+                            "start": 372,
+                            "end": 376,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 387,
-                            "end": 396,
+                            "start": 378,
+                            "end": 387,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 407,
-                          "end": 441,
+                          "start": 398,
+                          "end": 432,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 450,
-                      "end": 478,
+                      "start": 441,
+                      "end": 469,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 450,
-                        "end": 478,
+                        "start": 441,
+                        "end": 469,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 450,
-                          "end": 466,
+                          "start": 441,
+                          "end": 457,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 450,
-                            "end": 454,
+                            "start": 441,
+                            "end": 445,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 455,
-                            "end": 466,
+                            "start": 446,
+                            "end": 457,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 469,
-                          "end": 478,
+                          "start": 460,
+                          "end": 469,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 407,
-                          "end": 441,
+                          "start": 398,
+                          "end": 432,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 298,
-                    "end": 324,
+                    "start": 289,
+                    "end": 315,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories\n     ",
-                    "start": 490,
-                    "end": 900,
+                    "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories\n     ",
+                    "start": 481,
+                    "end": 843,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 905,
-                "end": 1124,
+                "start": 848,
+                "end": 1067,
                 "loc": {
                   "start": {
                     "line": 30,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 905,
-                  "end": 933,
+                  "start": 848,
+                  "end": 876,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 934,
-                    "end": 951,
+                    "start": 877,
+                    "end": 894,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -720,8 +720,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 934,
-                      "end": 939,
+                      "start": 877,
+                      "end": 882,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -737,8 +737,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 942,
-                      "end": 951,
+                      "start": 885,
+                      "end": 894,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -755,8 +755,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 953,
-                    "end": 971,
+                    "start": 896,
+                    "end": 914,
                     "loc": {
                       "start": {
                         "line": 30,
@@ -769,8 +769,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 953,
-                      "end": 959,
+                      "start": 896,
+                      "end": 902,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -786,8 +786,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 962,
-                      "end": 971,
+                      "start": 905,
+                      "end": 914,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -805,8 +805,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 973,
-                  "end": 1124,
+                  "start": 916,
+                  "end": 1067,
                   "loc": {
                     "start": {
                       "line": 30,
@@ -820,8 +820,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 983,
-                      "end": 1118,
+                      "start": 926,
+                      "end": 1061,
                       "loc": {
                         "start": {
                           "line": 31,
@@ -834,8 +834,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 990,
-                        "end": 1118,
+                        "start": 933,
+                        "end": 1061,
                         "loc": {
                           "start": {
                             "line": 31,
@@ -848,8 +848,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 990,
-                          "end": 1003,
+                          "start": 933,
+                          "end": 946,
                           "loc": {
                             "start": {
                               "line": 31,
@@ -862,8 +862,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 990,
-                            "end": 999,
+                            "start": 933,
+                            "end": 942,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -876,8 +876,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 990,
-                              "end": 994,
+                              "start": 933,
+                              "end": 937,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -891,8 +891,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 995,
-                              "end": 999,
+                              "start": 938,
+                              "end": 942,
                               "loc": {
                                 "start": {
                                   "line": 31,
@@ -910,8 +910,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1000,
-                            "end": 1003,
+                            "start": 943,
+                            "end": 946,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -930,8 +930,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 1004,
-                            "end": 1012,
+                            "start": 947,
+                            "end": 955,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -947,8 +947,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1014,
-                            "end": 1117,
+                            "start": 957,
+                            "end": 1060,
                             "loc": {
                               "start": {
                                 "line": 31,
@@ -962,8 +962,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1028,
-                                "end": 1040,
+                                "start": 971,
+                                "end": 983,
                                 "loc": {
                                   "start": {
                                     "line": 32,
@@ -979,8 +979,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1028,
-                                  "end": 1033,
+                                  "start": 971,
+                                  "end": 976,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -996,8 +996,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1035,
-                                  "end": 1040,
+                                  "start": 978,
+                                  "end": 983,
                                   "loc": {
                                     "start": {
                                       "line": 32,
@@ -1014,8 +1014,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1054,
-                                "end": 1068,
+                                "start": 997,
+                                "end": 1011,
                                 "loc": {
                                   "start": {
                                     "line": 33,
@@ -1031,8 +1031,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1054,
-                                  "end": 1060,
+                                  "start": 997,
+                                  "end": 1003,
                                   "loc": {
                                     "start": {
                                       "line": 33,
@@ -1048,8 +1048,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 1062,
-                                  "end": 1068,
+                                  "start": 1005,
+                                  "end": 1011,
                                   "loc": {
                                     "start": {
                                       "line": 33,
@@ -1066,8 +1066,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 1082,
-                                "end": 1107,
+                                "start": 1025,
+                                "end": 1050,
                                 "loc": {
                                   "start": {
                                     "line": 34,
@@ -1083,8 +1083,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1082,
-                                  "end": 1091,
+                                  "start": 1025,
+                                  "end": 1034,
                                   "loc": {
                                     "start": {
                                       "line": 34,
@@ -1100,8 +1100,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1093,
-                                  "end": 1107,
+                                  "start": 1036,
+                                  "end": 1050,
                                   "loc": {
                                     "start": {
                                       "line": 34,
@@ -1114,8 +1114,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1093,
-                                    "end": 1097,
+                                    "start": 1036,
+                                    "end": 1040,
                                     "loc": {
                                       "start": {
                                         "line": 34,
@@ -1129,8 +1129,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1098,
-                                    "end": 1107,
+                                    "start": 1041,
+                                    "end": 1050,
                                     "loc": {
                                       "start": {
                                         "line": 34,
@@ -1159,9 +1159,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories\n     ",
-                    "start": 490,
-                    "end": 900,
+                    "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories\n     ",
+                    "start": 481,
+                    "end": 843,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -1177,9 +1177,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-                    "start": 1130,
-                    "end": 1427,
+                    "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+                    "start": 1073,
+                    "end": 1322,
                     "loc": {
                       "start": {
                         "line": 38,
@@ -1195,8 +1195,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1432,
-                "end": 1533,
+                "start": 1327,
+                "end": 1428,
                 "loc": {
                   "start": {
                     "line": 45,
@@ -1210,8 +1210,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1432,
-                  "end": 1445,
+                  "start": 1327,
+                  "end": 1340,
                   "loc": {
                     "start": {
                       "line": 45,
@@ -1235,8 +1235,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1446,
-                    "end": 1457,
+                    "start": 1341,
+                    "end": 1352,
                     "loc": {
                       "start": {
                         "line": 45,
@@ -1253,8 +1253,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1459,
-                  "end": 1533,
+                  "start": 1354,
+                  "end": 1428,
                   "loc": {
                     "start": {
                       "line": 45,
@@ -1268,8 +1268,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1469,
-                      "end": 1499,
+                      "start": 1364,
+                      "end": 1394,
                       "loc": {
                         "start": {
                           "line": 46,
@@ -1282,8 +1282,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1469,
-                        "end": 1499,
+                        "start": 1364,
+                        "end": 1394,
                         "loc": {
                           "start": {
                             "line": 46,
@@ -1297,8 +1297,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1469,
-                          "end": 1485,
+                          "start": 1364,
+                          "end": 1380,
                           "loc": {
                             "start": {
                               "line": 46,
@@ -1311,8 +1311,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1469,
-                            "end": 1473,
+                            "start": 1364,
+                            "end": 1368,
                             "loc": {
                               "start": {
                                 "line": 46,
@@ -1326,8 +1326,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1474,
-                            "end": 1485,
+                            "start": 1369,
+                            "end": 1380,
                             "loc": {
                               "start": {
                                 "line": 46,
@@ -1345,8 +1345,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1488,
-                          "end": 1499,
+                          "start": 1383,
+                          "end": 1394,
                           "loc": {
                             "start": {
                               "line": 46,
@@ -1364,8 +1364,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1516,
-                      "end": 1527,
+                      "start": 1411,
+                      "end": 1422,
                       "loc": {
                         "start": {
                           "line": 47,
@@ -1378,8 +1378,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1523,
-                        "end": 1527,
+                        "start": 1418,
+                        "end": 1422,
                         "loc": {
                           "start": {
                             "line": 47,
@@ -1399,9 +1399,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-                    "start": 1130,
-                    "end": 1427,
+                    "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+                    "start": 1073,
+                    "end": 1322,
                     "loc": {
                       "start": {
                         "line": 38,
@@ -1417,9 +1417,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-                    "start": 1539,
-                    "end": 1875,
+                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+                    "start": 1434,
+                    "end": 1722,
                     "loc": {
                       "start": {
                         "line": 50,
@@ -1435,8 +1435,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1880,
-                "end": 1990,
+                "start": 1727,
+                "end": 1837,
                 "loc": {
                   "start": {
                     "line": 57,
@@ -1450,8 +1450,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1880,
-                  "end": 1893,
+                  "start": 1727,
+                  "end": 1740,
                   "loc": {
                     "start": {
                       "line": 57,
@@ -1475,8 +1475,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1896,
-                  "end": 1990,
+                  "start": 1743,
+                  "end": 1837,
                   "loc": {
                     "start": {
                       "line": 57,
@@ -1490,8 +1490,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1906,
-                      "end": 1984,
+                      "start": 1753,
+                      "end": 1831,
                       "loc": {
                         "start": {
                           "line": 58,
@@ -1504,8 +1504,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1913,
-                        "end": 1984,
+                        "start": 1760,
+                        "end": 1831,
                         "loc": {
                           "start": {
                             "line": 58,
@@ -1518,8 +1518,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1913,
-                          "end": 1926,
+                          "start": 1760,
+                          "end": 1773,
                           "loc": {
                             "start": {
                               "line": 58,
@@ -1532,8 +1532,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1913,
-                            "end": 1922,
+                            "start": 1760,
+                            "end": 1769,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1546,8 +1546,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1913,
-                              "end": 1917,
+                              "start": 1760,
+                              "end": 1764,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1561,8 +1561,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1918,
-                              "end": 1922,
+                              "start": 1765,
+                              "end": 1769,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1580,8 +1580,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1923,
-                            "end": 1926,
+                            "start": 1770,
+                            "end": 1773,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1600,8 +1600,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1927,
-                            "end": 1954,
+                            "start": 1774,
+                            "end": 1801,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1614,8 +1614,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1927,
-                              "end": 1935,
+                              "start": 1774,
+                              "end": 1782,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1632,8 +1632,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1938,
-                              "end": 1954,
+                              "start": 1785,
+                              "end": 1801,
                               "loc": {
                                 "start": {
                                   "line": 58,
@@ -1646,8 +1646,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1938,
-                                "end": 1942,
+                                "start": 1785,
+                                "end": 1789,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1661,8 +1661,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1943,
-                                "end": 1954,
+                                "start": 1790,
+                                "end": 1801,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1681,8 +1681,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1956,
-                            "end": 1983,
+                            "start": 1803,
+                            "end": 1830,
                             "loc": {
                               "start": {
                                 "line": 58,
@@ -1696,8 +1696,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1957,
-                                "end": 1982,
+                                "start": 1804,
+                                "end": 1829,
                                 "loc": {
                                   "start": {
                                     "line": 58,
@@ -1713,8 +1713,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1957,
-                                  "end": 1966,
+                                  "start": 1804,
+                                  "end": 1813,
                                   "loc": {
                                     "start": {
                                       "line": 58,
@@ -1730,8 +1730,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1968,
-                                  "end": 1982,
+                                  "start": 1815,
+                                  "end": 1829,
                                   "loc": {
                                     "start": {
                                       "line": 58,
@@ -1744,8 +1744,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1968,
-                                    "end": 1972,
+                                    "start": 1815,
+                                    "end": 1819,
                                     "loc": {
                                       "start": {
                                         "line": 58,
@@ -1759,8 +1759,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1973,
-                                    "end": 1982,
+                                    "start": 1820,
+                                    "end": 1829,
                                     "loc": {
                                       "start": {
                                         "line": 58,
@@ -1789,9 +1789,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-                    "start": 1539,
-                    "end": 1875,
+                    "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+                    "start": 1434,
+                    "end": 1722,
                     "loc": {
                       "start": {
                         "line": 50,
@@ -1807,9 +1807,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums\n     ",
-                    "start": 1996,
-                    "end": 2509,
+                    "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums\n     ",
+                    "start": 1843,
+                    "end": 2308,
                     "loc": {
                       "start": {
                         "line": 61,
@@ -1825,8 +1825,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 2514,
-                "end": 2747,
+                "start": 2313,
+                "end": 2546,
                 "loc": {
                   "start": {
                     "line": 70,
@@ -1840,8 +1840,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 2514,
-                  "end": 2525,
+                  "start": 2313,
+                  "end": 2324,
                   "loc": {
                     "start": {
                       "line": 70,
@@ -1865,8 +1865,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 2526,
-                    "end": 2543,
+                    "start": 2325,
+                    "end": 2342,
                     "loc": {
                       "start": {
                         "line": 70,
@@ -1879,8 +1879,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2526,
-                      "end": 2531,
+                      "start": 2325,
+                      "end": 2330,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -1896,8 +1896,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2534,
-                      "end": 2543,
+                      "start": 2333,
+                      "end": 2342,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -1914,8 +1914,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 2545,
-                    "end": 2563,
+                    "start": 2344,
+                    "end": 2362,
                     "loc": {
                       "start": {
                         "line": 70,
@@ -1928,8 +1928,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2545,
-                      "end": 2551,
+                      "start": 2344,
+                      "end": 2350,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -1945,8 +1945,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2554,
-                      "end": 2563,
+                      "start": 2353,
+                      "end": 2362,
                       "loc": {
                         "start": {
                           "line": 70,
@@ -1964,8 +1964,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 2565,
-                  "end": 2747,
+                  "start": 2364,
+                  "end": 2546,
                   "loc": {
                     "start": {
                       "line": 70,
@@ -1979,8 +1979,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 2575,
-                      "end": 2741,
+                      "start": 2374,
+                      "end": 2540,
                       "loc": {
                         "start": {
                           "line": 71,
@@ -1993,8 +1993,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 2582,
-                        "end": 2741,
+                        "start": 2381,
+                        "end": 2540,
                         "loc": {
                           "start": {
                             "line": 71,
@@ -2007,8 +2007,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 2582,
-                          "end": 2595,
+                          "start": 2381,
+                          "end": 2394,
                           "loc": {
                             "start": {
                               "line": 71,
@@ -2021,8 +2021,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 2582,
-                            "end": 2591,
+                            "start": 2381,
+                            "end": 2390,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2035,8 +2035,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 2582,
-                              "end": 2586,
+                              "start": 2381,
+                              "end": 2385,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2050,8 +2050,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 2587,
-                              "end": 2591,
+                              "start": 2386,
+                              "end": 2390,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2069,8 +2069,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 2592,
-                            "end": 2595,
+                            "start": 2391,
+                            "end": 2394,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2089,8 +2089,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 2596,
-                            "end": 2635,
+                            "start": 2395,
+                            "end": 2434,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2103,8 +2103,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 2596,
-                              "end": 2623,
+                              "start": 2395,
+                              "end": 2422,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2117,8 +2117,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 2596,
-                                "end": 2604,
+                                "start": 2395,
+                                "end": 2403,
                                 "loc": {
                                   "start": {
                                     "line": 71,
@@ -2135,8 +2135,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 2607,
-                                "end": 2623,
+                                "start": 2406,
+                                "end": 2422,
                                 "loc": {
                                   "start": {
                                     "line": 71,
@@ -2149,8 +2149,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 2607,
-                                  "end": 2611,
+                                  "start": 2406,
+                                  "end": 2410,
                                   "loc": {
                                     "start": {
                                       "line": 71,
@@ -2164,8 +2164,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2612,
-                                  "end": 2623,
+                                  "start": 2411,
+                                  "end": 2422,
                                   "loc": {
                                     "start": {
                                       "line": 71,
@@ -2185,8 +2185,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 2626,
-                              "end": 2635,
+                              "start": 2425,
+                              "end": 2434,
                               "loc": {
                                 "start": {
                                   "line": 71,
@@ -2206,8 +2206,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 2637,
-                            "end": 2740,
+                            "start": 2436,
+                            "end": 2539,
                             "loc": {
                               "start": {
                                 "line": 71,
@@ -2221,8 +2221,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 2651,
-                                "end": 2676,
+                                "start": 2450,
+                                "end": 2475,
                                 "loc": {
                                   "start": {
                                     "line": 72,
@@ -2238,8 +2238,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2651,
-                                  "end": 2660,
+                                  "start": 2450,
+                                  "end": 2459,
                                   "loc": {
                                     "start": {
                                       "line": 72,
@@ -2255,8 +2255,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 2662,
-                                  "end": 2676,
+                                  "start": 2461,
+                                  "end": 2475,
                                   "loc": {
                                     "start": {
                                       "line": 72,
@@ -2269,8 +2269,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 2662,
-                                    "end": 2666,
+                                    "start": 2461,
+                                    "end": 2465,
                                     "loc": {
                                       "start": {
                                         "line": 72,
@@ -2284,8 +2284,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2667,
-                                    "end": 2676,
+                                    "start": 2466,
+                                    "end": 2475,
                                     "loc": {
                                       "start": {
                                         "line": 72,
@@ -2304,8 +2304,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2690,
-                                "end": 2702,
+                                "start": 2489,
+                                "end": 2501,
                                 "loc": {
                                   "start": {
                                     "line": 73,
@@ -2321,8 +2321,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2690,
-                                  "end": 2695,
+                                  "start": 2489,
+                                  "end": 2494,
                                   "loc": {
                                     "start": {
                                       "line": 73,
@@ -2338,8 +2338,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2697,
-                                  "end": 2702,
+                                  "start": 2496,
+                                  "end": 2501,
                                   "loc": {
                                     "start": {
                                       "line": 73,
@@ -2356,8 +2356,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2716,
-                                "end": 2730,
+                                "start": 2515,
+                                "end": 2529,
                                 "loc": {
                                   "start": {
                                     "line": 74,
@@ -2373,8 +2373,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2716,
-                                  "end": 2722,
+                                  "start": 2515,
+                                  "end": 2521,
                                   "loc": {
                                     "start": {
                                       "line": 74,
@@ -2390,8 +2390,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2724,
-                                  "end": 2730,
+                                  "start": 2523,
+                                  "end": 2529,
                                   "loc": {
                                     "start": {
                                       "line": 74,
@@ -2417,9 +2417,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums\n     ",
-                    "start": 1996,
-                    "end": 2509,
+                    "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums\n     ",
+                    "start": 1843,
+                    "end": 2308,
                     "loc": {
                       "start": {
                         "line": 61,
@@ -2438,9 +2438,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n ",
+              "value": "*\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n ",
               "start": 96,
-              "end": 228,
+              "end": 219,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2458,9 +2458,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n ",
+            "value": "*\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n ",
             "start": 96,
-            "end": 228,
+            "end": 219,
             "loc": {
               "start": {
                 "line": 4,
@@ -2480,9 +2480,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n ",
+      "value": "*\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n ",
       "start": 96,
-      "end": 228,
+      "end": 219,
       "loc": {
         "start": {
           "line": 4,
@@ -2497,8 +2497,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 298,
-      "end": 324,
+      "start": 289,
+      "end": 315,
       "loc": {
         "start": {
           "line": 9,
@@ -2513,8 +2513,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 407,
-      "end": 441,
+      "start": 398,
+      "end": 432,
       "loc": {
         "start": {
           "line": 15,
@@ -2528,9 +2528,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories\n     ",
-      "start": 490,
-      "end": 900,
+      "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories\n     ",
+      "start": 481,
+      "end": 843,
       "loc": {
         "start": {
           "line": 21,
@@ -2544,9 +2544,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-      "start": 1130,
-      "end": 1427,
+      "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+      "start": 1073,
+      "end": 1322,
       "loc": {
         "start": {
           "line": 38,
@@ -2560,9 +2560,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-      "start": 1539,
-      "end": 1875,
+      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+      "start": 1434,
+      "end": 1722,
       "loc": {
         "start": {
           "line": 50,
@@ -2576,9 +2576,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums\n     ",
-      "start": 1996,
-      "end": 2509,
+      "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums\n     ",
+      "start": 1843,
+      "end": 2308,
       "loc": {
         "start": {
           "line": 61,
@@ -2910,9 +2910,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n ",
+      "value": "*\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n ",
       "start": 96,
-      "end": 228,
+      "end": 219,
       "loc": {
         "start": {
           "line": 4,
@@ -2939,8 +2939,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 229,
-      "end": 235,
+      "start": 220,
+      "end": 226,
       "loc": {
         "start": {
           "line": 8,
@@ -2967,8 +2967,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 236,
-      "end": 243,
+      "start": 227,
+      "end": 234,
       "loc": {
         "start": {
           "line": 8,
@@ -2995,8 +2995,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 244,
-      "end": 249,
+      "start": 235,
+      "end": 240,
       "loc": {
         "start": {
           "line": 8,
@@ -3021,8 +3021,8 @@
         "binop": null
       },
       "value": "NewReleaseCategoryFetcher",
-      "start": 250,
-      "end": 275,
+      "start": 241,
+      "end": 266,
       "loc": {
         "start": {
           "line": 8,
@@ -3049,8 +3049,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 276,
-      "end": 283,
+      "start": 267,
+      "end": 274,
       "loc": {
         "start": {
           "line": 8,
@@ -3075,8 +3075,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 284,
-      "end": 291,
+      "start": 275,
+      "end": 282,
       "loc": {
         "start": {
           "line": 8,
@@ -3100,8 +3100,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 292,
-      "end": 293,
+      "start": 283,
+      "end": 284,
       "loc": {
         "start": {
           "line": 8,
@@ -3116,8 +3116,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 298,
-      "end": 324,
+      "start": 289,
+      "end": 315,
       "loc": {
         "start": {
           "line": 9,
@@ -3142,8 +3142,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 329,
-      "end": 340,
+      "start": 320,
+      "end": 331,
       "loc": {
         "start": {
           "line": 12,
@@ -3167,8 +3167,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 340,
-      "end": 341,
+      "start": 331,
+      "end": 332,
       "loc": {
         "start": {
           "line": 12,
@@ -3193,8 +3193,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 341,
-      "end": 345,
+      "start": 332,
+      "end": 336,
       "loc": {
         "start": {
           "line": 12,
@@ -3219,8 +3219,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 345,
-      "end": 346,
+      "start": 336,
+      "end": 337,
       "loc": {
         "start": {
           "line": 12,
@@ -3245,8 +3245,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 347,
-      "end": 356,
+      "start": 338,
+      "end": 347,
       "loc": {
         "start": {
           "line": 12,
@@ -3272,8 +3272,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 357,
-      "end": 358,
+      "start": 348,
+      "end": 349,
       "loc": {
         "start": {
           "line": 12,
@@ -3299,8 +3299,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 359,
-      "end": 363,
+      "start": 350,
+      "end": 354,
       "loc": {
         "start": {
           "line": 12,
@@ -3324,8 +3324,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 363,
-      "end": 364,
+      "start": 354,
+      "end": 355,
       "loc": {
         "start": {
           "line": 12,
@@ -3349,8 +3349,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 365,
-      "end": 366,
+      "start": 356,
+      "end": 357,
       "loc": {
         "start": {
           "line": 12,
@@ -3377,8 +3377,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 375,
-      "end": 380,
+      "start": 366,
+      "end": 371,
       "loc": {
         "start": {
           "line": 13,
@@ -3402,8 +3402,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 380,
-      "end": 381,
+      "start": 371,
+      "end": 372,
       "loc": {
         "start": {
           "line": 13,
@@ -3428,8 +3428,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 381,
-      "end": 385,
+      "start": 372,
+      "end": 376,
       "loc": {
         "start": {
           "line": 13,
@@ -3454,8 +3454,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 385,
-      "end": 386,
+      "start": 376,
+      "end": 377,
       "loc": {
         "start": {
           "line": 13,
@@ -3480,8 +3480,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 387,
-      "end": 396,
+      "start": 378,
+      "end": 387,
       "loc": {
         "start": {
           "line": 13,
@@ -3505,8 +3505,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 396,
-      "end": 397,
+      "start": 387,
+      "end": 388,
       "loc": {
         "start": {
           "line": 13,
@@ -3521,8 +3521,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 407,
-      "end": 441,
+      "start": 398,
+      "end": 432,
       "loc": {
         "start": {
           "line": 15,
@@ -3549,8 +3549,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 450,
-      "end": 454,
+      "start": 441,
+      "end": 445,
       "loc": {
         "start": {
           "line": 18,
@@ -3575,8 +3575,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 454,
-      "end": 455,
+      "start": 445,
+      "end": 446,
       "loc": {
         "start": {
           "line": 18,
@@ -3601,8 +3601,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 455,
-      "end": 466,
+      "start": 446,
+      "end": 457,
       "loc": {
         "start": {
           "line": 18,
@@ -3628,8 +3628,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 467,
-      "end": 468,
+      "start": 458,
+      "end": 459,
       "loc": {
         "start": {
           "line": 18,
@@ -3654,8 +3654,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 469,
-      "end": 478,
+      "start": 460,
+      "end": 469,
       "loc": {
         "start": {
           "line": 18,
@@ -3679,8 +3679,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 483,
-      "end": 484,
+      "start": 474,
+      "end": 475,
       "loc": {
         "start": {
           "line": 19,
@@ -3694,9 +3694,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories\n     ",
-      "start": 490,
-      "end": 900,
+      "value": "*\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories\n     ",
+      "start": 481,
+      "end": 843,
       "loc": {
         "start": {
           "line": 21,
@@ -3721,8 +3721,8 @@
         "binop": null
       },
       "value": "fetchAllNewReleaseCategories",
-      "start": 905,
-      "end": 933,
+      "start": 848,
+      "end": 876,
       "loc": {
         "start": {
           "line": 30,
@@ -3746,8 +3746,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 933,
-      "end": 934,
+      "start": 876,
+      "end": 877,
       "loc": {
         "start": {
           "line": 30,
@@ -3772,8 +3772,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 934,
-      "end": 939,
+      "start": 877,
+      "end": 882,
       "loc": {
         "start": {
           "line": 30,
@@ -3799,8 +3799,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 940,
-      "end": 941,
+      "start": 883,
+      "end": 884,
       "loc": {
         "start": {
           "line": 30,
@@ -3825,8 +3825,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 942,
-      "end": 951,
+      "start": 885,
+      "end": 894,
       "loc": {
         "start": {
           "line": 30,
@@ -3851,8 +3851,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 951,
-      "end": 952,
+      "start": 894,
+      "end": 895,
       "loc": {
         "start": {
           "line": 30,
@@ -3877,8 +3877,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 953,
-      "end": 959,
+      "start": 896,
+      "end": 902,
       "loc": {
         "start": {
           "line": 30,
@@ -3904,8 +3904,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 960,
-      "end": 961,
+      "start": 903,
+      "end": 904,
       "loc": {
         "start": {
           "line": 30,
@@ -3930,8 +3930,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 962,
-      "end": 971,
+      "start": 905,
+      "end": 914,
       "loc": {
         "start": {
           "line": 30,
@@ -3955,8 +3955,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 971,
-      "end": 972,
+      "start": 914,
+      "end": 915,
       "loc": {
         "start": {
           "line": 30,
@@ -3980,8 +3980,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 973,
-      "end": 974,
+      "start": 916,
+      "end": 917,
       "loc": {
         "start": {
           "line": 30,
@@ -4008,8 +4008,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 983,
-      "end": 989,
+      "start": 926,
+      "end": 932,
       "loc": {
         "start": {
           "line": 31,
@@ -4036,8 +4036,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 990,
-      "end": 994,
+      "start": 933,
+      "end": 937,
       "loc": {
         "start": {
           "line": 31,
@@ -4062,8 +4062,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 994,
-      "end": 995,
+      "start": 937,
+      "end": 938,
       "loc": {
         "start": {
           "line": 31,
@@ -4088,8 +4088,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 995,
-      "end": 999,
+      "start": 938,
+      "end": 942,
       "loc": {
         "start": {
           "line": 31,
@@ -4114,8 +4114,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 999,
-      "end": 1000,
+      "start": 942,
+      "end": 943,
       "loc": {
         "start": {
           "line": 31,
@@ -4140,8 +4140,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1000,
-      "end": 1003,
+      "start": 943,
+      "end": 946,
       "loc": {
         "start": {
           "line": 31,
@@ -4165,8 +4165,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1003,
-      "end": 1004,
+      "start": 946,
+      "end": 947,
       "loc": {
         "start": {
           "line": 31,
@@ -4191,8 +4191,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1004,
-      "end": 1012,
+      "start": 947,
+      "end": 955,
       "loc": {
         "start": {
           "line": 31,
@@ -4217,8 +4217,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1012,
-      "end": 1013,
+      "start": 955,
+      "end": 956,
       "loc": {
         "start": {
           "line": 31,
@@ -4242,8 +4242,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1014,
-      "end": 1015,
+      "start": 957,
+      "end": 958,
       "loc": {
         "start": {
           "line": 31,
@@ -4268,8 +4268,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1028,
-      "end": 1033,
+      "start": 971,
+      "end": 976,
       "loc": {
         "start": {
           "line": 32,
@@ -4294,8 +4294,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1033,
-      "end": 1034,
+      "start": 976,
+      "end": 977,
       "loc": {
         "start": {
           "line": 32,
@@ -4320,8 +4320,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 1035,
-      "end": 1040,
+      "start": 978,
+      "end": 983,
       "loc": {
         "start": {
           "line": 32,
@@ -4346,8 +4346,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1040,
-      "end": 1041,
+      "start": 983,
+      "end": 984,
       "loc": {
         "start": {
           "line": 32,
@@ -4372,8 +4372,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1054,
-      "end": 1060,
+      "start": 997,
+      "end": 1003,
       "loc": {
         "start": {
           "line": 33,
@@ -4398,8 +4398,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1060,
-      "end": 1061,
+      "start": 1003,
+      "end": 1004,
       "loc": {
         "start": {
           "line": 33,
@@ -4424,8 +4424,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 1062,
-      "end": 1068,
+      "start": 1005,
+      "end": 1011,
       "loc": {
         "start": {
           "line": 33,
@@ -4450,8 +4450,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1068,
-      "end": 1069,
+      "start": 1011,
+      "end": 1012,
       "loc": {
         "start": {
           "line": 33,
@@ -4476,8 +4476,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1082,
-      "end": 1091,
+      "start": 1025,
+      "end": 1034,
       "loc": {
         "start": {
           "line": 34,
@@ -4502,8 +4502,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1091,
-      "end": 1092,
+      "start": 1034,
+      "end": 1035,
       "loc": {
         "start": {
           "line": 34,
@@ -4530,8 +4530,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1093,
-      "end": 1097,
+      "start": 1036,
+      "end": 1040,
       "loc": {
         "start": {
           "line": 34,
@@ -4556,8 +4556,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1097,
-      "end": 1098,
+      "start": 1040,
+      "end": 1041,
       "loc": {
         "start": {
           "line": 34,
@@ -4582,8 +4582,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1098,
-      "end": 1107,
+      "start": 1041,
+      "end": 1050,
       "loc": {
         "start": {
           "line": 34,
@@ -4607,8 +4607,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1116,
-      "end": 1117,
+      "start": 1059,
+      "end": 1060,
       "loc": {
         "start": {
           "line": 35,
@@ -4632,8 +4632,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1117,
-      "end": 1118,
+      "start": 1060,
+      "end": 1061,
       "loc": {
         "start": {
           "line": 35,
@@ -4657,8 +4657,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1123,
-      "end": 1124,
+      "start": 1066,
+      "end": 1067,
       "loc": {
         "start": {
           "line": 36,
@@ -4672,9 +4672,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-      "start": 1130,
-      "end": 1427,
+      "value": "*\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+      "start": 1073,
+      "end": 1322,
       "loc": {
         "start": {
           "line": 38,
@@ -4699,8 +4699,8 @@
         "binop": null
       },
       "value": "setCategoryID",
-      "start": 1432,
-      "end": 1445,
+      "start": 1327,
+      "end": 1340,
       "loc": {
         "start": {
           "line": 45,
@@ -4724,8 +4724,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1445,
-      "end": 1446,
+      "start": 1340,
+      "end": 1341,
       "loc": {
         "start": {
           "line": 45,
@@ -4750,8 +4750,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1446,
-      "end": 1457,
+      "start": 1341,
+      "end": 1352,
       "loc": {
         "start": {
           "line": 45,
@@ -4775,8 +4775,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1457,
-      "end": 1458,
+      "start": 1352,
+      "end": 1353,
       "loc": {
         "start": {
           "line": 45,
@@ -4800,8 +4800,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1459,
-      "end": 1460,
+      "start": 1354,
+      "end": 1355,
       "loc": {
         "start": {
           "line": 45,
@@ -4828,8 +4828,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1469,
-      "end": 1473,
+      "start": 1364,
+      "end": 1368,
       "loc": {
         "start": {
           "line": 46,
@@ -4854,8 +4854,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1473,
-      "end": 1474,
+      "start": 1368,
+      "end": 1369,
       "loc": {
         "start": {
           "line": 46,
@@ -4880,8 +4880,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1474,
-      "end": 1485,
+      "start": 1369,
+      "end": 1380,
       "loc": {
         "start": {
           "line": 46,
@@ -4907,8 +4907,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1486,
-      "end": 1487,
+      "start": 1381,
+      "end": 1382,
       "loc": {
         "start": {
           "line": 46,
@@ -4933,8 +4933,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1488,
-      "end": 1499,
+      "start": 1383,
+      "end": 1394,
       "loc": {
         "start": {
           "line": 46,
@@ -4961,8 +4961,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1516,
-      "end": 1522,
+      "start": 1411,
+      "end": 1417,
       "loc": {
         "start": {
           "line": 47,
@@ -4989,8 +4989,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1523,
-      "end": 1527,
+      "start": 1418,
+      "end": 1422,
       "loc": {
         "start": {
           "line": 47,
@@ -5014,8 +5014,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1532,
-      "end": 1533,
+      "start": 1427,
+      "end": 1428,
       "loc": {
         "start": {
           "line": 48,
@@ -5029,9 +5029,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     ",
-      "start": 1539,
-      "end": 1875,
+      "value": "*\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     ",
+      "start": 1434,
+      "end": 1722,
       "loc": {
         "start": {
           "line": 50,
@@ -5056,8 +5056,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1880,
-      "end": 1893,
+      "start": 1727,
+      "end": 1740,
       "loc": {
         "start": {
           "line": 57,
@@ -5081,8 +5081,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1893,
-      "end": 1894,
+      "start": 1740,
+      "end": 1741,
       "loc": {
         "start": {
           "line": 57,
@@ -5106,8 +5106,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1894,
-      "end": 1895,
+      "start": 1741,
+      "end": 1742,
       "loc": {
         "start": {
           "line": 57,
@@ -5131,8 +5131,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1896,
-      "end": 1897,
+      "start": 1743,
+      "end": 1744,
       "loc": {
         "start": {
           "line": 57,
@@ -5159,8 +5159,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1906,
-      "end": 1912,
+      "start": 1753,
+      "end": 1759,
       "loc": {
         "start": {
           "line": 58,
@@ -5187,8 +5187,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1913,
-      "end": 1917,
+      "start": 1760,
+      "end": 1764,
       "loc": {
         "start": {
           "line": 58,
@@ -5213,8 +5213,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1917,
-      "end": 1918,
+      "start": 1764,
+      "end": 1765,
       "loc": {
         "start": {
           "line": 58,
@@ -5239,8 +5239,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1918,
-      "end": 1922,
+      "start": 1765,
+      "end": 1769,
       "loc": {
         "start": {
           "line": 58,
@@ -5265,8 +5265,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1922,
-      "end": 1923,
+      "start": 1769,
+      "end": 1770,
       "loc": {
         "start": {
           "line": 58,
@@ -5291,8 +5291,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1923,
-      "end": 1926,
+      "start": 1770,
+      "end": 1773,
       "loc": {
         "start": {
           "line": 58,
@@ -5316,8 +5316,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1926,
-      "end": 1927,
+      "start": 1773,
+      "end": 1774,
       "loc": {
         "start": {
           "line": 58,
@@ -5342,8 +5342,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1927,
-      "end": 1935,
+      "start": 1774,
+      "end": 1782,
       "loc": {
         "start": {
           "line": 58,
@@ -5369,8 +5369,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1936,
-      "end": 1937,
+      "start": 1783,
+      "end": 1784,
       "loc": {
         "start": {
           "line": 58,
@@ -5397,8 +5397,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1938,
-      "end": 1942,
+      "start": 1785,
+      "end": 1789,
       "loc": {
         "start": {
           "line": 58,
@@ -5423,8 +5423,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1942,
-      "end": 1943,
+      "start": 1789,
+      "end": 1790,
       "loc": {
         "start": {
           "line": 58,
@@ -5449,8 +5449,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 1943,
-      "end": 1954,
+      "start": 1790,
+      "end": 1801,
       "loc": {
         "start": {
           "line": 58,
@@ -5475,8 +5475,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1954,
-      "end": 1955,
+      "start": 1801,
+      "end": 1802,
       "loc": {
         "start": {
           "line": 58,
@@ -5500,8 +5500,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1956,
-      "end": 1957,
+      "start": 1803,
+      "end": 1804,
       "loc": {
         "start": {
           "line": 58,
@@ -5526,8 +5526,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1957,
-      "end": 1966,
+      "start": 1804,
+      "end": 1813,
       "loc": {
         "start": {
           "line": 58,
@@ -5552,8 +5552,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1966,
-      "end": 1967,
+      "start": 1813,
+      "end": 1814,
       "loc": {
         "start": {
           "line": 58,
@@ -5580,8 +5580,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1968,
-      "end": 1972,
+      "start": 1815,
+      "end": 1819,
       "loc": {
         "start": {
           "line": 58,
@@ -5606,8 +5606,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1972,
-      "end": 1973,
+      "start": 1819,
+      "end": 1820,
       "loc": {
         "start": {
           "line": 58,
@@ -5632,8 +5632,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1973,
-      "end": 1982,
+      "start": 1820,
+      "end": 1829,
       "loc": {
         "start": {
           "line": 58,
@@ -5657,8 +5657,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1982,
-      "end": 1983,
+      "start": 1829,
+      "end": 1830,
       "loc": {
         "start": {
           "line": 58,
@@ -5682,8 +5682,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1983,
-      "end": 1984,
+      "start": 1830,
+      "end": 1831,
       "loc": {
         "start": {
           "line": 58,
@@ -5707,8 +5707,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1989,
-      "end": 1990,
+      "start": 1836,
+      "end": 1837,
       "loc": {
         "start": {
           "line": 59,
@@ -5722,9 +5722,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums\n     ",
-      "start": 1996,
-      "end": 2509,
+      "value": "*\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums\n     ",
+      "start": 1843,
+      "end": 2308,
       "loc": {
         "start": {
           "line": 61,
@@ -5749,8 +5749,8 @@
         "binop": null
       },
       "value": "fetchAlbums",
-      "start": 2514,
-      "end": 2525,
+      "start": 2313,
+      "end": 2324,
       "loc": {
         "start": {
           "line": 70,
@@ -5774,8 +5774,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2525,
-      "end": 2526,
+      "start": 2324,
+      "end": 2325,
       "loc": {
         "start": {
           "line": 70,
@@ -5800,8 +5800,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2526,
-      "end": 2531,
+      "start": 2325,
+      "end": 2330,
       "loc": {
         "start": {
           "line": 70,
@@ -5827,8 +5827,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2532,
-      "end": 2533,
+      "start": 2331,
+      "end": 2332,
       "loc": {
         "start": {
           "line": 70,
@@ -5853,8 +5853,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2534,
-      "end": 2543,
+      "start": 2333,
+      "end": 2342,
       "loc": {
         "start": {
           "line": 70,
@@ -5879,8 +5879,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2543,
-      "end": 2544,
+      "start": 2342,
+      "end": 2343,
       "loc": {
         "start": {
           "line": 70,
@@ -5905,8 +5905,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2545,
-      "end": 2551,
+      "start": 2344,
+      "end": 2350,
       "loc": {
         "start": {
           "line": 70,
@@ -5932,8 +5932,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2552,
-      "end": 2553,
+      "start": 2351,
+      "end": 2352,
       "loc": {
         "start": {
           "line": 70,
@@ -5958,8 +5958,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2554,
-      "end": 2563,
+      "start": 2353,
+      "end": 2362,
       "loc": {
         "start": {
           "line": 70,
@@ -5983,8 +5983,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2563,
-      "end": 2564,
+      "start": 2362,
+      "end": 2363,
       "loc": {
         "start": {
           "line": 70,
@@ -6008,8 +6008,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2565,
-      "end": 2566,
+      "start": 2364,
+      "end": 2365,
       "loc": {
         "start": {
           "line": 70,
@@ -6036,8 +6036,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2575,
-      "end": 2581,
+      "start": 2374,
+      "end": 2380,
       "loc": {
         "start": {
           "line": 71,
@@ -6064,8 +6064,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2582,
-      "end": 2586,
+      "start": 2381,
+      "end": 2385,
       "loc": {
         "start": {
           "line": 71,
@@ -6090,8 +6090,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2586,
-      "end": 2587,
+      "start": 2385,
+      "end": 2386,
       "loc": {
         "start": {
           "line": 71,
@@ -6116,8 +6116,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 2587,
-      "end": 2591,
+      "start": 2386,
+      "end": 2390,
       "loc": {
         "start": {
           "line": 71,
@@ -6142,8 +6142,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2591,
-      "end": 2592,
+      "start": 2390,
+      "end": 2391,
       "loc": {
         "start": {
           "line": 71,
@@ -6168,8 +6168,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 2592,
-      "end": 2595,
+      "start": 2391,
+      "end": 2394,
       "loc": {
         "start": {
           "line": 71,
@@ -6193,8 +6193,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2595,
-      "end": 2596,
+      "start": 2394,
+      "end": 2395,
       "loc": {
         "start": {
           "line": 71,
@@ -6219,8 +6219,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 2596,
-      "end": 2604,
+      "start": 2395,
+      "end": 2403,
       "loc": {
         "start": {
           "line": 71,
@@ -6246,8 +6246,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2605,
-      "end": 2606,
+      "start": 2404,
+      "end": 2405,
       "loc": {
         "start": {
           "line": 71,
@@ -6274,8 +6274,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2607,
-      "end": 2611,
+      "start": 2406,
+      "end": 2410,
       "loc": {
         "start": {
           "line": 71,
@@ -6300,8 +6300,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2611,
-      "end": 2612,
+      "start": 2410,
+      "end": 2411,
       "loc": {
         "start": {
           "line": 71,
@@ -6326,8 +6326,8 @@
         "binop": null
       },
       "value": "category_id",
-      "start": 2612,
-      "end": 2623,
+      "start": 2411,
+      "end": 2422,
       "loc": {
         "start": {
           "line": 71,
@@ -6353,8 +6353,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2624,
-      "end": 2625,
+      "start": 2423,
+      "end": 2424,
       "loc": {
         "start": {
           "line": 71,
@@ -6380,8 +6380,8 @@
         "updateContext": null
       },
       "value": "/albums",
-      "start": 2626,
-      "end": 2635,
+      "start": 2425,
+      "end": 2434,
       "loc": {
         "start": {
           "line": 71,
@@ -6406,8 +6406,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2635,
-      "end": 2636,
+      "start": 2434,
+      "end": 2435,
       "loc": {
         "start": {
           "line": 71,
@@ -6431,8 +6431,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2637,
-      "end": 2638,
+      "start": 2436,
+      "end": 2437,
       "loc": {
         "start": {
           "line": 71,
@@ -6457,8 +6457,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2651,
-      "end": 2660,
+      "start": 2450,
+      "end": 2459,
       "loc": {
         "start": {
           "line": 72,
@@ -6483,8 +6483,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2660,
-      "end": 2661,
+      "start": 2459,
+      "end": 2460,
       "loc": {
         "start": {
           "line": 72,
@@ -6511,8 +6511,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2662,
-      "end": 2666,
+      "start": 2461,
+      "end": 2465,
       "loc": {
         "start": {
           "line": 72,
@@ -6537,8 +6537,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2666,
-      "end": 2667,
+      "start": 2465,
+      "end": 2466,
       "loc": {
         "start": {
           "line": 72,
@@ -6563,8 +6563,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2667,
-      "end": 2676,
+      "start": 2466,
+      "end": 2475,
       "loc": {
         "start": {
           "line": 72,
@@ -6589,8 +6589,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2676,
-      "end": 2677,
+      "start": 2475,
+      "end": 2476,
       "loc": {
         "start": {
           "line": 72,
@@ -6615,8 +6615,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2690,
-      "end": 2695,
+      "start": 2489,
+      "end": 2494,
       "loc": {
         "start": {
           "line": 73,
@@ -6641,8 +6641,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2695,
-      "end": 2696,
+      "start": 2494,
+      "end": 2495,
       "loc": {
         "start": {
           "line": 73,
@@ -6667,8 +6667,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2697,
-      "end": 2702,
+      "start": 2496,
+      "end": 2501,
       "loc": {
         "start": {
           "line": 73,
@@ -6693,8 +6693,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2702,
-      "end": 2703,
+      "start": 2501,
+      "end": 2502,
       "loc": {
         "start": {
           "line": 73,
@@ -6719,8 +6719,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2716,
-      "end": 2722,
+      "start": 2515,
+      "end": 2521,
       "loc": {
         "start": {
           "line": 74,
@@ -6745,8 +6745,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2722,
-      "end": 2723,
+      "start": 2521,
+      "end": 2522,
       "loc": {
         "start": {
           "line": 74,
@@ -6771,8 +6771,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2724,
-      "end": 2730,
+      "start": 2523,
+      "end": 2529,
       "loc": {
         "start": {
           "line": 74,
@@ -6796,8 +6796,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2739,
-      "end": 2740,
+      "start": 2538,
+      "end": 2539,
       "loc": {
         "start": {
           "line": 75,
@@ -6821,8 +6821,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2740,
-      "end": 2741,
+      "start": 2539,
+      "end": 2540,
       "loc": {
         "start": {
           "line": 75,
@@ -6846,8 +6846,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2746,
-      "end": 2747,
+      "start": 2545,
+      "end": 2546,
       "loc": {
         "start": {
           "line": 76,
@@ -6871,8 +6871,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2748,
-      "end": 2749,
+      "start": 2547,
+      "end": 2548,
       "loc": {
         "start": {
           "line": 77,
@@ -6897,8 +6897,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2749,
-      "end": 2749,
+      "start": 2548,
+      "end": 2548,
       "loc": {
         "start": {
           "line": 77,

--- a/docs/ast/source/api/SearchFetcher.js.json
+++ b/docs/ast/source/api/SearchFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 7045,
+  "end": 7001,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 7045,
+    "end": 7001,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n ",
+            "value": "*\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n ",
             "start": 80,
-            "end": 169,
+            "end": 160,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 170,
-        "end": 2672,
+        "start": 161,
+        "end": 2628,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 185,
-          "end": 2672,
+          "start": 176,
+          "end": 2628,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 191,
-            "end": 204,
+            "start": 182,
+            "end": 195,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 213,
-            "end": 220,
+            "start": 204,
+            "end": 211,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 221,
-            "end": 2672,
+            "start": 212,
+            "end": 2628,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 258,
-                "end": 563,
+                "start": 249,
+                "end": 554,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 258,
-                  "end": 269,
+                  "start": 249,
+                  "end": 260,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 270,
-                    "end": 274,
+                    "start": 261,
+                    "end": 265,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 276,
-                    "end": 292,
+                    "start": 267,
+                    "end": 283,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 276,
-                      "end": 285,
+                      "start": 267,
+                      "end": 276,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 288,
-                      "end": 292,
+                      "start": 279,
+                      "end": 283,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 294,
-                  "end": 563,
+                  "start": 285,
+                  "end": 554,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 304,
-                      "end": 326,
+                      "start": 295,
+                      "end": 317,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 304,
-                        "end": 326,
+                        "start": 295,
+                        "end": 317,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 304,
-                          "end": 309,
+                          "start": 295,
+                          "end": 300,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 310,
-                            "end": 314,
+                            "start": 301,
+                            "end": 305,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 316,
-                            "end": 325,
+                            "start": 307,
+                            "end": 316,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 336,
-                          "end": 370,
+                          "start": 327,
+                          "end": 361,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 379,
-                      "end": 412,
+                      "start": 370,
+                      "end": 403,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 379,
-                        "end": 412,
+                        "start": 370,
+                        "end": 403,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 379,
-                          "end": 400,
+                          "start": 370,
+                          "end": 391,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 379,
-                            "end": 383,
+                            "start": 370,
+                            "end": 374,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 384,
-                            "end": 400,
+                            "start": 375,
+                            "end": 391,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 403,
-                          "end": 412,
+                          "start": 394,
+                          "end": 403,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -611,8 +611,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 336,
-                          "end": 370,
+                          "start": 327,
+                          "end": 361,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -629,8 +629,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 422,
-                          "end": 456,
+                          "start": 413,
+                          "end": 447,
                           "loc": {
                             "start": {
                               "line": 20,
@@ -646,8 +646,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 465,
-                      "end": 483,
+                      "start": 456,
+                      "end": 474,
                       "loc": {
                         "start": {
                           "line": 23,
@@ -660,8 +660,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 465,
-                        "end": 483,
+                        "start": 456,
+                        "end": 474,
                         "loc": {
                           "start": {
                             "line": 23,
@@ -675,8 +675,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 465,
-                          "end": 471,
+                          "start": 456,
+                          "end": 462,
                           "loc": {
                             "start": {
                               "line": 23,
@@ -689,8 +689,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 465,
-                            "end": 469,
+                            "start": 456,
+                            "end": 460,
                             "loc": {
                               "start": {
                                 "line": 23,
@@ -705,8 +705,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 470,
-                            "end": 471,
+                            "start": 461,
+                            "end": 462,
                             "loc": {
                               "start": {
                                 "line": 23,
@@ -725,8 +725,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 474,
-                          "end": 483,
+                          "start": 465,
+                          "end": 474,
                           "loc": {
                             "start": {
                               "line": 23,
@@ -749,8 +749,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 422,
-                          "end": 456,
+                          "start": 413,
+                          "end": 447,
                           "loc": {
                             "start": {
                               "line": 20,
@@ -767,8 +767,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 493,
-                          "end": 527,
+                          "start": 484,
+                          "end": 518,
                           "loc": {
                             "start": {
                               "line": 25,
@@ -784,8 +784,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 536,
-                      "end": 557,
+                      "start": 527,
+                      "end": 548,
                       "loc": {
                         "start": {
                           "line": 28,
@@ -798,8 +798,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 536,
-                        "end": 557,
+                        "start": 527,
+                        "end": 548,
                         "loc": {
                           "start": {
                             "line": 28,
@@ -813,8 +813,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 536,
-                          "end": 545,
+                          "start": 527,
+                          "end": 536,
                           "loc": {
                             "start": {
                               "line": 28,
@@ -827,8 +827,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 536,
-                            "end": 540,
+                            "start": 527,
+                            "end": 531,
                             "loc": {
                               "start": {
                                 "line": 28,
@@ -843,8 +843,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 541,
-                            "end": 545,
+                            "start": 532,
+                            "end": 536,
                             "loc": {
                               "start": {
                                 "line": 28,
@@ -863,8 +863,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 548,
-                          "end": 557,
+                          "start": 539,
+                          "end": 548,
                           "loc": {
                             "start": {
                               "line": 28,
@@ -884,8 +884,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 493,
-                          "end": 527,
+                          "start": 484,
+                          "end": 518,
                           "loc": {
                             "start": {
                               "line": 25,
@@ -907,8 +907,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 227,
-                    "end": 253,
+                    "start": 218,
+                    "end": 244,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -925,8 +925,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     ",
-                    "start": 569,
-                    "end": 1149,
+                    "start": 560,
+                    "end": 1140,
                     "loc": {
                       "start": {
                         "line": 31,
@@ -942,8 +942,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1154,
-                "end": 1410,
+                "start": 1145,
+                "end": 1401,
                 "loc": {
                   "start": {
                     "line": 43,
@@ -957,8 +957,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1154,
-                  "end": 1160,
+                  "start": 1145,
+                  "end": 1151,
                   "loc": {
                     "start": {
                       "line": 43,
@@ -982,8 +982,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 1161,
-                    "end": 1338,
+                    "start": 1152,
+                    "end": 1329,
                     "loc": {
                       "start": {
                         "line": 43,
@@ -996,8 +996,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1161,
-                      "end": 1171,
+                      "start": 1152,
+                      "end": 1162,
                       "loc": {
                         "start": {
                           "line": 43,
@@ -1013,8 +1013,8 @@
                     },
                     "right": {
                       "type": "AssignmentExpression",
-                      "start": 1174,
-                      "end": 1338,
+                      "start": 1165,
+                      "end": 1329,
                       "loc": {
                         "start": {
                           "line": 43,
@@ -1028,8 +1028,8 @@
                       "operator": "=",
                       "left": {
                         "type": "ObjectPattern",
-                        "start": 1174,
-                        "end": 1333,
+                        "start": 1165,
+                        "end": 1324,
                         "loc": {
                           "start": {
                             "line": 43,
@@ -1043,8 +1043,8 @@
                         "properties": [
                           {
                             "type": "ObjectProperty",
-                            "start": 1184,
-                            "end": 1201,
+                            "start": 1175,
+                            "end": 1192,
                             "loc": {
                               "start": {
                                 "line": 44,
@@ -1060,8 +1060,8 @@
                             "computed": false,
                             "key": {
                               "type": "Identifier",
-                              "start": 1184,
-                              "end": 1189,
+                              "start": 1175,
+                              "end": 1180,
                               "loc": {
                                 "start": {
                                   "line": 44,
@@ -1077,8 +1077,8 @@
                             },
                             "value": {
                               "type": "AssignmentPattern",
-                              "start": 1184,
-                              "end": 1201,
+                              "start": 1175,
+                              "end": 1192,
                               "loc": {
                                 "start": {
                                   "line": 44,
@@ -1091,8 +1091,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1184,
-                                "end": 1189,
+                                "start": 1175,
+                                "end": 1180,
                                 "loc": {
                                   "start": {
                                     "line": 44,
@@ -1108,8 +1108,8 @@
                               },
                               "right": {
                                 "type": "Identifier",
-                                "start": 1192,
-                                "end": 1201,
+                                "start": 1183,
+                                "end": 1192,
                                 "loc": {
                                   "start": {
                                     "line": 44,
@@ -1130,8 +1130,8 @@
                           },
                           {
                             "type": "ObjectProperty",
-                            "start": 1211,
-                            "end": 1228,
+                            "start": 1202,
+                            "end": 1219,
                             "loc": {
                               "start": {
                                 "line": 45,
@@ -1147,8 +1147,8 @@
                             "computed": false,
                             "key": {
                               "type": "Identifier",
-                              "start": 1211,
-                              "end": 1216,
+                              "start": 1202,
+                              "end": 1207,
                               "loc": {
                                 "start": {
                                   "line": 45,
@@ -1164,8 +1164,8 @@
                             },
                             "value": {
                               "type": "AssignmentPattern",
-                              "start": 1211,
-                              "end": 1228,
+                              "start": 1202,
+                              "end": 1219,
                               "loc": {
                                 "start": {
                                   "line": 45,
@@ -1178,8 +1178,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1211,
-                                "end": 1216,
+                                "start": 1202,
+                                "end": 1207,
                                 "loc": {
                                   "start": {
                                     "line": 45,
@@ -1195,8 +1195,8 @@
                               },
                               "right": {
                                 "type": "Identifier",
-                                "start": 1219,
-                                "end": 1228,
+                                "start": 1210,
+                                "end": 1219,
                                 "loc": {
                                   "start": {
                                     "line": 45,
@@ -1217,8 +1217,8 @@
                           },
                           {
                             "type": "ObjectProperty",
-                            "start": 1238,
-                            "end": 1256,
+                            "start": 1229,
+                            "end": 1247,
                             "loc": {
                               "start": {
                                 "line": 46,
@@ -1234,8 +1234,8 @@
                             "computed": false,
                             "key": {
                               "type": "Identifier",
-                              "start": 1238,
-                              "end": 1244,
+                              "start": 1229,
+                              "end": 1235,
                               "loc": {
                                 "start": {
                                   "line": 46,
@@ -1251,8 +1251,8 @@
                             },
                             "value": {
                               "type": "AssignmentPattern",
-                              "start": 1238,
-                              "end": 1256,
+                              "start": 1229,
+                              "end": 1247,
                               "loc": {
                                 "start": {
                                   "line": 46,
@@ -1265,8 +1265,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1238,
-                                "end": 1244,
+                                "start": 1229,
+                                "end": 1235,
                                 "loc": {
                                   "start": {
                                     "line": 46,
@@ -1282,8 +1282,8 @@
                               },
                               "right": {
                                 "type": "Identifier",
-                                "start": 1247,
-                                "end": 1256,
+                                "start": 1238,
+                                "end": 1247,
                                 "loc": {
                                   "start": {
                                     "line": 46,
@@ -1304,8 +1304,8 @@
                           },
                           {
                             "type": "ObjectProperty",
-                            "start": 1266,
-                            "end": 1286,
+                            "start": 1257,
+                            "end": 1277,
                             "loc": {
                               "start": {
                                 "line": 47,
@@ -1321,8 +1321,8 @@
                             "computed": false,
                             "key": {
                               "type": "Identifier",
-                              "start": 1266,
-                              "end": 1274,
+                              "start": 1257,
+                              "end": 1265,
                               "loc": {
                                 "start": {
                                   "line": 47,
@@ -1338,8 +1338,8 @@
                             },
                             "value": {
                               "type": "AssignmentPattern",
-                              "start": 1266,
-                              "end": 1286,
+                              "start": 1257,
+                              "end": 1277,
                               "loc": {
                                 "start": {
                                   "line": 47,
@@ -1352,8 +1352,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1266,
-                                "end": 1274,
+                                "start": 1257,
+                                "end": 1265,
                                 "loc": {
                                   "start": {
                                     "line": 47,
@@ -1369,8 +1369,8 @@
                               },
                               "right": {
                                 "type": "Identifier",
-                                "start": 1277,
-                                "end": 1286,
+                                "start": 1268,
+                                "end": 1277,
                                 "loc": {
                                   "start": {
                                     "line": 47,
@@ -1391,8 +1391,8 @@
                           },
                           {
                             "type": "ObjectProperty",
-                            "start": 1296,
-                            "end": 1327,
+                            "start": 1287,
+                            "end": 1318,
                             "loc": {
                               "start": {
                                 "line": 48,
@@ -1408,8 +1408,8 @@
                             "computed": false,
                             "key": {
                               "type": "Identifier",
-                              "start": 1296,
-                              "end": 1315,
+                              "start": 1287,
+                              "end": 1306,
                               "loc": {
                                 "start": {
                                   "line": 48,
@@ -1425,8 +1425,8 @@
                             },
                             "value": {
                               "type": "AssignmentPattern",
-                              "start": 1296,
-                              "end": 1327,
+                              "start": 1287,
+                              "end": 1318,
                               "loc": {
                                 "start": {
                                   "line": 48,
@@ -1439,8 +1439,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 1296,
-                                "end": 1315,
+                                "start": 1287,
+                                "end": 1306,
                                 "loc": {
                                   "start": {
                                     "line": 48,
@@ -1456,8 +1456,8 @@
                               },
                               "right": {
                                 "type": "Identifier",
-                                "start": 1318,
-                                "end": 1327,
+                                "start": 1309,
+                                "end": 1318,
                                 "loc": {
                                   "start": {
                                     "line": 48,
@@ -1480,8 +1480,8 @@
                       },
                       "right": {
                         "type": "ObjectExpression",
-                        "start": 1336,
-                        "end": 1338,
+                        "start": 1327,
+                        "end": 1329,
                         "loc": {
                           "start": {
                             "line": 49,
@@ -1499,8 +1499,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1340,
-                  "end": 1410,
+                  "start": 1331,
+                  "end": 1401,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1514,8 +1514,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1350,
-                      "end": 1384,
+                      "start": 1341,
+                      "end": 1375,
                       "loc": {
                         "start": {
                           "line": 50,
@@ -1528,8 +1528,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1350,
-                        "end": 1384,
+                        "start": 1341,
+                        "end": 1375,
                         "loc": {
                           "start": {
                             "line": 50,
@@ -1543,8 +1543,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1350,
-                          "end": 1371,
+                          "start": 1341,
+                          "end": 1362,
                           "loc": {
                             "start": {
                               "line": 50,
@@ -1557,8 +1557,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1350,
-                            "end": 1354,
+                            "start": 1341,
+                            "end": 1345,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1572,8 +1572,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1355,
-                            "end": 1371,
+                            "start": 1346,
+                            "end": 1362,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1591,8 +1591,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1374,
-                          "end": 1384,
+                          "start": 1365,
+                          "end": 1375,
                           "loc": {
                             "start": {
                               "line": 50,
@@ -1610,8 +1610,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1393,
-                      "end": 1404,
+                      "start": 1384,
+                      "end": 1395,
                       "loc": {
                         "start": {
                           "line": 51,
@@ -1624,8 +1624,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1400,
-                        "end": 1404,
+                        "start": 1391,
+                        "end": 1395,
                         "loc": {
                           "start": {
                             "line": 51,
@@ -1646,8 +1646,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     ",
-                    "start": 569,
-                    "end": 1149,
+                    "start": 560,
+                    "end": 1140,
                     "loc": {
                       "start": {
                         "line": 31,
@@ -1663,9 +1663,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n     ",
-                    "start": 1416,
-                    "end": 1864,
+                    "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+                    "start": 1407,
+                    "end": 1848,
                     "loc": {
                       "start": {
                         "line": 54,
@@ -1681,8 +1681,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1869,
-                "end": 1987,
+                "start": 1853,
+                "end": 1971,
                 "loc": {
                   "start": {
                     "line": 62,
@@ -1696,8 +1696,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1869,
-                  "end": 1886,
+                  "start": 1853,
+                  "end": 1870,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1721,8 +1721,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 1887,
-                    "end": 1888,
+                    "start": 1871,
+                    "end": 1872,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1738,8 +1738,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 1890,
-                    "end": 1906,
+                    "start": 1874,
+                    "end": 1890,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1752,8 +1752,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 1890,
-                      "end": 1894,
+                      "start": 1874,
+                      "end": 1878,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1769,8 +1769,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 1897,
-                      "end": 1906,
+                      "start": 1881,
+                      "end": 1890,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1788,8 +1788,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1908,
-                  "end": 1987,
+                  "start": 1892,
+                  "end": 1971,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1803,8 +1803,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 1918,
-                      "end": 1928,
+                      "start": 1902,
+                      "end": 1912,
                       "loc": {
                         "start": {
                           "line": 63,
@@ -1817,8 +1817,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1918,
-                        "end": 1928,
+                        "start": 1902,
+                        "end": 1912,
                         "loc": {
                           "start": {
                             "line": 63,
@@ -1832,8 +1832,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1918,
-                          "end": 1924,
+                          "start": 1902,
+                          "end": 1908,
                           "loc": {
                             "start": {
                               "line": 63,
@@ -1846,8 +1846,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1918,
-                            "end": 1922,
+                            "start": 1902,
+                            "end": 1906,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1861,8 +1861,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1923,
-                            "end": 1924,
+                            "start": 1907,
+                            "end": 1908,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1880,8 +1880,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1927,
-                          "end": 1928,
+                          "start": 1911,
+                          "end": 1912,
                           "loc": {
                             "start": {
                               "line": 63,
@@ -1899,8 +1899,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 1937,
-                      "end": 1953,
+                      "start": 1921,
+                      "end": 1937,
                       "loc": {
                         "start": {
                           "line": 64,
@@ -1913,8 +1913,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 1937,
-                        "end": 1953,
+                        "start": 1921,
+                        "end": 1937,
                         "loc": {
                           "start": {
                             "line": 64,
@@ -1928,8 +1928,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 1937,
-                          "end": 1946,
+                          "start": 1921,
+                          "end": 1930,
                           "loc": {
                             "start": {
                               "line": 64,
@@ -1942,8 +1942,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 1937,
-                            "end": 1941,
+                            "start": 1921,
+                            "end": 1925,
                             "loc": {
                               "start": {
                                 "line": 64,
@@ -1957,8 +1957,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1942,
-                            "end": 1946,
+                            "start": 1926,
+                            "end": 1930,
                             "loc": {
                               "start": {
                                 "line": 64,
@@ -1976,8 +1976,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 1949,
-                          "end": 1953,
+                          "start": 1933,
+                          "end": 1937,
                           "loc": {
                             "start": {
                               "line": 64,
@@ -1995,8 +1995,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 1970,
-                      "end": 1981,
+                      "start": 1954,
+                      "end": 1965,
                       "loc": {
                         "start": {
                           "line": 65,
@@ -2009,8 +2009,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 1977,
-                        "end": 1981,
+                        "start": 1961,
+                        "end": 1965,
                         "loc": {
                           "start": {
                             "line": 65,
@@ -2030,9 +2030,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n     ",
-                    "start": 1416,
-                    "end": 1864,
+                    "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+                    "start": 1407,
+                    "end": 1848,
                     "loc": {
                       "start": {
                         "line": 54,
@@ -2048,9 +2048,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search\n     ",
-                    "start": 1993,
-                    "end": 2367,
+                    "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+                    "start": 1977,
+                    "end": 2323,
                     "loc": {
                       "start": {
                         "line": 68,
@@ -2066,8 +2066,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 2372,
-                "end": 2670,
+                "start": 2328,
+                "end": 2626,
                 "loc": {
                   "start": {
                     "line": 77,
@@ -2081,8 +2081,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 2372,
-                  "end": 2389,
+                  "start": 2328,
+                  "end": 2345,
                   "loc": {
                     "start": {
                       "line": 77,
@@ -2106,8 +2106,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 2390,
-                    "end": 2407,
+                    "start": 2346,
+                    "end": 2363,
                     "loc": {
                       "start": {
                         "line": 77,
@@ -2120,8 +2120,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2390,
-                      "end": 2395,
+                      "start": 2346,
+                      "end": 2351,
                       "loc": {
                         "start": {
                           "line": 77,
@@ -2137,8 +2137,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2398,
-                      "end": 2407,
+                      "start": 2354,
+                      "end": 2363,
                       "loc": {
                         "start": {
                           "line": 77,
@@ -2155,8 +2155,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 2409,
-                    "end": 2427,
+                    "start": 2365,
+                    "end": 2383,
                     "loc": {
                       "start": {
                         "line": 77,
@@ -2169,8 +2169,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2409,
-                      "end": 2415,
+                      "start": 2365,
+                      "end": 2371,
                       "loc": {
                         "start": {
                           "line": 77,
@@ -2186,8 +2186,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2418,
-                      "end": 2427,
+                      "start": 2374,
+                      "end": 2383,
                       "loc": {
                         "start": {
                           "line": 77,
@@ -2205,8 +2205,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 2429,
-                  "end": 2670,
+                  "start": 2385,
+                  "end": 2626,
                   "loc": {
                     "start": {
                       "line": 77,
@@ -2220,8 +2220,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 2439,
-                      "end": 2664,
+                      "start": 2395,
+                      "end": 2620,
                       "loc": {
                         "start": {
                           "line": 78,
@@ -2234,8 +2234,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 2446,
-                        "end": 2664,
+                        "start": 2402,
+                        "end": 2620,
                         "loc": {
                           "start": {
                             "line": 78,
@@ -2248,8 +2248,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 2446,
-                          "end": 2643,
+                          "start": 2402,
+                          "end": 2599,
                           "loc": {
                             "start": {
                               "line": 78,
@@ -2262,8 +2262,8 @@
                           },
                           "object": {
                             "type": "CallExpression",
-                            "start": 2446,
-                            "end": 2638,
+                            "start": 2402,
+                            "end": 2594,
                             "loc": {
                               "start": {
                                 "line": 78,
@@ -2276,8 +2276,8 @@
                             },
                             "callee": {
                               "type": "MemberExpression",
-                              "start": 2446,
-                              "end": 2459,
+                              "start": 2402,
+                              "end": 2415,
                               "loc": {
                                 "start": {
                                   "line": 78,
@@ -2290,8 +2290,8 @@
                               },
                               "object": {
                                 "type": "MemberExpression",
-                                "start": 2446,
-                                "end": 2455,
+                                "start": 2402,
+                                "end": 2411,
                                 "loc": {
                                   "start": {
                                     "line": 78,
@@ -2304,8 +2304,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 2446,
-                                  "end": 2450,
+                                  "start": 2402,
+                                  "end": 2406,
                                   "loc": {
                                     "start": {
                                       "line": 78,
@@ -2319,8 +2319,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2451,
-                                  "end": 2455,
+                                  "start": 2407,
+                                  "end": 2411,
                                   "loc": {
                                     "start": {
                                       "line": 78,
@@ -2338,8 +2338,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 2456,
-                                "end": 2459,
+                                "start": 2412,
+                                "end": 2415,
                                 "loc": {
                                   "start": {
                                     "line": 78,
@@ -2358,8 +2358,8 @@
                             "arguments": [
                               {
                                 "type": "Identifier",
-                                "start": 2460,
-                                "end": 2468,
+                                "start": 2416,
+                                "end": 2424,
                                 "loc": {
                                   "start": {
                                     "line": 78,
@@ -2375,8 +2375,8 @@
                               },
                               {
                                 "type": "ObjectExpression",
-                                "start": 2470,
-                                "end": 2637,
+                                "start": 2426,
+                                "end": 2593,
                                 "loc": {
                                   "start": {
                                     "line": 78,
@@ -2390,8 +2390,8 @@
                                 "properties": [
                                   {
                                     "type": "ObjectProperty",
-                                    "start": 2484,
-                                    "end": 2493,
+                                    "start": 2440,
+                                    "end": 2449,
                                     "loc": {
                                       "start": {
                                         "line": 79,
@@ -2407,8 +2407,8 @@
                                     "computed": false,
                                     "key": {
                                       "type": "Identifier",
-                                      "start": 2484,
-                                      "end": 2485,
+                                      "start": 2440,
+                                      "end": 2441,
                                       "loc": {
                                         "start": {
                                           "line": 79,
@@ -2424,8 +2424,8 @@
                                     },
                                     "value": {
                                       "type": "MemberExpression",
-                                      "start": 2487,
-                                      "end": 2493,
+                                      "start": 2443,
+                                      "end": 2449,
                                       "loc": {
                                         "start": {
                                           "line": 79,
@@ -2438,8 +2438,8 @@
                                       },
                                       "object": {
                                         "type": "ThisExpression",
-                                        "start": 2487,
-                                        "end": 2491,
+                                        "start": 2443,
+                                        "end": 2447,
                                         "loc": {
                                           "start": {
                                             "line": 79,
@@ -2453,8 +2453,8 @@
                                       },
                                       "property": {
                                         "type": "Identifier",
-                                        "start": 2492,
-                                        "end": 2493,
+                                        "start": 2448,
+                                        "end": 2449,
                                         "loc": {
                                           "start": {
                                             "line": 79,
@@ -2473,8 +2473,8 @@
                                   },
                                   {
                                     "type": "ObjectProperty",
-                                    "start": 2507,
-                                    "end": 2522,
+                                    "start": 2463,
+                                    "end": 2478,
                                     "loc": {
                                       "start": {
                                         "line": 80,
@@ -2490,8 +2490,8 @@
                                     "computed": false,
                                     "key": {
                                       "type": "Identifier",
-                                      "start": 2507,
-                                      "end": 2511,
+                                      "start": 2463,
+                                      "end": 2467,
                                       "loc": {
                                         "start": {
                                           "line": 80,
@@ -2507,8 +2507,8 @@
                                     },
                                     "value": {
                                       "type": "MemberExpression",
-                                      "start": 2513,
-                                      "end": 2522,
+                                      "start": 2469,
+                                      "end": 2478,
                                       "loc": {
                                         "start": {
                                           "line": 80,
@@ -2521,8 +2521,8 @@
                                       },
                                       "object": {
                                         "type": "ThisExpression",
-                                        "start": 2513,
-                                        "end": 2517,
+                                        "start": 2469,
+                                        "end": 2473,
                                         "loc": {
                                           "start": {
                                             "line": 80,
@@ -2536,8 +2536,8 @@
                                       },
                                       "property": {
                                         "type": "Identifier",
-                                        "start": 2518,
-                                        "end": 2522,
+                                        "start": 2474,
+                                        "end": 2478,
                                         "loc": {
                                           "start": {
                                             "line": 80,
@@ -2556,8 +2556,8 @@
                                   },
                                   {
                                     "type": "ObjectProperty",
-                                    "start": 2536,
-                                    "end": 2561,
+                                    "start": 2492,
+                                    "end": 2517,
                                     "loc": {
                                       "start": {
                                         "line": 81,
@@ -2573,8 +2573,8 @@
                                     "computed": false,
                                     "key": {
                                       "type": "Identifier",
-                                      "start": 2536,
-                                      "end": 2545,
+                                      "start": 2492,
+                                      "end": 2501,
                                       "loc": {
                                         "start": {
                                           "line": 81,
@@ -2590,8 +2590,8 @@
                                     },
                                     "value": {
                                       "type": "MemberExpression",
-                                      "start": 2547,
-                                      "end": 2561,
+                                      "start": 2503,
+                                      "end": 2517,
                                       "loc": {
                                         "start": {
                                           "line": 81,
@@ -2604,8 +2604,8 @@
                                       },
                                       "object": {
                                         "type": "ThisExpression",
-                                        "start": 2547,
-                                        "end": 2551,
+                                        "start": 2503,
+                                        "end": 2507,
                                         "loc": {
                                           "start": {
                                             "line": 81,
@@ -2619,8 +2619,8 @@
                                       },
                                       "property": {
                                         "type": "Identifier",
-                                        "start": 2552,
-                                        "end": 2561,
+                                        "start": 2508,
+                                        "end": 2517,
                                         "loc": {
                                           "start": {
                                             "line": 81,
@@ -2639,8 +2639,8 @@
                                   },
                                   {
                                     "type": "ObjectProperty",
-                                    "start": 2575,
-                                    "end": 2587,
+                                    "start": 2531,
+                                    "end": 2543,
                                     "loc": {
                                       "start": {
                                         "line": 82,
@@ -2656,8 +2656,8 @@
                                     "computed": false,
                                     "key": {
                                       "type": "Identifier",
-                                      "start": 2575,
-                                      "end": 2580,
+                                      "start": 2531,
+                                      "end": 2536,
                                       "loc": {
                                         "start": {
                                           "line": 82,
@@ -2673,8 +2673,8 @@
                                     },
                                     "value": {
                                       "type": "Identifier",
-                                      "start": 2582,
-                                      "end": 2587,
+                                      "start": 2538,
+                                      "end": 2543,
                                       "loc": {
                                         "start": {
                                           "line": 82,
@@ -2691,8 +2691,8 @@
                                   },
                                   {
                                     "type": "ObjectProperty",
-                                    "start": 2601,
-                                    "end": 2615,
+                                    "start": 2557,
+                                    "end": 2571,
                                     "loc": {
                                       "start": {
                                         "line": 83,
@@ -2708,8 +2708,8 @@
                                     "computed": false,
                                     "key": {
                                       "type": "Identifier",
-                                      "start": 2601,
-                                      "end": 2607,
+                                      "start": 2557,
+                                      "end": 2563,
                                       "loc": {
                                         "start": {
                                           "line": 83,
@@ -2725,8 +2725,8 @@
                                     },
                                     "value": {
                                       "type": "Identifier",
-                                      "start": 2609,
-                                      "end": 2615,
+                                      "start": 2565,
+                                      "end": 2571,
                                       "loc": {
                                         "start": {
                                           "line": 83,
@@ -2747,8 +2747,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 2639,
-                            "end": 2643,
+                            "start": 2595,
+                            "end": 2599,
                             "loc": {
                               "start": {
                                 "line": 84,
@@ -2767,8 +2767,8 @@
                         "arguments": [
                           {
                             "type": "CallExpression",
-                            "start": 2644,
-                            "end": 2663,
+                            "start": 2600,
+                            "end": 2619,
                             "loc": {
                               "start": {
                                 "line": 84,
@@ -2781,8 +2781,8 @@
                             },
                             "callee": {
                               "type": "MemberExpression",
-                              "start": 2644,
-                              "end": 2657,
+                              "start": 2600,
+                              "end": 2613,
                               "loc": {
                                 "start": {
                                   "line": 84,
@@ -2795,8 +2795,8 @@
                               },
                               "object": {
                                 "type": "Identifier",
-                                "start": 2644,
-                                "end": 2652,
+                                "start": 2600,
+                                "end": 2608,
                                 "loc": {
                                   "start": {
                                     "line": 84,
@@ -2812,8 +2812,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 2653,
-                                "end": 2657,
+                                "start": 2609,
+                                "end": 2613,
                                 "loc": {
                                   "start": {
                                     "line": 84,
@@ -2832,8 +2832,8 @@
                             "arguments": [
                               {
                                 "type": "ThisExpression",
-                                "start": 2658,
-                                "end": 2662,
+                                "start": 2614,
+                                "end": 2618,
                                 "loc": {
                                   "start": {
                                     "line": 84,
@@ -2856,9 +2856,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search\n     ",
-                    "start": 1993,
-                    "end": 2367,
+                    "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+                    "start": 1977,
+                    "end": 2323,
                     "loc": {
                       "start": {
                         "line": 68,
@@ -2877,9 +2877,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n ",
+              "value": "*\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n ",
               "start": 80,
-              "end": 169,
+              "end": 160,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2897,9 +2897,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n ",
+            "value": "*\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n ",
             "start": 80,
-            "end": 169,
+            "end": 160,
             "loc": {
               "start": {
                 "line": 4,
@@ -2915,8 +2915,8 @@
       },
       {
         "type": "FunctionDeclaration",
-        "start": 2674,
-        "end": 7045,
+        "start": 2630,
+        "end": 7001,
         "loc": {
           "start": {
             "line": 88,
@@ -2929,8 +2929,8 @@
         },
         "id": {
           "type": "Identifier",
-          "start": 2683,
-          "end": 2691,
+          "start": 2639,
+          "end": 2647,
           "loc": {
             "start": {
               "line": 88,
@@ -2950,8 +2950,8 @@
         "params": [
           {
             "type": "Identifier",
-            "start": 2692,
-            "end": 2700,
+            "start": 2648,
+            "end": 2656,
             "loc": {
               "start": {
                 "line": 88,
@@ -2968,8 +2968,8 @@
         ],
         "body": {
           "type": "BlockStatement",
-          "start": 2702,
-          "end": 7045,
+          "start": 2658,
+          "end": 7001,
           "loc": {
             "start": {
               "line": 88,
@@ -2983,8 +2983,8 @@
           "body": [
             {
               "type": "IfStatement",
-              "start": 2708,
-              "end": 7043,
+              "start": 2664,
+              "end": 6999,
               "loc": {
                 "start": {
                   "line": 89,
@@ -2997,8 +2997,8 @@
               },
               "test": {
                 "type": "BinaryExpression",
-                "start": 2712,
-                "end": 2747,
+                "start": 2668,
+                "end": 2703,
                 "loc": {
                   "start": {
                     "line": 89,
@@ -3011,8 +3011,8 @@
                 },
                 "left": {
                   "type": "MemberExpression",
-                  "start": 2712,
-                  "end": 2733,
+                  "start": 2668,
+                  "end": 2689,
                   "loc": {
                     "start": {
                       "line": 89,
@@ -3025,8 +3025,8 @@
                   },
                   "object": {
                     "type": "ThisExpression",
-                    "start": 2712,
-                    "end": 2716,
+                    "start": 2668,
+                    "end": 2672,
                     "loc": {
                       "start": {
                         "line": 89,
@@ -3040,8 +3040,8 @@
                   },
                   "property": {
                     "type": "Identifier",
-                    "start": 2717,
-                    "end": 2733,
+                    "start": 2673,
+                    "end": 2689,
                     "loc": {
                       "start": {
                         "line": 89,
@@ -3060,8 +3060,8 @@
                 "operator": "!==",
                 "right": {
                   "type": "Identifier",
-                  "start": 2738,
-                  "end": 2747,
+                  "start": 2694,
+                  "end": 2703,
                   "loc": {
                     "start": {
                       "line": 89,
@@ -3078,8 +3078,8 @@
               },
               "consequent": {
                 "type": "BlockStatement",
-                "start": 2749,
-                "end": 7006,
+                "start": 2705,
+                "end": 6962,
                 "loc": {
                   "start": {
                     "line": 89,
@@ -3093,8 +3093,8 @@
                 "body": [
                   {
                     "type": "VariableDeclaration",
-                    "start": 2759,
-                    "end": 6929,
+                    "start": 2715,
+                    "end": 6885,
                     "loc": {
                       "start": {
                         "line": 90,
@@ -3108,8 +3108,8 @@
                     "declarations": [
                       {
                         "type": "VariableDeclarator",
-                        "start": 2765,
-                        "end": 6929,
+                        "start": 2721,
+                        "end": 6885,
                         "loc": {
                           "start": {
                             "line": 90,
@@ -3122,8 +3122,8 @@
                         },
                         "id": {
                           "type": "Identifier",
-                          "start": 2765,
-                          "end": 2769,
+                          "start": 2721,
+                          "end": 2725,
                           "loc": {
                             "start": {
                               "line": 90,
@@ -3139,8 +3139,8 @@
                         },
                         "init": {
                           "type": "CallExpression",
-                          "start": 2772,
-                          "end": 6929,
+                          "start": 2728,
+                          "end": 6885,
                           "loc": {
                             "start": {
                               "line": 90,
@@ -3153,8 +3153,8 @@
                           },
                           "callee": {
                             "type": "MemberExpression",
-                            "start": 2772,
-                            "end": 2802,
+                            "start": 2728,
+                            "end": 2758,
                             "loc": {
                               "start": {
                                 "line": 90,
@@ -3167,8 +3167,8 @@
                             },
                             "object": {
                               "type": "CallExpression",
-                              "start": 2772,
-                              "end": 2798,
+                              "start": 2728,
+                              "end": 2754,
                               "loc": {
                                 "start": {
                                   "line": 90,
@@ -3181,8 +3181,8 @@
                               },
                               "callee": {
                                 "type": "MemberExpression",
-                                "start": 2772,
-                                "end": 2783,
+                                "start": 2728,
+                                "end": 2739,
                                 "loc": {
                                   "start": {
                                     "line": 90,
@@ -3195,8 +3195,8 @@
                                 },
                                 "object": {
                                   "type": "Identifier",
-                                  "start": 2772,
-                                  "end": 2778,
+                                  "start": 2728,
+                                  "end": 2734,
                                   "loc": {
                                     "start": {
                                       "line": 90,
@@ -3212,8 +3212,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2779,
-                                  "end": 2783,
+                                  "start": 2735,
+                                  "end": 2739,
                                   "loc": {
                                     "start": {
                                       "line": 90,
@@ -3232,8 +3232,8 @@
                               "arguments": [
                                 {
                                   "type": "MemberExpression",
-                                  "start": 2784,
-                                  "end": 2797,
+                                  "start": 2740,
+                                  "end": 2753,
                                   "loc": {
                                     "start": {
                                       "line": 90,
@@ -3246,8 +3246,8 @@
                                   },
                                   "object": {
                                     "type": "Identifier",
-                                    "start": 2784,
-                                    "end": 2792,
+                                    "start": 2740,
+                                    "end": 2748,
                                     "loc": {
                                       "start": {
                                         "line": 90,
@@ -3263,8 +3263,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2793,
-                                    "end": 2797,
+                                    "start": 2749,
+                                    "end": 2753,
                                     "loc": {
                                       "start": {
                                         "line": 90,
@@ -3284,8 +3284,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 2799,
-                              "end": 2802,
+                              "start": 2755,
+                              "end": 2758,
                               "loc": {
                                 "start": {
                                   "line": 90,
@@ -3304,8 +3304,8 @@
                           "arguments": [
                             {
                               "type": "ArrowFunctionExpression",
-                              "start": 2803,
-                              "end": 6928,
+                              "start": 2759,
+                              "end": 6884,
                               "loc": {
                                 "start": {
                                   "line": 90,
@@ -3323,8 +3323,8 @@
                               "params": [
                                 {
                                   "type": "Identifier",
-                                  "start": 2803,
-                                  "end": 2806,
+                                  "start": 2759,
+                                  "end": 2762,
                                   "loc": {
                                     "start": {
                                       "line": 90,
@@ -3341,8 +3341,8 @@
                               ],
                               "body": {
                                 "type": "BlockStatement",
-                                "start": 2810,
-                                "end": 6928,
+                                "start": 2766,
+                                "end": 6884,
                                 "loc": {
                                   "start": {
                                     "line": 90,
@@ -3356,8 +3356,8 @@
                                 "body": [
                                   {
                                     "type": "SwitchStatement",
-                                    "start": 2824,
-                                    "end": 6918,
+                                    "start": 2780,
+                                    "end": 6874,
                                     "loc": {
                                       "start": {
                                         "line": 91,
@@ -3370,8 +3370,8 @@
                                     },
                                     "discriminant": {
                                       "type": "Identifier",
-                                      "start": 2832,
-                                      "end": 2835,
+                                      "start": 2788,
+                                      "end": 2791,
                                       "loc": {
                                         "start": {
                                           "line": 91,
@@ -3388,8 +3388,8 @@
                                     "cases": [
                                       {
                                         "type": "SwitchCase",
-                                        "start": 2855,
-                                        "end": 4274,
+                                        "start": 2811,
+                                        "end": 4230,
                                         "loc": {
                                           "start": {
                                             "line": 92,
@@ -3403,8 +3403,8 @@
                                         "consequent": [
                                           {
                                             "type": "ReturnStatement",
-                                            "start": 2890,
-                                            "end": 4274,
+                                            "start": 2846,
+                                            "end": 4230,
                                             "loc": {
                                               "start": {
                                                 "line": 93,
@@ -3417,8 +3417,8 @@
                                             },
                                             "argument": {
                                               "type": "ObjectExpression",
-                                              "start": 2897,
-                                              "end": 4274,
+                                              "start": 2853,
+                                              "end": 4230,
                                               "loc": {
                                                 "start": {
                                                   "line": 93,
@@ -3432,8 +3432,8 @@
                                               "properties": [
                                                 {
                                                   "type": "ObjectProperty",
-                                                  "start": 2923,
-                                                  "end": 4252,
+                                                  "start": 2879,
+                                                  "end": 4208,
                                                   "loc": {
                                                     "start": {
                                                       "line": 94,
@@ -3449,8 +3449,8 @@
                                                   "computed": true,
                                                   "key": {
                                                     "type": "Identifier",
-                                                    "start": 2924,
-                                                    "end": 2927,
+                                                    "start": 2880,
+                                                    "end": 2883,
                                                     "loc": {
                                                       "start": {
                                                         "line": 94,
@@ -3466,8 +3466,8 @@
                                                   },
                                                   "value": {
                                                     "type": "CallExpression",
-                                                    "start": 2930,
-                                                    "end": 4252,
+                                                    "start": 2886,
+                                                    "end": 4208,
                                                     "loc": {
                                                       "start": {
                                                         "line": 94,
@@ -3480,8 +3480,8 @@
                                                     },
                                                     "callee": {
                                                       "type": "MemberExpression",
-                                                      "start": 2930,
-                                                      "end": 2943,
+                                                      "start": 2886,
+                                                      "end": 2899,
                                                       "loc": {
                                                         "start": {
                                                           "line": 94,
@@ -3494,8 +3494,8 @@
                                                       },
                                                       "object": {
                                                         "type": "Identifier",
-                                                        "start": 2930,
-                                                        "end": 2936,
+                                                        "start": 2886,
+                                                        "end": 2892,
                                                         "loc": {
                                                           "start": {
                                                             "line": 94,
@@ -3511,8 +3511,8 @@
                                                       },
                                                       "property": {
                                                         "type": "Identifier",
-                                                        "start": 2937,
-                                                        "end": 2943,
+                                                        "start": 2893,
+                                                        "end": 2899,
                                                         "loc": {
                                                           "start": {
                                                             "line": 94,
@@ -3531,8 +3531,8 @@
                                                     "arguments": [
                                                       {
                                                         "type": "MemberExpression",
-                                                        "start": 2944,
-                                                        "end": 2962,
+                                                        "start": 2900,
+                                                        "end": 2918,
                                                         "loc": {
                                                           "start": {
                                                             "line": 94,
@@ -3545,8 +3545,8 @@
                                                         },
                                                         "object": {
                                                           "type": "MemberExpression",
-                                                          "start": 2944,
-                                                          "end": 2957,
+                                                          "start": 2900,
+                                                          "end": 2913,
                                                           "loc": {
                                                             "start": {
                                                               "line": 94,
@@ -3559,8 +3559,8 @@
                                                           },
                                                           "object": {
                                                             "type": "Identifier",
-                                                            "start": 2944,
-                                                            "end": 2952,
+                                                            "start": 2900,
+                                                            "end": 2908,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 94,
@@ -3576,8 +3576,8 @@
                                                           },
                                                           "property": {
                                                             "type": "Identifier",
-                                                            "start": 2953,
-                                                            "end": 2957,
+                                                            "start": 2909,
+                                                            "end": 2913,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 94,
@@ -3595,8 +3595,8 @@
                                                         },
                                                         "property": {
                                                           "type": "Identifier",
-                                                          "start": 2958,
-                                                          "end": 2961,
+                                                          "start": 2914,
+                                                          "end": 2917,
                                                           "loc": {
                                                             "start": {
                                                               "line": 94,
@@ -3614,8 +3614,8 @@
                                                       },
                                                       {
                                                         "type": "ObjectExpression",
-                                                        "start": 2964,
-                                                        "end": 4251,
+                                                        "start": 2920,
+                                                        "end": 4207,
                                                         "loc": {
                                                           "start": {
                                                             "line": 94,
@@ -3629,8 +3629,8 @@
                                                         "properties": [
                                                           {
                                                             "type": "ObjectProperty",
-                                                            "start": 2994,
-                                                            "end": 4225,
+                                                            "start": 2950,
+                                                            "end": 4181,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 95,
@@ -3646,8 +3646,8 @@
                                                             "computed": false,
                                                             "key": {
                                                               "type": "Identifier",
-                                                              "start": 2994,
-                                                              "end": 2998,
+                                                              "start": 2950,
+                                                              "end": 2954,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 95,
@@ -3663,8 +3663,8 @@
                                                             },
                                                             "value": {
                                                               "type": "CallExpression",
-                                                              "start": 3000,
-                                                              "end": 4225,
+                                                              "start": 2956,
+                                                              "end": 4181,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 95,
@@ -3677,8 +3677,8 @@
                                                               },
                                                               "callee": {
                                                                 "type": "MemberExpression",
-                                                                "start": 3000,
-                                                                "end": 3063,
+                                                                "start": 2956,
+                                                                "end": 3019,
                                                                 "loc": {
                                                                   "start": {
                                                                     "line": 95,
@@ -3691,8 +3691,8 @@
                                                                 },
                                                                 "object": {
                                                                   "type": "MemberExpression",
-                                                                  "start": 3000,
-                                                                  "end": 3023,
+                                                                  "start": 2956,
+                                                                  "end": 2979,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 95,
@@ -3705,8 +3705,8 @@
                                                                   },
                                                                   "object": {
                                                                     "type": "MemberExpression",
-                                                                    "start": 3000,
-                                                                    "end": 3018,
+                                                                    "start": 2956,
+                                                                    "end": 2974,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 95,
@@ -3719,8 +3719,8 @@
                                                                     },
                                                                     "object": {
                                                                       "type": "MemberExpression",
-                                                                      "start": 3000,
-                                                                      "end": 3013,
+                                                                      "start": 2956,
+                                                                      "end": 2969,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 95,
@@ -3733,8 +3733,8 @@
                                                                       },
                                                                       "object": {
                                                                         "type": "Identifier",
-                                                                        "start": 3000,
-                                                                        "end": 3008,
+                                                                        "start": 2956,
+                                                                        "end": 2964,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 95,
@@ -3750,8 +3750,8 @@
                                                                       },
                                                                       "property": {
                                                                         "type": "Identifier",
-                                                                        "start": 3009,
-                                                                        "end": 3013,
+                                                                        "start": 2965,
+                                                                        "end": 2969,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 95,
@@ -3769,8 +3769,8 @@
                                                                     },
                                                                     "property": {
                                                                       "type": "Identifier",
-                                                                      "start": 3014,
-                                                                      "end": 3017,
+                                                                      "start": 2970,
+                                                                      "end": 2973,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 95,
@@ -3788,8 +3788,8 @@
                                                                   },
                                                                   "property": {
                                                                     "type": "Identifier",
-                                                                    "start": 3019,
-                                                                    "end": 3023,
+                                                                    "start": 2975,
+                                                                    "end": 2979,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 95,
@@ -3807,8 +3807,8 @@
                                                                 },
                                                                 "property": {
                                                                   "type": "Identifier",
-                                                                  "start": 3057,
-                                                                  "end": 3063,
+                                                                  "start": 3013,
+                                                                  "end": 3019,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 96,
@@ -3827,8 +3827,8 @@
                                                               "arguments": [
                                                                 {
                                                                   "type": "ArrowFunctionExpression",
-                                                                  "start": 3064,
-                                                                  "end": 4224,
+                                                                  "start": 3020,
+                                                                  "end": 4180,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 96,
@@ -3846,8 +3846,8 @@
                                                                   "params": [
                                                                     {
                                                                       "type": "Identifier",
-                                                                      "start": 3064,
-                                                                      "end": 3069,
+                                                                      "start": 3020,
+                                                                      "end": 3025,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 96,
@@ -3864,8 +3864,8 @@
                                                                   ],
                                                                   "body": {
                                                                     "type": "BlockStatement",
-                                                                    "start": 3073,
-                                                                    "end": 4224,
+                                                                    "start": 3029,
+                                                                    "end": 4180,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 96,
@@ -3879,8 +3879,8 @@
                                                                     "body": [
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 3111,
-                                                                        "end": 3388,
+                                                                        "start": 3067,
+                                                                        "end": 3344,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 97,
@@ -3893,8 +3893,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "LogicalExpression",
-                                                                          "start": 3115,
-                                                                          "end": 3294,
+                                                                          "start": 3071,
+                                                                          "end": 3250,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 97,
@@ -3907,8 +3907,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "BinaryExpression",
-                                                                            "start": 3115,
-                                                                            "end": 3170,
+                                                                            "start": 3071,
+                                                                            "end": 3126,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 97,
@@ -3921,8 +3921,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 3115,
-                                                                              "end": 3156,
+                                                                              "start": 3071,
+                                                                              "end": 3112,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 97,
@@ -3935,8 +3935,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3115,
-                                                                                "end": 3136,
+                                                                                "start": 3071,
+                                                                                "end": 3092,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 97,
@@ -3949,8 +3949,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "ThisExpression",
-                                                                                  "start": 3115,
-                                                                                  "end": 3119,
+                                                                                  "start": 3071,
+                                                                                  "end": 3075,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 97,
@@ -3964,8 +3964,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3120,
-                                                                                  "end": 3136,
+                                                                                  "start": 3076,
+                                                                                  "end": 3092,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 97,
@@ -3983,8 +3983,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 3137,
-                                                                                "end": 3156,
+                                                                                "start": 3093,
+                                                                                "end": 3112,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 97,
@@ -4003,8 +4003,8 @@
                                                                             "operator": "!==",
                                                                             "right": {
                                                                               "type": "Identifier",
-                                                                              "start": 3161,
-                                                                              "end": 3170,
+                                                                              "start": 3117,
+                                                                              "end": 3126,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 97,
@@ -4022,8 +4022,8 @@
                                                                           "operator": "&&",
                                                                           "right": {
                                                                             "type": "UnaryExpression",
-                                                                            "start": 3214,
-                                                                            "end": 3294,
+                                                                            "start": 3170,
+                                                                            "end": 3250,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 98,
@@ -4038,8 +4038,8 @@
                                                                             "prefix": true,
                                                                             "argument": {
                                                                               "type": "CallExpression",
-                                                                              "start": 3215,
-                                                                              "end": 3294,
+                                                                              "start": 3171,
+                                                                              "end": 3250,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 98,
@@ -4052,8 +4052,8 @@
                                                                               },
                                                                               "callee": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3215,
-                                                                                "end": 3251,
+                                                                                "start": 3171,
+                                                                                "end": 3207,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 98,
@@ -4066,8 +4066,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 3215,
-                                                                                  "end": 3242,
+                                                                                  "start": 3171,
+                                                                                  "end": 3198,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 98,
@@ -4080,8 +4080,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3215,
-                                                                                    "end": 3220,
+                                                                                    "start": 3171,
+                                                                                    "end": 3176,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 98,
@@ -4097,8 +4097,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3221,
-                                                                                    "end": 3242,
+                                                                                    "start": 3177,
+                                                                                    "end": 3198,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 98,
@@ -4116,8 +4116,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3243,
-                                                                                  "end": 3251,
+                                                                                  "start": 3199,
+                                                                                  "end": 3207,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 98,
@@ -4136,8 +4136,8 @@
                                                                               "arguments": [
                                                                                 {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 3252,
-                                                                                  "end": 3293,
+                                                                                  "start": 3208,
+                                                                                  "end": 3249,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 98,
@@ -4150,8 +4150,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 3252,
-                                                                                    "end": 3273,
+                                                                                    "start": 3208,
+                                                                                    "end": 3229,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 98,
@@ -4164,8 +4164,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "ThisExpression",
-                                                                                      "start": 3252,
-                                                                                      "end": 3256,
+                                                                                      "start": 3208,
+                                                                                      "end": 3212,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 98,
@@ -4179,8 +4179,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 3257,
-                                                                                      "end": 3273,
+                                                                                      "start": 3213,
+                                                                                      "end": 3229,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 98,
@@ -4198,8 +4198,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3274,
-                                                                                    "end": 3293,
+                                                                                    "start": 3230,
+                                                                                    "end": 3249,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 98,
@@ -4224,8 +4224,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 3296,
-                                                                          "end": 3388,
+                                                                          "start": 3252,
+                                                                          "end": 3344,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 98,
@@ -4239,8 +4239,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 3338,
-                                                                              "end": 3350,
+                                                                              "start": 3294,
+                                                                              "end": 3306,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 99,
@@ -4253,8 +4253,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 3345,
-                                                                                "end": 3350,
+                                                                                "start": 3301,
+                                                                                "end": 3306,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 99,
@@ -4275,8 +4275,8 @@
                                                                       },
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 3425,
-                                                                        "end": 3679,
+                                                                        "start": 3381,
+                                                                        "end": 3635,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 101,
@@ -4289,8 +4289,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "LogicalExpression",
-                                                                          "start": 3429,
-                                                                          "end": 3585,
+                                                                          "start": 3385,
+                                                                          "end": 3541,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 101,
@@ -4303,8 +4303,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "BinaryExpression",
-                                                                            "start": 3429,
-                                                                            "end": 3470,
+                                                                            "start": 3385,
+                                                                            "end": 3426,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 101,
@@ -4317,8 +4317,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 3429,
-                                                                              "end": 3456,
+                                                                              "start": 3385,
+                                                                              "end": 3412,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 101,
@@ -4331,8 +4331,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3429,
-                                                                                "end": 3450,
+                                                                                "start": 3385,
+                                                                                "end": 3406,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 101,
@@ -4345,8 +4345,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "ThisExpression",
-                                                                                  "start": 3429,
-                                                                                  "end": 3433,
+                                                                                  "start": 3385,
+                                                                                  "end": 3389,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 101,
@@ -4360,8 +4360,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3434,
-                                                                                  "end": 3450,
+                                                                                  "start": 3390,
+                                                                                  "end": 3406,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 101,
@@ -4379,8 +4379,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 3451,
-                                                                                "end": 3456,
+                                                                                "start": 3407,
+                                                                                "end": 3412,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 101,
@@ -4399,8 +4399,8 @@
                                                                             "operator": "!==",
                                                                             "right": {
                                                                               "type": "Identifier",
-                                                                              "start": 3461,
-                                                                              "end": 3470,
+                                                                              "start": 3417,
+                                                                              "end": 3426,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 101,
@@ -4418,8 +4418,8 @@
                                                                           "operator": "&&",
                                                                           "right": {
                                                                             "type": "UnaryExpression",
-                                                                            "start": 3514,
-                                                                            "end": 3585,
+                                                                            "start": 3470,
+                                                                            "end": 3541,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 102,
@@ -4434,8 +4434,8 @@
                                                                             "prefix": true,
                                                                             "argument": {
                                                                               "type": "CallExpression",
-                                                                              "start": 3515,
-                                                                              "end": 3585,
+                                                                              "start": 3471,
+                                                                              "end": 3541,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 102,
@@ -4448,8 +4448,8 @@
                                                                               },
                                                                               "callee": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3515,
-                                                                                "end": 3573,
+                                                                                "start": 3471,
+                                                                                "end": 3529,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 102,
@@ -4462,8 +4462,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "NewExpression",
-                                                                                  "start": 3515,
-                                                                                  "end": 3568,
+                                                                                  "start": 3471,
+                                                                                  "end": 3524,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 102,
@@ -4476,8 +4476,8 @@
                                                                                   },
                                                                                   "callee": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3519,
-                                                                                    "end": 3525,
+                                                                                    "start": 3475,
+                                                                                    "end": 3481,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 102,
@@ -4494,8 +4494,8 @@
                                                                                   "arguments": [
                                                                                     {
                                                                                       "type": "BinaryExpression",
-                                                                                      "start": 3526,
-                                                                                      "end": 3567,
+                                                                                      "start": 3482,
+                                                                                      "end": 3523,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 102,
@@ -4508,8 +4508,8 @@
                                                                                       },
                                                                                       "left": {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 3526,
-                                                                                        "end": 3560,
+                                                                                        "start": 3482,
+                                                                                        "end": 3516,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 102,
@@ -4522,8 +4522,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 3526,
-                                                                                          "end": 3530,
+                                                                                          "start": 3482,
+                                                                                          "end": 3486,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 102,
@@ -4543,8 +4543,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "MemberExpression",
-                                                                                          "start": 3533,
-                                                                                          "end": 3560,
+                                                                                          "start": 3489,
+                                                                                          "end": 3516,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 102,
@@ -4557,8 +4557,8 @@
                                                                                           },
                                                                                           "object": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 3533,
-                                                                                            "end": 3554,
+                                                                                            "start": 3489,
+                                                                                            "end": 3510,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 102,
@@ -4571,8 +4571,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "ThisExpression",
-                                                                                              "start": 3533,
-                                                                                              "end": 3537,
+                                                                                              "start": 3489,
+                                                                                              "end": 3493,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 102,
@@ -4586,8 +4586,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 3538,
-                                                                                              "end": 3554,
+                                                                                              "start": 3494,
+                                                                                              "end": 3510,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 102,
@@ -4605,8 +4605,8 @@
                                                                                           },
                                                                                           "property": {
                                                                                             "type": "Identifier",
-                                                                                            "start": 3555,
-                                                                                            "end": 3560,
+                                                                                            "start": 3511,
+                                                                                            "end": 3516,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 102,
@@ -4626,8 +4626,8 @@
                                                                                       "operator": "+",
                                                                                       "right": {
                                                                                         "type": "StringLiteral",
-                                                                                        "start": 3563,
-                                                                                        "end": 3567,
+                                                                                        "start": 3519,
+                                                                                        "end": 3523,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 102,
@@ -4649,8 +4649,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3569,
-                                                                                  "end": 3573,
+                                                                                  "start": 3525,
+                                                                                  "end": 3529,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 102,
@@ -4669,8 +4669,8 @@
                                                                               "arguments": [
                                                                                 {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 3574,
-                                                                                  "end": 3584,
+                                                                                  "start": 3530,
+                                                                                  "end": 3540,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 102,
@@ -4683,8 +4683,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3574,
-                                                                                    "end": 3579,
+                                                                                    "start": 3530,
+                                                                                    "end": 3535,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 102,
@@ -4700,8 +4700,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3580,
-                                                                                    "end": 3584,
+                                                                                    "start": 3536,
+                                                                                    "end": 3540,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 102,
@@ -4726,8 +4726,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 3587,
-                                                                          "end": 3679,
+                                                                          "start": 3543,
+                                                                          "end": 3635,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 102,
@@ -4741,8 +4741,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 3629,
-                                                                              "end": 3641,
+                                                                              "start": 3585,
+                                                                              "end": 3597,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 103,
@@ -4755,8 +4755,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 3636,
-                                                                                "end": 3641,
+                                                                                "start": 3592,
+                                                                                "end": 3597,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 103,
@@ -4777,8 +4777,8 @@
                                                                       },
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 3716,
-                                                                        "end": 3976,
+                                                                        "start": 3672,
+                                                                        "end": 3932,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 105,
@@ -4791,8 +4791,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "LogicalExpression",
-                                                                          "start": 3720,
-                                                                          "end": 3882,
+                                                                          "start": 3676,
+                                                                          "end": 3838,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 105,
@@ -4805,8 +4805,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "BinaryExpression",
-                                                                            "start": 3720,
-                                                                            "end": 3761,
+                                                                            "start": 3676,
+                                                                            "end": 3717,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 105,
@@ -4819,8 +4819,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 3720,
-                                                                              "end": 3747,
+                                                                              "start": 3676,
+                                                                              "end": 3703,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 105,
@@ -4833,8 +4833,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3720,
-                                                                                "end": 3741,
+                                                                                "start": 3676,
+                                                                                "end": 3697,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 105,
@@ -4847,8 +4847,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "ThisExpression",
-                                                                                  "start": 3720,
-                                                                                  "end": 3724,
+                                                                                  "start": 3676,
+                                                                                  "end": 3680,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 105,
@@ -4862,8 +4862,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3725,
-                                                                                  "end": 3741,
+                                                                                  "start": 3681,
+                                                                                  "end": 3697,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 105,
@@ -4881,8 +4881,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 3742,
-                                                                                "end": 3747,
+                                                                                "start": 3698,
+                                                                                "end": 3703,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 105,
@@ -4901,8 +4901,8 @@
                                                                             "operator": "!==",
                                                                             "right": {
                                                                               "type": "Identifier",
-                                                                              "start": 3752,
-                                                                              "end": 3761,
+                                                                              "start": 3708,
+                                                                              "end": 3717,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 105,
@@ -4920,8 +4920,8 @@
                                                                           "operator": "&&",
                                                                           "right": {
                                                                             "type": "UnaryExpression",
-                                                                            "start": 3805,
-                                                                            "end": 3882,
+                                                                            "start": 3761,
+                                                                            "end": 3838,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 106,
@@ -4936,8 +4936,8 @@
                                                                             "prefix": true,
                                                                             "argument": {
                                                                               "type": "CallExpression",
-                                                                              "start": 3806,
-                                                                              "end": 3882,
+                                                                              "start": 3762,
+                                                                              "end": 3838,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 106,
@@ -4950,8 +4950,8 @@
                                                                               },
                                                                               "callee": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 3806,
-                                                                                "end": 3864,
+                                                                                "start": 3762,
+                                                                                "end": 3820,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 106,
@@ -4964,8 +4964,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "NewExpression",
-                                                                                  "start": 3806,
-                                                                                  "end": 3859,
+                                                                                  "start": 3762,
+                                                                                  "end": 3815,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 106,
@@ -4978,8 +4978,8 @@
                                                                                   },
                                                                                   "callee": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3810,
-                                                                                    "end": 3816,
+                                                                                    "start": 3766,
+                                                                                    "end": 3772,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 106,
@@ -4996,8 +4996,8 @@
                                                                                   "arguments": [
                                                                                     {
                                                                                       "type": "BinaryExpression",
-                                                                                      "start": 3817,
-                                                                                      "end": 3858,
+                                                                                      "start": 3773,
+                                                                                      "end": 3814,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 106,
@@ -5010,8 +5010,8 @@
                                                                                       },
                                                                                       "left": {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 3817,
-                                                                                        "end": 3851,
+                                                                                        "start": 3773,
+                                                                                        "end": 3807,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 106,
@@ -5024,8 +5024,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 3817,
-                                                                                          "end": 3821,
+                                                                                          "start": 3773,
+                                                                                          "end": 3777,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 106,
@@ -5045,8 +5045,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "MemberExpression",
-                                                                                          "start": 3824,
-                                                                                          "end": 3851,
+                                                                                          "start": 3780,
+                                                                                          "end": 3807,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 106,
@@ -5059,8 +5059,8 @@
                                                                                           },
                                                                                           "object": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 3824,
-                                                                                            "end": 3845,
+                                                                                            "start": 3780,
+                                                                                            "end": 3801,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 106,
@@ -5073,8 +5073,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "ThisExpression",
-                                                                                              "start": 3824,
-                                                                                              "end": 3828,
+                                                                                              "start": 3780,
+                                                                                              "end": 3784,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 106,
@@ -5088,8 +5088,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 3829,
-                                                                                              "end": 3845,
+                                                                                              "start": 3785,
+                                                                                              "end": 3801,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 106,
@@ -5107,8 +5107,8 @@
                                                                                           },
                                                                                           "property": {
                                                                                             "type": "Identifier",
-                                                                                            "start": 3846,
-                                                                                            "end": 3851,
+                                                                                            "start": 3802,
+                                                                                            "end": 3807,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 106,
@@ -5128,8 +5128,8 @@
                                                                                       "operator": "+",
                                                                                       "right": {
                                                                                         "type": "StringLiteral",
-                                                                                        "start": 3854,
-                                                                                        "end": 3858,
+                                                                                        "start": 3810,
+                                                                                        "end": 3814,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 106,
@@ -5151,8 +5151,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 3860,
-                                                                                  "end": 3864,
+                                                                                  "start": 3816,
+                                                                                  "end": 3820,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 106,
@@ -5171,8 +5171,8 @@
                                                                               "arguments": [
                                                                                 {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 3865,
-                                                                                  "end": 3881,
+                                                                                  "start": 3821,
+                                                                                  "end": 3837,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 106,
@@ -5185,8 +5185,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 3865,
-                                                                                    "end": 3876,
+                                                                                    "start": 3821,
+                                                                                    "end": 3832,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 106,
@@ -5199,8 +5199,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 3865,
-                                                                                      "end": 3870,
+                                                                                      "start": 3821,
+                                                                                      "end": 3826,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 106,
@@ -5216,8 +5216,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 3871,
-                                                                                      "end": 3876,
+                                                                                      "start": 3827,
+                                                                                      "end": 3832,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 106,
@@ -5235,8 +5235,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 3877,
-                                                                                    "end": 3881,
+                                                                                    "start": 3833,
+                                                                                    "end": 3837,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 106,
@@ -5261,8 +5261,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 3884,
-                                                                          "end": 3976,
+                                                                          "start": 3840,
+                                                                          "end": 3932,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 106,
@@ -5276,8 +5276,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 3926,
-                                                                              "end": 3938,
+                                                                              "start": 3882,
+                                                                              "end": 3894,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 107,
@@ -5290,8 +5290,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 3933,
-                                                                                "end": 3938,
+                                                                                "start": 3889,
+                                                                                "end": 3894,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 107,
@@ -5312,8 +5312,8 @@
                                                                       },
                                                                       {
                                                                         "type": "ReturnStatement",
-                                                                        "start": 4013,
-                                                                        "end": 4190,
+                                                                        "start": 3969,
+                                                                        "end": 4146,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 109,
@@ -5326,8 +5326,8 @@
                                                                         },
                                                                         "argument": {
                                                                           "type": "UnaryExpression",
-                                                                          "start": 4020,
-                                                                          "end": 4190,
+                                                                          "start": 3976,
+                                                                          "end": 4146,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 109,
@@ -5342,8 +5342,8 @@
                                                                           "prefix": true,
                                                                           "argument": {
                                                                             "type": "LogicalExpression",
-                                                                            "start": 4022,
-                                                                            "end": 4189,
+                                                                            "start": 3978,
+                                                                            "end": 4145,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 109,
@@ -5356,8 +5356,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "BinaryExpression",
-                                                                              "start": 4022,
-                                                                              "end": 4064,
+                                                                              "start": 3978,
+                                                                              "end": 4020,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 109,
@@ -5370,8 +5370,8 @@
                                                                               },
                                                                               "left": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 4022,
-                                                                                "end": 4050,
+                                                                                "start": 3978,
+                                                                                "end": 4006,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 109,
@@ -5384,8 +5384,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 4022,
-                                                                                  "end": 4043,
+                                                                                  "start": 3978,
+                                                                                  "end": 3999,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 109,
@@ -5398,8 +5398,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "ThisExpression",
-                                                                                    "start": 4022,
-                                                                                    "end": 4026,
+                                                                                    "start": 3978,
+                                                                                    "end": 3982,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 109,
@@ -5413,8 +5413,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4027,
-                                                                                    "end": 4043,
+                                                                                    "start": 3983,
+                                                                                    "end": 3999,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 109,
@@ -5432,8 +5432,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 4044,
-                                                                                  "end": 4050,
+                                                                                  "start": 4000,
+                                                                                  "end": 4006,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 109,
@@ -5452,8 +5452,8 @@
                                                                               "operator": "!==",
                                                                               "right": {
                                                                                 "type": "Identifier",
-                                                                                "start": 4055,
-                                                                                "end": 4064,
+                                                                                "start": 4011,
+                                                                                "end": 4020,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 109,
@@ -5471,8 +5471,8 @@
                                                                             "operator": "&&",
                                                                             "right": {
                                                                               "type": "UnaryExpression",
-                                                                              "start": 4104,
-                                                                              "end": 4189,
+                                                                              "start": 4060,
+                                                                              "end": 4145,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 110,
@@ -5487,8 +5487,8 @@
                                                                               "prefix": true,
                                                                               "argument": {
                                                                                 "type": "CallExpression",
-                                                                                "start": 4105,
-                                                                                "end": 4189,
+                                                                                "start": 4061,
+                                                                                "end": 4145,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 110,
@@ -5501,8 +5501,8 @@
                                                                                 },
                                                                                 "callee": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 4105,
-                                                                                  "end": 4164,
+                                                                                  "start": 4061,
+                                                                                  "end": 4120,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 110,
@@ -5515,8 +5515,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "NewExpression",
-                                                                                    "start": 4105,
-                                                                                    "end": 4159,
+                                                                                    "start": 4061,
+                                                                                    "end": 4115,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 110,
@@ -5529,8 +5529,8 @@
                                                                                     },
                                                                                     "callee": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 4109,
-                                                                                      "end": 4115,
+                                                                                      "start": 4065,
+                                                                                      "end": 4071,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 110,
@@ -5547,8 +5547,8 @@
                                                                                     "arguments": [
                                                                                       {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 4116,
-                                                                                        "end": 4158,
+                                                                                        "start": 4072,
+                                                                                        "end": 4114,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 110,
@@ -5561,8 +5561,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "BinaryExpression",
-                                                                                          "start": 4116,
-                                                                                          "end": 4151,
+                                                                                          "start": 4072,
+                                                                                          "end": 4107,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 110,
@@ -5575,8 +5575,8 @@
                                                                                           },
                                                                                           "left": {
                                                                                             "type": "StringLiteral",
-                                                                                            "start": 4116,
-                                                                                            "end": 4120,
+                                                                                            "start": 4072,
+                                                                                            "end": 4076,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 110,
@@ -5596,8 +5596,8 @@
                                                                                           "operator": "+",
                                                                                           "right": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 4123,
-                                                                                            "end": 4151,
+                                                                                            "start": 4079,
+                                                                                            "end": 4107,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 110,
@@ -5610,8 +5610,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "MemberExpression",
-                                                                                              "start": 4123,
-                                                                                              "end": 4144,
+                                                                                              "start": 4079,
+                                                                                              "end": 4100,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 110,
@@ -5624,8 +5624,8 @@
                                                                                               },
                                                                                               "object": {
                                                                                                 "type": "ThisExpression",
-                                                                                                "start": 4123,
-                                                                                                "end": 4127,
+                                                                                                "start": 4079,
+                                                                                                "end": 4083,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 110,
@@ -5639,8 +5639,8 @@
                                                                                               },
                                                                                               "property": {
                                                                                                 "type": "Identifier",
-                                                                                                "start": 4128,
-                                                                                                "end": 4144,
+                                                                                                "start": 4084,
+                                                                                                "end": 4100,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 110,
@@ -5658,8 +5658,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 4145,
-                                                                                              "end": 4151,
+                                                                                              "start": 4101,
+                                                                                              "end": 4107,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 110,
@@ -5679,8 +5679,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 4154,
-                                                                                          "end": 4158,
+                                                                                          "start": 4110,
+                                                                                          "end": 4114,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 110,
@@ -5702,8 +5702,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4160,
-                                                                                    "end": 4164,
+                                                                                    "start": 4116,
+                                                                                    "end": 4120,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 110,
@@ -5722,8 +5722,8 @@
                                                                                 "arguments": [
                                                                                   {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 4165,
-                                                                                    "end": 4188,
+                                                                                    "start": 4121,
+                                                                                    "end": 4144,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 110,
@@ -5736,8 +5736,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "MemberExpression",
-                                                                                      "start": 4165,
-                                                                                      "end": 4183,
+                                                                                      "start": 4121,
+                                                                                      "end": 4139,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 110,
@@ -5750,8 +5750,8 @@
                                                                                       },
                                                                                       "object": {
                                                                                         "type": "MemberExpression",
-                                                                                        "start": 4165,
-                                                                                        "end": 4176,
+                                                                                        "start": 4121,
+                                                                                        "end": 4132,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 110,
@@ -5764,8 +5764,8 @@
                                                                                         },
                                                                                         "object": {
                                                                                           "type": "Identifier",
-                                                                                          "start": 4165,
-                                                                                          "end": 4170,
+                                                                                          "start": 4121,
+                                                                                          "end": 4126,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 110,
@@ -5781,8 +5781,8 @@
                                                                                         },
                                                                                         "property": {
                                                                                           "type": "Identifier",
-                                                                                          "start": 4171,
-                                                                                          "end": 4176,
+                                                                                          "start": 4127,
+                                                                                          "end": 4132,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 110,
@@ -5800,8 +5800,8 @@
                                                                                       },
                                                                                       "property": {
                                                                                         "type": "Identifier",
-                                                                                        "start": 4177,
-                                                                                        "end": 4183,
+                                                                                        "start": 4133,
+                                                                                        "end": 4139,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 110,
@@ -5819,8 +5819,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 4184,
-                                                                                      "end": 4188,
+                                                                                      "start": 4140,
+                                                                                      "end": 4144,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 110,
@@ -5844,7 +5844,7 @@
                                                                             },
                                                                             "extra": {
                                                                               "parenthesized": true,
-                                                                              "parenStart": 4021
+                                                                              "parenStart": 3977
                                                                             }
                                                                           },
                                                                           "extra": {
@@ -5870,8 +5870,8 @@
                                         ],
                                         "test": {
                                           "type": "StringLiteral",
-                                          "start": 2860,
-                                          "end": 2868,
+                                          "start": 2816,
+                                          "end": 2824,
                                           "loc": {
                                             "start": {
                                               "line": 92,
@@ -5891,8 +5891,8 @@
                                       },
                                       {
                                         "type": "SwitchCase",
-                                        "start": 4311,
-                                        "end": 5427,
+                                        "start": 4267,
+                                        "end": 5383,
                                         "loc": {
                                           "start": {
                                             "line": 114,
@@ -5906,8 +5906,8 @@
                                         "consequent": [
                                           {
                                             "type": "ReturnStatement",
-                                            "start": 4346,
-                                            "end": 5427,
+                                            "start": 4302,
+                                            "end": 5383,
                                             "loc": {
                                               "start": {
                                                 "line": 115,
@@ -5920,8 +5920,8 @@
                                             },
                                             "argument": {
                                               "type": "ObjectExpression",
-                                              "start": 4353,
-                                              "end": 5427,
+                                              "start": 4309,
+                                              "end": 5383,
                                               "loc": {
                                                 "start": {
                                                   "line": 115,
@@ -5935,8 +5935,8 @@
                                               "properties": [
                                                 {
                                                   "type": "ObjectProperty",
-                                                  "start": 4379,
-                                                  "end": 5405,
+                                                  "start": 4335,
+                                                  "end": 5361,
                                                   "loc": {
                                                     "start": {
                                                       "line": 116,
@@ -5952,8 +5952,8 @@
                                                   "computed": true,
                                                   "key": {
                                                     "type": "Identifier",
-                                                    "start": 4380,
-                                                    "end": 4383,
+                                                    "start": 4336,
+                                                    "end": 4339,
                                                     "loc": {
                                                       "start": {
                                                         "line": 116,
@@ -5969,8 +5969,8 @@
                                                   },
                                                   "value": {
                                                     "type": "CallExpression",
-                                                    "start": 4386,
-                                                    "end": 5405,
+                                                    "start": 4342,
+                                                    "end": 5361,
                                                     "loc": {
                                                       "start": {
                                                         "line": 116,
@@ -5983,8 +5983,8 @@
                                                     },
                                                     "callee": {
                                                       "type": "MemberExpression",
-                                                      "start": 4386,
-                                                      "end": 4399,
+                                                      "start": 4342,
+                                                      "end": 4355,
                                                       "loc": {
                                                         "start": {
                                                           "line": 116,
@@ -5997,8 +5997,8 @@
                                                       },
                                                       "object": {
                                                         "type": "Identifier",
-                                                        "start": 4386,
-                                                        "end": 4392,
+                                                        "start": 4342,
+                                                        "end": 4348,
                                                         "loc": {
                                                           "start": {
                                                             "line": 116,
@@ -6014,8 +6014,8 @@
                                                       },
                                                       "property": {
                                                         "type": "Identifier",
-                                                        "start": 4393,
-                                                        "end": 4399,
+                                                        "start": 4349,
+                                                        "end": 4355,
                                                         "loc": {
                                                           "start": {
                                                             "line": 116,
@@ -6034,8 +6034,8 @@
                                                     "arguments": [
                                                       {
                                                         "type": "MemberExpression",
-                                                        "start": 4400,
-                                                        "end": 4418,
+                                                        "start": 4356,
+                                                        "end": 4374,
                                                         "loc": {
                                                           "start": {
                                                             "line": 116,
@@ -6048,8 +6048,8 @@
                                                         },
                                                         "object": {
                                                           "type": "MemberExpression",
-                                                          "start": 4400,
-                                                          "end": 4413,
+                                                          "start": 4356,
+                                                          "end": 4369,
                                                           "loc": {
                                                             "start": {
                                                               "line": 116,
@@ -6062,8 +6062,8 @@
                                                           },
                                                           "object": {
                                                             "type": "Identifier",
-                                                            "start": 4400,
-                                                            "end": 4408,
+                                                            "start": 4356,
+                                                            "end": 4364,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 116,
@@ -6079,8 +6079,8 @@
                                                           },
                                                           "property": {
                                                             "type": "Identifier",
-                                                            "start": 4409,
-                                                            "end": 4413,
+                                                            "start": 4365,
+                                                            "end": 4369,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 116,
@@ -6098,8 +6098,8 @@
                                                         },
                                                         "property": {
                                                           "type": "Identifier",
-                                                          "start": 4414,
-                                                          "end": 4417,
+                                                          "start": 4370,
+                                                          "end": 4373,
                                                           "loc": {
                                                             "start": {
                                                               "line": 116,
@@ -6117,8 +6117,8 @@
                                                       },
                                                       {
                                                         "type": "ObjectExpression",
-                                                        "start": 4420,
-                                                        "end": 5404,
+                                                        "start": 4376,
+                                                        "end": 5360,
                                                         "loc": {
                                                           "start": {
                                                             "line": 116,
@@ -6132,8 +6132,8 @@
                                                         "properties": [
                                                           {
                                                             "type": "ObjectProperty",
-                                                            "start": 4450,
-                                                            "end": 5378,
+                                                            "start": 4406,
+                                                            "end": 5334,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 117,
@@ -6149,8 +6149,8 @@
                                                             "computed": false,
                                                             "key": {
                                                               "type": "Identifier",
-                                                              "start": 4450,
-                                                              "end": 4454,
+                                                              "start": 4406,
+                                                              "end": 4410,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 117,
@@ -6166,8 +6166,8 @@
                                                             },
                                                             "value": {
                                                               "type": "CallExpression",
-                                                              "start": 4456,
-                                                              "end": 5378,
+                                                              "start": 4412,
+                                                              "end": 5334,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 117,
@@ -6180,8 +6180,8 @@
                                                               },
                                                               "callee": {
                                                                 "type": "MemberExpression",
-                                                                "start": 4456,
-                                                                "end": 4519,
+                                                                "start": 4412,
+                                                                "end": 4475,
                                                                 "loc": {
                                                                   "start": {
                                                                     "line": 117,
@@ -6194,8 +6194,8 @@
                                                                 },
                                                                 "object": {
                                                                   "type": "MemberExpression",
-                                                                  "start": 4456,
-                                                                  "end": 4479,
+                                                                  "start": 4412,
+                                                                  "end": 4435,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 117,
@@ -6208,8 +6208,8 @@
                                                                   },
                                                                   "object": {
                                                                     "type": "MemberExpression",
-                                                                    "start": 4456,
-                                                                    "end": 4474,
+                                                                    "start": 4412,
+                                                                    "end": 4430,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 117,
@@ -6222,8 +6222,8 @@
                                                                     },
                                                                     "object": {
                                                                       "type": "MemberExpression",
-                                                                      "start": 4456,
-                                                                      "end": 4469,
+                                                                      "start": 4412,
+                                                                      "end": 4425,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 117,
@@ -6236,8 +6236,8 @@
                                                                       },
                                                                       "object": {
                                                                         "type": "Identifier",
-                                                                        "start": 4456,
-                                                                        "end": 4464,
+                                                                        "start": 4412,
+                                                                        "end": 4420,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 117,
@@ -6253,8 +6253,8 @@
                                                                       },
                                                                       "property": {
                                                                         "type": "Identifier",
-                                                                        "start": 4465,
-                                                                        "end": 4469,
+                                                                        "start": 4421,
+                                                                        "end": 4425,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 117,
@@ -6272,8 +6272,8 @@
                                                                     },
                                                                     "property": {
                                                                       "type": "Identifier",
-                                                                      "start": 4470,
-                                                                      "end": 4473,
+                                                                      "start": 4426,
+                                                                      "end": 4429,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 117,
@@ -6291,8 +6291,8 @@
                                                                   },
                                                                   "property": {
                                                                     "type": "Identifier",
-                                                                    "start": 4475,
-                                                                    "end": 4479,
+                                                                    "start": 4431,
+                                                                    "end": 4435,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 117,
@@ -6310,8 +6310,8 @@
                                                                 },
                                                                 "property": {
                                                                   "type": "Identifier",
-                                                                  "start": 4513,
-                                                                  "end": 4519,
+                                                                  "start": 4469,
+                                                                  "end": 4475,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 118,
@@ -6330,8 +6330,8 @@
                                                               "arguments": [
                                                                 {
                                                                   "type": "ArrowFunctionExpression",
-                                                                  "start": 4520,
-                                                                  "end": 5377,
+                                                                  "start": 4476,
+                                                                  "end": 5333,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 118,
@@ -6349,8 +6349,8 @@
                                                                   "params": [
                                                                     {
                                                                       "type": "Identifier",
-                                                                      "start": 4520,
-                                                                      "end": 4525,
+                                                                      "start": 4476,
+                                                                      "end": 4481,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 118,
@@ -6367,8 +6367,8 @@
                                                                   ],
                                                                   "body": {
                                                                     "type": "BlockStatement",
-                                                                    "start": 4529,
-                                                                    "end": 5377,
+                                                                    "start": 4485,
+                                                                    "end": 5333,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 118,
@@ -6382,8 +6382,8 @@
                                                                     "body": [
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 4567,
-                                                                        "end": 4844,
+                                                                        "start": 4523,
+                                                                        "end": 4800,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 119,
@@ -6396,8 +6396,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "LogicalExpression",
-                                                                          "start": 4571,
-                                                                          "end": 4750,
+                                                                          "start": 4527,
+                                                                          "end": 4706,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 119,
@@ -6410,8 +6410,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "BinaryExpression",
-                                                                            "start": 4571,
-                                                                            "end": 4626,
+                                                                            "start": 4527,
+                                                                            "end": 4582,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 119,
@@ -6424,8 +6424,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 4571,
-                                                                              "end": 4612,
+                                                                              "start": 4527,
+                                                                              "end": 4568,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 119,
@@ -6438,8 +6438,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 4571,
-                                                                                "end": 4592,
+                                                                                "start": 4527,
+                                                                                "end": 4548,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 119,
@@ -6452,8 +6452,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "ThisExpression",
-                                                                                  "start": 4571,
-                                                                                  "end": 4575,
+                                                                                  "start": 4527,
+                                                                                  "end": 4531,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 119,
@@ -6467,8 +6467,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 4576,
-                                                                                  "end": 4592,
+                                                                                  "start": 4532,
+                                                                                  "end": 4548,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 119,
@@ -6486,8 +6486,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 4593,
-                                                                                "end": 4612,
+                                                                                "start": 4549,
+                                                                                "end": 4568,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 119,
@@ -6506,8 +6506,8 @@
                                                                             "operator": "!==",
                                                                             "right": {
                                                                               "type": "Identifier",
-                                                                              "start": 4617,
-                                                                              "end": 4626,
+                                                                              "start": 4573,
+                                                                              "end": 4582,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 119,
@@ -6525,8 +6525,8 @@
                                                                           "operator": "&&",
                                                                           "right": {
                                                                             "type": "UnaryExpression",
-                                                                            "start": 4670,
-                                                                            "end": 4750,
+                                                                            "start": 4626,
+                                                                            "end": 4706,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 120,
@@ -6541,8 +6541,8 @@
                                                                             "prefix": true,
                                                                             "argument": {
                                                                               "type": "CallExpression",
-                                                                              "start": 4671,
-                                                                              "end": 4750,
+                                                                              "start": 4627,
+                                                                              "end": 4706,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 120,
@@ -6555,8 +6555,8 @@
                                                                               },
                                                                               "callee": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 4671,
-                                                                                "end": 4707,
+                                                                                "start": 4627,
+                                                                                "end": 4663,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 120,
@@ -6569,8 +6569,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 4671,
-                                                                                  "end": 4698,
+                                                                                  "start": 4627,
+                                                                                  "end": 4654,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 120,
@@ -6583,8 +6583,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4671,
-                                                                                    "end": 4676,
+                                                                                    "start": 4627,
+                                                                                    "end": 4632,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 120,
@@ -6600,8 +6600,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4677,
-                                                                                    "end": 4698,
+                                                                                    "start": 4633,
+                                                                                    "end": 4654,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 120,
@@ -6619,8 +6619,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 4699,
-                                                                                  "end": 4707,
+                                                                                  "start": 4655,
+                                                                                  "end": 4663,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 120,
@@ -6639,8 +6639,8 @@
                                                                               "arguments": [
                                                                                 {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 4708,
-                                                                                  "end": 4749,
+                                                                                  "start": 4664,
+                                                                                  "end": 4705,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 120,
@@ -6653,8 +6653,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 4708,
-                                                                                    "end": 4729,
+                                                                                    "start": 4664,
+                                                                                    "end": 4685,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 120,
@@ -6667,8 +6667,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "ThisExpression",
-                                                                                      "start": 4708,
-                                                                                      "end": 4712,
+                                                                                      "start": 4664,
+                                                                                      "end": 4668,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 120,
@@ -6682,8 +6682,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 4713,
-                                                                                      "end": 4729,
+                                                                                      "start": 4669,
+                                                                                      "end": 4685,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 120,
@@ -6701,8 +6701,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4730,
-                                                                                    "end": 4749,
+                                                                                    "start": 4686,
+                                                                                    "end": 4705,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 120,
@@ -6727,8 +6727,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 4752,
-                                                                          "end": 4844,
+                                                                          "start": 4708,
+                                                                          "end": 4800,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 120,
@@ -6742,8 +6742,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 4794,
-                                                                              "end": 4806,
+                                                                              "start": 4750,
+                                                                              "end": 4762,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 121,
@@ -6756,8 +6756,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 4801,
-                                                                                "end": 4806,
+                                                                                "start": 4757,
+                                                                                "end": 4762,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 121,
@@ -6778,8 +6778,8 @@
                                                                       },
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 4881,
-                                                                        "end": 5135,
+                                                                        "start": 4837,
+                                                                        "end": 5091,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 123,
@@ -6792,8 +6792,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "LogicalExpression",
-                                                                          "start": 4885,
-                                                                          "end": 5041,
+                                                                          "start": 4841,
+                                                                          "end": 4997,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 123,
@@ -6806,8 +6806,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "BinaryExpression",
-                                                                            "start": 4885,
-                                                                            "end": 4926,
+                                                                            "start": 4841,
+                                                                            "end": 4882,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 123,
@@ -6820,8 +6820,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 4885,
-                                                                              "end": 4912,
+                                                                              "start": 4841,
+                                                                              "end": 4868,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 123,
@@ -6834,8 +6834,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 4885,
-                                                                                "end": 4906,
+                                                                                "start": 4841,
+                                                                                "end": 4862,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 123,
@@ -6848,8 +6848,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "ThisExpression",
-                                                                                  "start": 4885,
-                                                                                  "end": 4889,
+                                                                                  "start": 4841,
+                                                                                  "end": 4845,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 123,
@@ -6863,8 +6863,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 4890,
-                                                                                  "end": 4906,
+                                                                                  "start": 4846,
+                                                                                  "end": 4862,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 123,
@@ -6882,8 +6882,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 4907,
-                                                                                "end": 4912,
+                                                                                "start": 4863,
+                                                                                "end": 4868,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 123,
@@ -6902,8 +6902,8 @@
                                                                             "operator": "!==",
                                                                             "right": {
                                                                               "type": "Identifier",
-                                                                              "start": 4917,
-                                                                              "end": 4926,
+                                                                              "start": 4873,
+                                                                              "end": 4882,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 123,
@@ -6921,8 +6921,8 @@
                                                                           "operator": "&&",
                                                                           "right": {
                                                                             "type": "UnaryExpression",
-                                                                            "start": 4970,
-                                                                            "end": 5041,
+                                                                            "start": 4926,
+                                                                            "end": 4997,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 124,
@@ -6937,8 +6937,8 @@
                                                                             "prefix": true,
                                                                             "argument": {
                                                                               "type": "CallExpression",
-                                                                              "start": 4971,
-                                                                              "end": 5041,
+                                                                              "start": 4927,
+                                                                              "end": 4997,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 124,
@@ -6951,8 +6951,8 @@
                                                                               },
                                                                               "callee": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 4971,
-                                                                                "end": 5029,
+                                                                                "start": 4927,
+                                                                                "end": 4985,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 124,
@@ -6965,8 +6965,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "NewExpression",
-                                                                                  "start": 4971,
-                                                                                  "end": 5024,
+                                                                                  "start": 4927,
+                                                                                  "end": 4980,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 124,
@@ -6979,8 +6979,8 @@
                                                                                   },
                                                                                   "callee": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 4975,
-                                                                                    "end": 4981,
+                                                                                    "start": 4931,
+                                                                                    "end": 4937,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 124,
@@ -6997,8 +6997,8 @@
                                                                                   "arguments": [
                                                                                     {
                                                                                       "type": "BinaryExpression",
-                                                                                      "start": 4982,
-                                                                                      "end": 5023,
+                                                                                      "start": 4938,
+                                                                                      "end": 4979,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 124,
@@ -7011,8 +7011,8 @@
                                                                                       },
                                                                                       "left": {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 4982,
-                                                                                        "end": 5016,
+                                                                                        "start": 4938,
+                                                                                        "end": 4972,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 124,
@@ -7025,8 +7025,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 4982,
-                                                                                          "end": 4986,
+                                                                                          "start": 4938,
+                                                                                          "end": 4942,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 124,
@@ -7046,8 +7046,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "MemberExpression",
-                                                                                          "start": 4989,
-                                                                                          "end": 5016,
+                                                                                          "start": 4945,
+                                                                                          "end": 4972,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 124,
@@ -7060,8 +7060,8 @@
                                                                                           },
                                                                                           "object": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 4989,
-                                                                                            "end": 5010,
+                                                                                            "start": 4945,
+                                                                                            "end": 4966,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 124,
@@ -7074,8 +7074,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "ThisExpression",
-                                                                                              "start": 4989,
-                                                                                              "end": 4993,
+                                                                                              "start": 4945,
+                                                                                              "end": 4949,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 124,
@@ -7089,8 +7089,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 4994,
-                                                                                              "end": 5010,
+                                                                                              "start": 4950,
+                                                                                              "end": 4966,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 124,
@@ -7108,8 +7108,8 @@
                                                                                           },
                                                                                           "property": {
                                                                                             "type": "Identifier",
-                                                                                            "start": 5011,
-                                                                                            "end": 5016,
+                                                                                            "start": 4967,
+                                                                                            "end": 4972,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 124,
@@ -7129,8 +7129,8 @@
                                                                                       "operator": "+",
                                                                                       "right": {
                                                                                         "type": "StringLiteral",
-                                                                                        "start": 5019,
-                                                                                        "end": 5023,
+                                                                                        "start": 4975,
+                                                                                        "end": 4979,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 124,
@@ -7152,8 +7152,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 5025,
-                                                                                  "end": 5029,
+                                                                                  "start": 4981,
+                                                                                  "end": 4985,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 124,
@@ -7172,8 +7172,8 @@
                                                                               "arguments": [
                                                                                 {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 5030,
-                                                                                  "end": 5040,
+                                                                                  "start": 4986,
+                                                                                  "end": 4996,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 124,
@@ -7186,8 +7186,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 5030,
-                                                                                    "end": 5035,
+                                                                                    "start": 4986,
+                                                                                    "end": 4991,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 124,
@@ -7203,8 +7203,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 5036,
-                                                                                    "end": 5040,
+                                                                                    "start": 4992,
+                                                                                    "end": 4996,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 124,
@@ -7229,8 +7229,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 5043,
-                                                                          "end": 5135,
+                                                                          "start": 4999,
+                                                                          "end": 5091,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 124,
@@ -7244,8 +7244,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 5085,
-                                                                              "end": 5097,
+                                                                              "start": 5041,
+                                                                              "end": 5053,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 125,
@@ -7258,8 +7258,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 5092,
-                                                                                "end": 5097,
+                                                                                "start": 5048,
+                                                                                "end": 5053,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 125,
@@ -7280,8 +7280,8 @@
                                                                       },
                                                                       {
                                                                         "type": "ReturnStatement",
-                                                                        "start": 5172,
-                                                                        "end": 5343,
+                                                                        "start": 5128,
+                                                                        "end": 5299,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 127,
@@ -7294,8 +7294,8 @@
                                                                         },
                                                                         "argument": {
                                                                           "type": "UnaryExpression",
-                                                                          "start": 5179,
-                                                                          "end": 5343,
+                                                                          "start": 5135,
+                                                                          "end": 5299,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 127,
@@ -7310,8 +7310,8 @@
                                                                           "prefix": true,
                                                                           "argument": {
                                                                             "type": "LogicalExpression",
-                                                                            "start": 5181,
-                                                                            "end": 5342,
+                                                                            "start": 5137,
+                                                                            "end": 5298,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 127,
@@ -7324,8 +7324,8 @@
                                                                             },
                                                                             "left": {
                                                                               "type": "BinaryExpression",
-                                                                              "start": 5181,
-                                                                              "end": 5223,
+                                                                              "start": 5137,
+                                                                              "end": 5179,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 127,
@@ -7338,8 +7338,8 @@
                                                                               },
                                                                               "left": {
                                                                                 "type": "MemberExpression",
-                                                                                "start": 5181,
-                                                                                "end": 5209,
+                                                                                "start": 5137,
+                                                                                "end": 5165,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 127,
@@ -7352,8 +7352,8 @@
                                                                                 },
                                                                                 "object": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 5181,
-                                                                                  "end": 5202,
+                                                                                  "start": 5137,
+                                                                                  "end": 5158,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 127,
@@ -7366,8 +7366,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "ThisExpression",
-                                                                                    "start": 5181,
-                                                                                    "end": 5185,
+                                                                                    "start": 5137,
+                                                                                    "end": 5141,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 127,
@@ -7381,8 +7381,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 5186,
-                                                                                    "end": 5202,
+                                                                                    "start": 5142,
+                                                                                    "end": 5158,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 127,
@@ -7400,8 +7400,8 @@
                                                                                 },
                                                                                 "property": {
                                                                                   "type": "Identifier",
-                                                                                  "start": 5203,
-                                                                                  "end": 5209,
+                                                                                  "start": 5159,
+                                                                                  "end": 5165,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 127,
@@ -7420,8 +7420,8 @@
                                                                               "operator": "!==",
                                                                               "right": {
                                                                                 "type": "Identifier",
-                                                                                "start": 5214,
-                                                                                "end": 5223,
+                                                                                "start": 5170,
+                                                                                "end": 5179,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 127,
@@ -7439,8 +7439,8 @@
                                                                             "operator": "&&",
                                                                             "right": {
                                                                               "type": "UnaryExpression",
-                                                                              "start": 5263,
-                                                                              "end": 5342,
+                                                                              "start": 5219,
+                                                                              "end": 5298,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 128,
@@ -7455,8 +7455,8 @@
                                                                               "prefix": true,
                                                                               "argument": {
                                                                                 "type": "CallExpression",
-                                                                                "start": 5264,
-                                                                                "end": 5342,
+                                                                                "start": 5220,
+                                                                                "end": 5298,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 128,
@@ -7469,8 +7469,8 @@
                                                                                 },
                                                                                 "callee": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 5264,
-                                                                                  "end": 5323,
+                                                                                  "start": 5220,
+                                                                                  "end": 5279,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 128,
@@ -7483,8 +7483,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "NewExpression",
-                                                                                    "start": 5264,
-                                                                                    "end": 5318,
+                                                                                    "start": 5220,
+                                                                                    "end": 5274,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 128,
@@ -7497,8 +7497,8 @@
                                                                                     },
                                                                                     "callee": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 5268,
-                                                                                      "end": 5274,
+                                                                                      "start": 5224,
+                                                                                      "end": 5230,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 128,
@@ -7515,8 +7515,8 @@
                                                                                     "arguments": [
                                                                                       {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 5275,
-                                                                                        "end": 5317,
+                                                                                        "start": 5231,
+                                                                                        "end": 5273,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 128,
@@ -7529,8 +7529,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "BinaryExpression",
-                                                                                          "start": 5275,
-                                                                                          "end": 5310,
+                                                                                          "start": 5231,
+                                                                                          "end": 5266,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 128,
@@ -7543,8 +7543,8 @@
                                                                                           },
                                                                                           "left": {
                                                                                             "type": "StringLiteral",
-                                                                                            "start": 5275,
-                                                                                            "end": 5279,
+                                                                                            "start": 5231,
+                                                                                            "end": 5235,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 128,
@@ -7564,8 +7564,8 @@
                                                                                           "operator": "+",
                                                                                           "right": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 5282,
-                                                                                            "end": 5310,
+                                                                                            "start": 5238,
+                                                                                            "end": 5266,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 128,
@@ -7578,8 +7578,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "MemberExpression",
-                                                                                              "start": 5282,
-                                                                                              "end": 5303,
+                                                                                              "start": 5238,
+                                                                                              "end": 5259,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 128,
@@ -7592,8 +7592,8 @@
                                                                                               },
                                                                                               "object": {
                                                                                                 "type": "ThisExpression",
-                                                                                                "start": 5282,
-                                                                                                "end": 5286,
+                                                                                                "start": 5238,
+                                                                                                "end": 5242,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 128,
@@ -7607,8 +7607,8 @@
                                                                                               },
                                                                                               "property": {
                                                                                                 "type": "Identifier",
-                                                                                                "start": 5287,
-                                                                                                "end": 5303,
+                                                                                                "start": 5243,
+                                                                                                "end": 5259,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 128,
@@ -7626,8 +7626,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 5304,
-                                                                                              "end": 5310,
+                                                                                              "start": 5260,
+                                                                                              "end": 5266,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 128,
@@ -7647,8 +7647,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 5313,
-                                                                                          "end": 5317,
+                                                                                          "start": 5269,
+                                                                                          "end": 5273,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 128,
@@ -7670,8 +7670,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 5319,
-                                                                                    "end": 5323,
+                                                                                    "start": 5275,
+                                                                                    "end": 5279,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 128,
@@ -7690,8 +7690,8 @@
                                                                                 "arguments": [
                                                                                   {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 5324,
-                                                                                    "end": 5341,
+                                                                                    "start": 5280,
+                                                                                    "end": 5297,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 128,
@@ -7704,8 +7704,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "MemberExpression",
-                                                                                      "start": 5324,
-                                                                                      "end": 5336,
+                                                                                      "start": 5280,
+                                                                                      "end": 5292,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 128,
@@ -7718,8 +7718,8 @@
                                                                                       },
                                                                                       "object": {
                                                                                         "type": "Identifier",
-                                                                                        "start": 5324,
-                                                                                        "end": 5329,
+                                                                                        "start": 5280,
+                                                                                        "end": 5285,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 128,
@@ -7735,8 +7735,8 @@
                                                                                       },
                                                                                       "property": {
                                                                                         "type": "Identifier",
-                                                                                        "start": 5330,
-                                                                                        "end": 5336,
+                                                                                        "start": 5286,
+                                                                                        "end": 5292,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 128,
@@ -7754,8 +7754,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 5337,
-                                                                                      "end": 5341,
+                                                                                      "start": 5293,
+                                                                                      "end": 5297,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 128,
@@ -7779,7 +7779,7 @@
                                                                             },
                                                                             "extra": {
                                                                               "parenthesized": true,
-                                                                              "parenStart": 5180
+                                                                              "parenStart": 5136
                                                                             }
                                                                           },
                                                                           "extra": {
@@ -7805,8 +7805,8 @@
                                         ],
                                         "test": {
                                           "type": "StringLiteral",
-                                          "start": 4316,
-                                          "end": 4324,
+                                          "start": 4272,
+                                          "end": 4280,
                                           "loc": {
                                             "start": {
                                               "line": 114,
@@ -7826,8 +7826,8 @@
                                       },
                                       {
                                         "type": "SwitchCase",
-                                        "start": 5464,
-                                        "end": 6110,
+                                        "start": 5420,
+                                        "end": 6066,
                                         "loc": {
                                           "start": {
                                             "line": 132,
@@ -7841,8 +7841,8 @@
                                         "consequent": [
                                           {
                                             "type": "ReturnStatement",
-                                            "start": 5500,
-                                            "end": 6110,
+                                            "start": 5456,
+                                            "end": 6066,
                                             "loc": {
                                               "start": {
                                                 "line": 133,
@@ -7855,8 +7855,8 @@
                                             },
                                             "argument": {
                                               "type": "ObjectExpression",
-                                              "start": 5507,
-                                              "end": 6110,
+                                              "start": 5463,
+                                              "end": 6066,
                                               "loc": {
                                                 "start": {
                                                   "line": 133,
@@ -7870,8 +7870,8 @@
                                               "properties": [
                                                 {
                                                   "type": "ObjectProperty",
-                                                  "start": 5533,
-                                                  "end": 6088,
+                                                  "start": 5489,
+                                                  "end": 6044,
                                                   "loc": {
                                                     "start": {
                                                       "line": 134,
@@ -7887,8 +7887,8 @@
                                                   "computed": true,
                                                   "key": {
                                                     "type": "Identifier",
-                                                    "start": 5534,
-                                                    "end": 5537,
+                                                    "start": 5490,
+                                                    "end": 5493,
                                                     "loc": {
                                                       "start": {
                                                         "line": 134,
@@ -7904,8 +7904,8 @@
                                                   },
                                                   "value": {
                                                     "type": "CallExpression",
-                                                    "start": 5540,
-                                                    "end": 6088,
+                                                    "start": 5496,
+                                                    "end": 6044,
                                                     "loc": {
                                                       "start": {
                                                         "line": 134,
@@ -7918,8 +7918,8 @@
                                                     },
                                                     "callee": {
                                                       "type": "MemberExpression",
-                                                      "start": 5540,
-                                                      "end": 5553,
+                                                      "start": 5496,
+                                                      "end": 5509,
                                                       "loc": {
                                                         "start": {
                                                           "line": 134,
@@ -7932,8 +7932,8 @@
                                                       },
                                                       "object": {
                                                         "type": "Identifier",
-                                                        "start": 5540,
-                                                        "end": 5546,
+                                                        "start": 5496,
+                                                        "end": 5502,
                                                         "loc": {
                                                           "start": {
                                                             "line": 134,
@@ -7949,8 +7949,8 @@
                                                       },
                                                       "property": {
                                                         "type": "Identifier",
-                                                        "start": 5547,
-                                                        "end": 5553,
+                                                        "start": 5503,
+                                                        "end": 5509,
                                                         "loc": {
                                                           "start": {
                                                             "line": 134,
@@ -7969,8 +7969,8 @@
                                                     "arguments": [
                                                       {
                                                         "type": "MemberExpression",
-                                                        "start": 5554,
-                                                        "end": 5572,
+                                                        "start": 5510,
+                                                        "end": 5528,
                                                         "loc": {
                                                           "start": {
                                                             "line": 134,
@@ -7983,8 +7983,8 @@
                                                         },
                                                         "object": {
                                                           "type": "MemberExpression",
-                                                          "start": 5554,
-                                                          "end": 5567,
+                                                          "start": 5510,
+                                                          "end": 5523,
                                                           "loc": {
                                                             "start": {
                                                               "line": 134,
@@ -7997,8 +7997,8 @@
                                                           },
                                                           "object": {
                                                             "type": "Identifier",
-                                                            "start": 5554,
-                                                            "end": 5562,
+                                                            "start": 5510,
+                                                            "end": 5518,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 134,
@@ -8014,8 +8014,8 @@
                                                           },
                                                           "property": {
                                                             "type": "Identifier",
-                                                            "start": 5563,
-                                                            "end": 5567,
+                                                            "start": 5519,
+                                                            "end": 5523,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 134,
@@ -8033,8 +8033,8 @@
                                                         },
                                                         "property": {
                                                           "type": "Identifier",
-                                                          "start": 5568,
-                                                          "end": 5571,
+                                                          "start": 5524,
+                                                          "end": 5527,
                                                           "loc": {
                                                             "start": {
                                                               "line": 134,
@@ -8052,8 +8052,8 @@
                                                       },
                                                       {
                                                         "type": "ObjectExpression",
-                                                        "start": 5574,
-                                                        "end": 6087,
+                                                        "start": 5530,
+                                                        "end": 6043,
                                                         "loc": {
                                                           "start": {
                                                             "line": 134,
@@ -8067,8 +8067,8 @@
                                                         "properties": [
                                                           {
                                                             "type": "ObjectProperty",
-                                                            "start": 5604,
-                                                            "end": 6061,
+                                                            "start": 5560,
+                                                            "end": 6017,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 135,
@@ -8084,8 +8084,8 @@
                                                             "computed": false,
                                                             "key": {
                                                               "type": "Identifier",
-                                                              "start": 5604,
-                                                              "end": 5608,
+                                                              "start": 5560,
+                                                              "end": 5564,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 135,
@@ -8101,8 +8101,8 @@
                                                             },
                                                             "value": {
                                                               "type": "CallExpression",
-                                                              "start": 5610,
-                                                              "end": 6061,
+                                                              "start": 5566,
+                                                              "end": 6017,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 135,
@@ -8115,8 +8115,8 @@
                                                               },
                                                               "callee": {
                                                                 "type": "MemberExpression",
-                                                                "start": 5610,
-                                                                "end": 5673,
+                                                                "start": 5566,
+                                                                "end": 5629,
                                                                 "loc": {
                                                                   "start": {
                                                                     "line": 135,
@@ -8129,8 +8129,8 @@
                                                                 },
                                                                 "object": {
                                                                   "type": "MemberExpression",
-                                                                  "start": 5610,
-                                                                  "end": 5633,
+                                                                  "start": 5566,
+                                                                  "end": 5589,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 135,
@@ -8143,8 +8143,8 @@
                                                                   },
                                                                   "object": {
                                                                     "type": "MemberExpression",
-                                                                    "start": 5610,
-                                                                    "end": 5628,
+                                                                    "start": 5566,
+                                                                    "end": 5584,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 135,
@@ -8157,8 +8157,8 @@
                                                                     },
                                                                     "object": {
                                                                       "type": "MemberExpression",
-                                                                      "start": 5610,
-                                                                      "end": 5623,
+                                                                      "start": 5566,
+                                                                      "end": 5579,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 135,
@@ -8171,8 +8171,8 @@
                                                                       },
                                                                       "object": {
                                                                         "type": "Identifier",
-                                                                        "start": 5610,
-                                                                        "end": 5618,
+                                                                        "start": 5566,
+                                                                        "end": 5574,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 135,
@@ -8188,8 +8188,8 @@
                                                                       },
                                                                       "property": {
                                                                         "type": "Identifier",
-                                                                        "start": 5619,
-                                                                        "end": 5623,
+                                                                        "start": 5575,
+                                                                        "end": 5579,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 135,
@@ -8207,8 +8207,8 @@
                                                                     },
                                                                     "property": {
                                                                       "type": "Identifier",
-                                                                      "start": 5624,
-                                                                      "end": 5627,
+                                                                      "start": 5580,
+                                                                      "end": 5583,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 135,
@@ -8226,8 +8226,8 @@
                                                                   },
                                                                   "property": {
                                                                     "type": "Identifier",
-                                                                    "start": 5629,
-                                                                    "end": 5633,
+                                                                    "start": 5585,
+                                                                    "end": 5589,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 135,
@@ -8245,8 +8245,8 @@
                                                                 },
                                                                 "property": {
                                                                   "type": "Identifier",
-                                                                  "start": 5667,
-                                                                  "end": 5673,
+                                                                  "start": 5623,
+                                                                  "end": 5629,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 136,
@@ -8265,8 +8265,8 @@
                                                               "arguments": [
                                                                 {
                                                                   "type": "ArrowFunctionExpression",
-                                                                  "start": 5674,
-                                                                  "end": 6060,
+                                                                  "start": 5630,
+                                                                  "end": 6016,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 136,
@@ -8284,8 +8284,8 @@
                                                                   "params": [
                                                                     {
                                                                       "type": "Identifier",
-                                                                      "start": 5674,
-                                                                      "end": 5680,
+                                                                      "start": 5630,
+                                                                      "end": 5636,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 136,
@@ -8302,8 +8302,8 @@
                                                                   ],
                                                                   "body": {
                                                                     "type": "BlockStatement",
-                                                                    "start": 5684,
-                                                                    "end": 6060,
+                                                                    "start": 5640,
+                                                                    "end": 6016,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 136,
@@ -8317,8 +8317,8 @@
                                                                     "body": [
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 5722,
-                                                                        "end": 6026,
+                                                                        "start": 5678,
+                                                                        "end": 5982,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 137,
@@ -8331,8 +8331,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "BinaryExpression",
-                                                                          "start": 5726,
-                                                                          "end": 5768,
+                                                                          "start": 5682,
+                                                                          "end": 5724,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 137,
@@ -8345,8 +8345,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "MemberExpression",
-                                                                            "start": 5726,
-                                                                            "end": 5754,
+                                                                            "start": 5682,
+                                                                            "end": 5710,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 137,
@@ -8359,8 +8359,8 @@
                                                                             },
                                                                             "object": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 5726,
-                                                                              "end": 5747,
+                                                                              "start": 5682,
+                                                                              "end": 5703,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 137,
@@ -8373,8 +8373,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "ThisExpression",
-                                                                                "start": 5726,
-                                                                                "end": 5730,
+                                                                                "start": 5682,
+                                                                                "end": 5686,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 137,
@@ -8388,8 +8388,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 5731,
-                                                                                "end": 5747,
+                                                                                "start": 5687,
+                                                                                "end": 5703,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 137,
@@ -8407,8 +8407,8 @@
                                                                             },
                                                                             "property": {
                                                                               "type": "Identifier",
-                                                                              "start": 5748,
-                                                                              "end": 5754,
+                                                                              "start": 5704,
+                                                                              "end": 5710,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 137,
@@ -8427,8 +8427,8 @@
                                                                           "operator": "===",
                                                                           "right": {
                                                                             "type": "Identifier",
-                                                                            "start": 5759,
-                                                                            "end": 5768,
+                                                                            "start": 5715,
+                                                                            "end": 5724,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 137,
@@ -8445,8 +8445,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 5770,
-                                                                          "end": 5861,
+                                                                          "start": 5726,
+                                                                          "end": 5817,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 137,
@@ -8460,8 +8460,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 5812,
-                                                                              "end": 5823,
+                                                                              "start": 5768,
+                                                                              "end": 5779,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 138,
@@ -8474,8 +8474,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 5819,
-                                                                                "end": 5823,
+                                                                                "start": 5775,
+                                                                                "end": 5779,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 138,
@@ -8494,8 +8494,8 @@
                                                                         },
                                                                         "alternate": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 5867,
-                                                                          "end": 6026,
+                                                                          "start": 5823,
+                                                                          "end": 5982,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 139,
@@ -8509,8 +8509,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 5909,
-                                                                              "end": 5988,
+                                                                              "start": 5865,
+                                                                              "end": 5944,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 140,
@@ -8523,8 +8523,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "CallExpression",
-                                                                                "start": 5916,
-                                                                                "end": 5988,
+                                                                                "start": 5872,
+                                                                                "end": 5944,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 140,
@@ -8537,8 +8537,8 @@
                                                                                 },
                                                                                 "callee": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 5916,
-                                                                                  "end": 5975,
+                                                                                  "start": 5872,
+                                                                                  "end": 5931,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 140,
@@ -8551,8 +8551,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "NewExpression",
-                                                                                    "start": 5916,
-                                                                                    "end": 5970,
+                                                                                    "start": 5872,
+                                                                                    "end": 5926,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 140,
@@ -8565,8 +8565,8 @@
                                                                                     },
                                                                                     "callee": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 5920,
-                                                                                      "end": 5926,
+                                                                                      "start": 5876,
+                                                                                      "end": 5882,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 140,
@@ -8583,8 +8583,8 @@
                                                                                     "arguments": [
                                                                                       {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 5927,
-                                                                                        "end": 5969,
+                                                                                        "start": 5883,
+                                                                                        "end": 5925,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 140,
@@ -8597,8 +8597,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "BinaryExpression",
-                                                                                          "start": 5927,
-                                                                                          "end": 5962,
+                                                                                          "start": 5883,
+                                                                                          "end": 5918,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 140,
@@ -8611,8 +8611,8 @@
                                                                                           },
                                                                                           "left": {
                                                                                             "type": "StringLiteral",
-                                                                                            "start": 5927,
-                                                                                            "end": 5931,
+                                                                                            "start": 5883,
+                                                                                            "end": 5887,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 140,
@@ -8632,8 +8632,8 @@
                                                                                           "operator": "+",
                                                                                           "right": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 5934,
-                                                                                            "end": 5962,
+                                                                                            "start": 5890,
+                                                                                            "end": 5918,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 140,
@@ -8646,8 +8646,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "MemberExpression",
-                                                                                              "start": 5934,
-                                                                                              "end": 5955,
+                                                                                              "start": 5890,
+                                                                                              "end": 5911,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 140,
@@ -8660,8 +8660,8 @@
                                                                                               },
                                                                                               "object": {
                                                                                                 "type": "ThisExpression",
-                                                                                                "start": 5934,
-                                                                                                "end": 5938,
+                                                                                                "start": 5890,
+                                                                                                "end": 5894,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 140,
@@ -8675,8 +8675,8 @@
                                                                                               },
                                                                                               "property": {
                                                                                                 "type": "Identifier",
-                                                                                                "start": 5939,
-                                                                                                "end": 5955,
+                                                                                                "start": 5895,
+                                                                                                "end": 5911,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 140,
@@ -8694,8 +8694,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 5956,
-                                                                                              "end": 5962,
+                                                                                              "start": 5912,
+                                                                                              "end": 5918,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 140,
@@ -8715,8 +8715,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 5965,
-                                                                                          "end": 5969,
+                                                                                          "start": 5921,
+                                                                                          "end": 5925,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 140,
@@ -8738,8 +8738,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 5971,
-                                                                                    "end": 5975,
+                                                                                    "start": 5927,
+                                                                                    "end": 5931,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 140,
@@ -8758,8 +8758,8 @@
                                                                                 "arguments": [
                                                                                   {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 5976,
-                                                                                    "end": 5987,
+                                                                                    "start": 5932,
+                                                                                    "end": 5943,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 140,
@@ -8772,8 +8772,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 5976,
-                                                                                      "end": 5982,
+                                                                                      "start": 5932,
+                                                                                      "end": 5938,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 140,
@@ -8789,8 +8789,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 5983,
-                                                                                      "end": 5987,
+                                                                                      "start": 5939,
+                                                                                      "end": 5943,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 140,
@@ -8831,8 +8831,8 @@
                                         ],
                                         "test": {
                                           "type": "StringLiteral",
-                                          "start": 5469,
-                                          "end": 5478,
+                                          "start": 5425,
+                                          "end": 5434,
                                           "loc": {
                                             "start": {
                                               "line": 132,
@@ -8852,8 +8852,8 @@
                                       },
                                       {
                                         "type": "SwitchCase",
-                                        "start": 6147,
-                                        "end": 6804,
+                                        "start": 6103,
+                                        "end": 6760,
                                         "loc": {
                                           "start": {
                                             "line": 145,
@@ -8867,8 +8867,8 @@
                                         "consequent": [
                                           {
                                             "type": "ReturnStatement",
-                                            "start": 6185,
-                                            "end": 6804,
+                                            "start": 6141,
+                                            "end": 6760,
                                             "loc": {
                                               "start": {
                                                 "line": 146,
@@ -8881,8 +8881,8 @@
                                             },
                                             "argument": {
                                               "type": "ObjectExpression",
-                                              "start": 6192,
-                                              "end": 6804,
+                                              "start": 6148,
+                                              "end": 6760,
                                               "loc": {
                                                 "start": {
                                                   "line": 146,
@@ -8896,8 +8896,8 @@
                                               "properties": [
                                                 {
                                                   "type": "ObjectProperty",
-                                                  "start": 6218,
-                                                  "end": 6782,
+                                                  "start": 6174,
+                                                  "end": 6738,
                                                   "loc": {
                                                     "start": {
                                                       "line": 147,
@@ -8913,8 +8913,8 @@
                                                   "computed": true,
                                                   "key": {
                                                     "type": "Identifier",
-                                                    "start": 6219,
-                                                    "end": 6222,
+                                                    "start": 6175,
+                                                    "end": 6178,
                                                     "loc": {
                                                       "start": {
                                                         "line": 147,
@@ -8930,8 +8930,8 @@
                                                   },
                                                   "value": {
                                                     "type": "CallExpression",
-                                                    "start": 6225,
-                                                    "end": 6782,
+                                                    "start": 6181,
+                                                    "end": 6738,
                                                     "loc": {
                                                       "start": {
                                                         "line": 147,
@@ -8944,8 +8944,8 @@
                                                     },
                                                     "callee": {
                                                       "type": "MemberExpression",
-                                                      "start": 6225,
-                                                      "end": 6238,
+                                                      "start": 6181,
+                                                      "end": 6194,
                                                       "loc": {
                                                         "start": {
                                                           "line": 147,
@@ -8958,8 +8958,8 @@
                                                       },
                                                       "object": {
                                                         "type": "Identifier",
-                                                        "start": 6225,
-                                                        "end": 6231,
+                                                        "start": 6181,
+                                                        "end": 6187,
                                                         "loc": {
                                                           "start": {
                                                             "line": 147,
@@ -8975,8 +8975,8 @@
                                                       },
                                                       "property": {
                                                         "type": "Identifier",
-                                                        "start": 6232,
-                                                        "end": 6238,
+                                                        "start": 6188,
+                                                        "end": 6194,
                                                         "loc": {
                                                           "start": {
                                                             "line": 147,
@@ -8995,8 +8995,8 @@
                                                     "arguments": [
                                                       {
                                                         "type": "MemberExpression",
-                                                        "start": 6239,
-                                                        "end": 6257,
+                                                        "start": 6195,
+                                                        "end": 6213,
                                                         "loc": {
                                                           "start": {
                                                             "line": 147,
@@ -9009,8 +9009,8 @@
                                                         },
                                                         "object": {
                                                           "type": "MemberExpression",
-                                                          "start": 6239,
-                                                          "end": 6252,
+                                                          "start": 6195,
+                                                          "end": 6208,
                                                           "loc": {
                                                             "start": {
                                                               "line": 147,
@@ -9023,8 +9023,8 @@
                                                           },
                                                           "object": {
                                                             "type": "Identifier",
-                                                            "start": 6239,
-                                                            "end": 6247,
+                                                            "start": 6195,
+                                                            "end": 6203,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 147,
@@ -9040,8 +9040,8 @@
                                                           },
                                                           "property": {
                                                             "type": "Identifier",
-                                                            "start": 6248,
-                                                            "end": 6252,
+                                                            "start": 6204,
+                                                            "end": 6208,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 147,
@@ -9059,8 +9059,8 @@
                                                         },
                                                         "property": {
                                                           "type": "Identifier",
-                                                          "start": 6253,
-                                                          "end": 6256,
+                                                          "start": 6209,
+                                                          "end": 6212,
                                                           "loc": {
                                                             "start": {
                                                               "line": 147,
@@ -9078,8 +9078,8 @@
                                                       },
                                                       {
                                                         "type": "ObjectExpression",
-                                                        "start": 6259,
-                                                        "end": 6781,
+                                                        "start": 6215,
+                                                        "end": 6737,
                                                         "loc": {
                                                           "start": {
                                                             "line": 147,
@@ -9093,8 +9093,8 @@
                                                         "properties": [
                                                           {
                                                             "type": "ObjectProperty",
-                                                            "start": 6289,
-                                                            "end": 6755,
+                                                            "start": 6245,
+                                                            "end": 6711,
                                                             "loc": {
                                                               "start": {
                                                                 "line": 148,
@@ -9110,8 +9110,8 @@
                                                             "computed": false,
                                                             "key": {
                                                               "type": "Identifier",
-                                                              "start": 6289,
-                                                              "end": 6293,
+                                                              "start": 6245,
+                                                              "end": 6249,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 148,
@@ -9127,8 +9127,8 @@
                                                             },
                                                             "value": {
                                                               "type": "CallExpression",
-                                                              "start": 6295,
-                                                              "end": 6755,
+                                                              "start": 6251,
+                                                              "end": 6711,
                                                               "loc": {
                                                                 "start": {
                                                                   "line": 148,
@@ -9141,8 +9141,8 @@
                                                               },
                                                               "callee": {
                                                                 "type": "MemberExpression",
-                                                                "start": 6295,
-                                                                "end": 6358,
+                                                                "start": 6251,
+                                                                "end": 6314,
                                                                 "loc": {
                                                                   "start": {
                                                                     "line": 148,
@@ -9155,8 +9155,8 @@
                                                                 },
                                                                 "object": {
                                                                   "type": "MemberExpression",
-                                                                  "start": 6295,
-                                                                  "end": 6318,
+                                                                  "start": 6251,
+                                                                  "end": 6274,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 148,
@@ -9169,8 +9169,8 @@
                                                                   },
                                                                   "object": {
                                                                     "type": "MemberExpression",
-                                                                    "start": 6295,
-                                                                    "end": 6313,
+                                                                    "start": 6251,
+                                                                    "end": 6269,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 148,
@@ -9183,8 +9183,8 @@
                                                                     },
                                                                     "object": {
                                                                       "type": "MemberExpression",
-                                                                      "start": 6295,
-                                                                      "end": 6308,
+                                                                      "start": 6251,
+                                                                      "end": 6264,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 148,
@@ -9197,8 +9197,8 @@
                                                                       },
                                                                       "object": {
                                                                         "type": "Identifier",
-                                                                        "start": 6295,
-                                                                        "end": 6303,
+                                                                        "start": 6251,
+                                                                        "end": 6259,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 148,
@@ -9214,8 +9214,8 @@
                                                                       },
                                                                       "property": {
                                                                         "type": "Identifier",
-                                                                        "start": 6304,
-                                                                        "end": 6308,
+                                                                        "start": 6260,
+                                                                        "end": 6264,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 148,
@@ -9233,8 +9233,8 @@
                                                                     },
                                                                     "property": {
                                                                       "type": "Identifier",
-                                                                      "start": 6309,
-                                                                      "end": 6312,
+                                                                      "start": 6265,
+                                                                      "end": 6268,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 148,
@@ -9252,8 +9252,8 @@
                                                                   },
                                                                   "property": {
                                                                     "type": "Identifier",
-                                                                    "start": 6314,
-                                                                    "end": 6318,
+                                                                    "start": 6270,
+                                                                    "end": 6274,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 148,
@@ -9271,8 +9271,8 @@
                                                                 },
                                                                 "property": {
                                                                   "type": "Identifier",
-                                                                  "start": 6352,
-                                                                  "end": 6358,
+                                                                  "start": 6308,
+                                                                  "end": 6314,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 149,
@@ -9291,8 +9291,8 @@
                                                               "arguments": [
                                                                 {
                                                                   "type": "ArrowFunctionExpression",
-                                                                  "start": 6359,
-                                                                  "end": 6754,
+                                                                  "start": 6315,
+                                                                  "end": 6710,
                                                                   "loc": {
                                                                     "start": {
                                                                       "line": 149,
@@ -9310,8 +9310,8 @@
                                                                   "params": [
                                                                     {
                                                                       "type": "Identifier",
-                                                                      "start": 6359,
-                                                                      "end": 6367,
+                                                                      "start": 6315,
+                                                                      "end": 6323,
                                                                       "loc": {
                                                                         "start": {
                                                                           "line": 149,
@@ -9328,8 +9328,8 @@
                                                                   ],
                                                                   "body": {
                                                                     "type": "BlockStatement",
-                                                                    "start": 6371,
-                                                                    "end": 6754,
+                                                                    "start": 6327,
+                                                                    "end": 6710,
                                                                     "loc": {
                                                                       "start": {
                                                                         "line": 149,
@@ -9343,8 +9343,8 @@
                                                                     "body": [
                                                                       {
                                                                         "type": "IfStatement",
-                                                                        "start": 6409,
-                                                                        "end": 6720,
+                                                                        "start": 6365,
+                                                                        "end": 6676,
                                                                         "loc": {
                                                                           "start": {
                                                                             "line": 150,
@@ -9357,8 +9357,8 @@
                                                                         },
                                                                         "test": {
                                                                           "type": "BinaryExpression",
-                                                                          "start": 6413,
-                                                                          "end": 6457,
+                                                                          "start": 6369,
+                                                                          "end": 6413,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 150,
@@ -9371,8 +9371,8 @@
                                                                           },
                                                                           "left": {
                                                                             "type": "MemberExpression",
-                                                                            "start": 6413,
-                                                                            "end": 6443,
+                                                                            "start": 6369,
+                                                                            "end": 6399,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 150,
@@ -9385,8 +9385,8 @@
                                                                             },
                                                                             "object": {
                                                                               "type": "MemberExpression",
-                                                                              "start": 6413,
-                                                                              "end": 6434,
+                                                                              "start": 6369,
+                                                                              "end": 6390,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 150,
@@ -9399,8 +9399,8 @@
                                                                               },
                                                                               "object": {
                                                                                 "type": "ThisExpression",
-                                                                                "start": 6413,
-                                                                                "end": 6417,
+                                                                                "start": 6369,
+                                                                                "end": 6373,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 150,
@@ -9414,8 +9414,8 @@
                                                                               },
                                                                               "property": {
                                                                                 "type": "Identifier",
-                                                                                "start": 6418,
-                                                                                "end": 6434,
+                                                                                "start": 6374,
+                                                                                "end": 6390,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 150,
@@ -9433,8 +9433,8 @@
                                                                             },
                                                                             "property": {
                                                                               "type": "Identifier",
-                                                                              "start": 6435,
-                                                                              "end": 6443,
+                                                                              "start": 6391,
+                                                                              "end": 6399,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 150,
@@ -9453,8 +9453,8 @@
                                                                           "operator": "===",
                                                                           "right": {
                                                                             "type": "Identifier",
-                                                                            "start": 6448,
-                                                                            "end": 6457,
+                                                                            "start": 6404,
+                                                                            "end": 6413,
                                                                             "loc": {
                                                                               "start": {
                                                                                 "line": 150,
@@ -9471,8 +9471,8 @@
                                                                         },
                                                                         "consequent": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 6459,
-                                                                          "end": 6550,
+                                                                          "start": 6415,
+                                                                          "end": 6506,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 150,
@@ -9486,8 +9486,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 6501,
-                                                                              "end": 6512,
+                                                                              "start": 6457,
+                                                                              "end": 6468,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 151,
@@ -9500,8 +9500,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "BooleanLiteral",
-                                                                                "start": 6508,
-                                                                                "end": 6512,
+                                                                                "start": 6464,
+                                                                                "end": 6468,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 151,
@@ -9520,8 +9520,8 @@
                                                                         },
                                                                         "alternate": {
                                                                           "type": "BlockStatement",
-                                                                          "start": 6556,
-                                                                          "end": 6720,
+                                                                          "start": 6512,
+                                                                          "end": 6676,
                                                                           "loc": {
                                                                             "start": {
                                                                               "line": 152,
@@ -9535,8 +9535,8 @@
                                                                           "body": [
                                                                             {
                                                                               "type": "ReturnStatement",
-                                                                              "start": 6598,
-                                                                              "end": 6682,
+                                                                              "start": 6554,
+                                                                              "end": 6638,
                                                                               "loc": {
                                                                                 "start": {
                                                                                   "line": 153,
@@ -9549,8 +9549,8 @@
                                                                               },
                                                                               "argument": {
                                                                                 "type": "CallExpression",
-                                                                                "start": 6605,
-                                                                                "end": 6682,
+                                                                                "start": 6561,
+                                                                                "end": 6638,
                                                                                 "loc": {
                                                                                   "start": {
                                                                                     "line": 153,
@@ -9563,8 +9563,8 @@
                                                                                 },
                                                                                 "callee": {
                                                                                   "type": "MemberExpression",
-                                                                                  "start": 6605,
-                                                                                  "end": 6666,
+                                                                                  "start": 6561,
+                                                                                  "end": 6622,
                                                                                   "loc": {
                                                                                     "start": {
                                                                                       "line": 153,
@@ -9577,8 +9577,8 @@
                                                                                   },
                                                                                   "object": {
                                                                                     "type": "NewExpression",
-                                                                                    "start": 6605,
-                                                                                    "end": 6661,
+                                                                                    "start": 6561,
+                                                                                    "end": 6617,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 153,
@@ -9591,8 +9591,8 @@
                                                                                     },
                                                                                     "callee": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 6609,
-                                                                                      "end": 6615,
+                                                                                      "start": 6565,
+                                                                                      "end": 6571,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 153,
@@ -9609,8 +9609,8 @@
                                                                                     "arguments": [
                                                                                       {
                                                                                         "type": "BinaryExpression",
-                                                                                        "start": 6616,
-                                                                                        "end": 6660,
+                                                                                        "start": 6572,
+                                                                                        "end": 6616,
                                                                                         "loc": {
                                                                                           "start": {
                                                                                             "line": 153,
@@ -9623,8 +9623,8 @@
                                                                                         },
                                                                                         "left": {
                                                                                           "type": "BinaryExpression",
-                                                                                          "start": 6616,
-                                                                                          "end": 6653,
+                                                                                          "start": 6572,
+                                                                                          "end": 6609,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 153,
@@ -9637,8 +9637,8 @@
                                                                                           },
                                                                                           "left": {
                                                                                             "type": "StringLiteral",
-                                                                                            "start": 6616,
-                                                                                            "end": 6620,
+                                                                                            "start": 6572,
+                                                                                            "end": 6576,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 153,
@@ -9658,8 +9658,8 @@
                                                                                           "operator": "+",
                                                                                           "right": {
                                                                                             "type": "MemberExpression",
-                                                                                            "start": 6623,
-                                                                                            "end": 6653,
+                                                                                            "start": 6579,
+                                                                                            "end": 6609,
                                                                                             "loc": {
                                                                                               "start": {
                                                                                                 "line": 153,
@@ -9672,8 +9672,8 @@
                                                                                             },
                                                                                             "object": {
                                                                                               "type": "MemberExpression",
-                                                                                              "start": 6623,
-                                                                                              "end": 6644,
+                                                                                              "start": 6579,
+                                                                                              "end": 6600,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 153,
@@ -9686,8 +9686,8 @@
                                                                                               },
                                                                                               "object": {
                                                                                                 "type": "ThisExpression",
-                                                                                                "start": 6623,
-                                                                                                "end": 6627,
+                                                                                                "start": 6579,
+                                                                                                "end": 6583,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 153,
@@ -9701,8 +9701,8 @@
                                                                                               },
                                                                                               "property": {
                                                                                                 "type": "Identifier",
-                                                                                                "start": 6628,
-                                                                                                "end": 6644,
+                                                                                                "start": 6584,
+                                                                                                "end": 6600,
                                                                                                 "loc": {
                                                                                                   "start": {
                                                                                                     "line": 153,
@@ -9720,8 +9720,8 @@
                                                                                             },
                                                                                             "property": {
                                                                                               "type": "Identifier",
-                                                                                              "start": 6645,
-                                                                                              "end": 6653,
+                                                                                              "start": 6601,
+                                                                                              "end": 6609,
                                                                                               "loc": {
                                                                                                 "start": {
                                                                                                   "line": 153,
@@ -9741,8 +9741,8 @@
                                                                                         "operator": "+",
                                                                                         "right": {
                                                                                           "type": "StringLiteral",
-                                                                                          "start": 6656,
-                                                                                          "end": 6660,
+                                                                                          "start": 6612,
+                                                                                          "end": 6616,
                                                                                           "loc": {
                                                                                             "start": {
                                                                                               "line": 153,
@@ -9764,8 +9764,8 @@
                                                                                   },
                                                                                   "property": {
                                                                                     "type": "Identifier",
-                                                                                    "start": 6662,
-                                                                                    "end": 6666,
+                                                                                    "start": 6618,
+                                                                                    "end": 6622,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 153,
@@ -9784,8 +9784,8 @@
                                                                                 "arguments": [
                                                                                   {
                                                                                     "type": "MemberExpression",
-                                                                                    "start": 6667,
-                                                                                    "end": 6681,
+                                                                                    "start": 6623,
+                                                                                    "end": 6637,
                                                                                     "loc": {
                                                                                       "start": {
                                                                                         "line": 153,
@@ -9798,8 +9798,8 @@
                                                                                     },
                                                                                     "object": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 6667,
-                                                                                      "end": 6675,
+                                                                                      "start": 6623,
+                                                                                      "end": 6631,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 153,
@@ -9815,8 +9815,8 @@
                                                                                     },
                                                                                     "property": {
                                                                                       "type": "Identifier",
-                                                                                      "start": 6676,
-                                                                                      "end": 6681,
+                                                                                      "start": 6632,
+                                                                                      "end": 6637,
                                                                                       "loc": {
                                                                                         "start": {
                                                                                           "line": 153,
@@ -9857,8 +9857,8 @@
                                         ],
                                         "test": {
                                           "type": "StringLiteral",
-                                          "start": 6152,
-                                          "end": 6163,
+                                          "start": 6108,
+                                          "end": 6119,
                                           "loc": {
                                             "start": {
                                               "line": 145,
@@ -9878,8 +9878,8 @@
                                       },
                                       {
                                         "type": "SwitchCase",
-                                        "start": 6841,
-                                        "end": 6904,
+                                        "start": 6797,
+                                        "end": 6860,
                                         "loc": {
                                           "start": {
                                             "line": 158,
@@ -9893,8 +9893,8 @@
                                         "consequent": [
                                           {
                                             "type": "ReturnStatement",
-                                            "start": 6870,
-                                            "end": 6904,
+                                            "start": 6826,
+                                            "end": 6860,
                                             "loc": {
                                               "start": {
                                                 "line": 159,
@@ -9907,8 +9907,8 @@
                                             },
                                             "argument": {
                                               "type": "ObjectExpression",
-                                              "start": 6877,
-                                              "end": 6904,
+                                              "start": 6833,
+                                              "end": 6860,
                                               "loc": {
                                                 "start": {
                                                   "line": 159,
@@ -9922,8 +9922,8 @@
                                               "properties": [
                                                 {
                                                   "type": "ObjectProperty",
-                                                  "start": 6878,
-                                                  "end": 6903,
+                                                  "start": 6834,
+                                                  "end": 6859,
                                                   "loc": {
                                                     "start": {
                                                       "line": 159,
@@ -9939,8 +9939,8 @@
                                                   "computed": true,
                                                   "key": {
                                                     "type": "Identifier",
-                                                    "start": 6879,
-                                                    "end": 6882,
+                                                    "start": 6835,
+                                                    "end": 6838,
                                                     "loc": {
                                                       "start": {
                                                         "line": 159,
@@ -9956,8 +9956,8 @@
                                                   },
                                                   "value": {
                                                     "type": "MemberExpression",
-                                                    "start": 6885,
-                                                    "end": 6903,
+                                                    "start": 6841,
+                                                    "end": 6859,
                                                     "loc": {
                                                       "start": {
                                                         "line": 159,
@@ -9970,8 +9970,8 @@
                                                     },
                                                     "object": {
                                                       "type": "MemberExpression",
-                                                      "start": 6885,
-                                                      "end": 6898,
+                                                      "start": 6841,
+                                                      "end": 6854,
                                                       "loc": {
                                                         "start": {
                                                           "line": 159,
@@ -9984,8 +9984,8 @@
                                                       },
                                                       "object": {
                                                         "type": "Identifier",
-                                                        "start": 6885,
-                                                        "end": 6893,
+                                                        "start": 6841,
+                                                        "end": 6849,
                                                         "loc": {
                                                           "start": {
                                                             "line": 159,
@@ -10001,8 +10001,8 @@
                                                       },
                                                       "property": {
                                                         "type": "Identifier",
-                                                        "start": 6894,
-                                                        "end": 6898,
+                                                        "start": 6850,
+                                                        "end": 6854,
                                                         "loc": {
                                                           "start": {
                                                             "line": 159,
@@ -10020,8 +10020,8 @@
                                                     },
                                                     "property": {
                                                       "type": "Identifier",
-                                                      "start": 6899,
-                                                      "end": 6902,
+                                                      "start": 6855,
+                                                      "end": 6858,
                                                       "loc": {
                                                         "start": {
                                                           "line": 159,
@@ -10058,8 +10058,8 @@
                   },
                   {
                     "type": "ReturnStatement",
-                    "start": 6938,
-                    "end": 7000,
+                    "start": 6894,
+                    "end": 6956,
                     "loc": {
                       "start": {
                         "line": 162,
@@ -10072,8 +10072,8 @@
                     },
                     "argument": {
                       "type": "CallExpression",
-                      "start": 6945,
-                      "end": 7000,
+                      "start": 6901,
+                      "end": 6956,
                       "loc": {
                         "start": {
                           "line": 162,
@@ -10086,8 +10086,8 @@
                       },
                       "callee": {
                         "type": "MemberExpression",
-                        "start": 6945,
-                        "end": 6958,
+                        "start": 6901,
+                        "end": 6914,
                         "loc": {
                           "start": {
                             "line": 162,
@@ -10100,8 +10100,8 @@
                         },
                         "object": {
                           "type": "Identifier",
-                          "start": 6945,
-                          "end": 6951,
+                          "start": 6901,
+                          "end": 6907,
                           "loc": {
                             "start": {
                               "line": 162,
@@ -10117,8 +10117,8 @@
                         },
                         "property": {
                           "type": "Identifier",
-                          "start": 6952,
-                          "end": 6958,
+                          "start": 6908,
+                          "end": 6914,
                           "loc": {
                             "start": {
                               "line": 162,
@@ -10137,8 +10137,8 @@
                       "arguments": [
                         {
                           "type": "Identifier",
-                          "start": 6959,
-                          "end": 6967,
+                          "start": 6915,
+                          "end": 6923,
                           "loc": {
                             "start": {
                               "line": 162,
@@ -10154,8 +10154,8 @@
                         },
                         {
                           "type": "ObjectExpression",
-                          "start": 6969,
-                          "end": 6999,
+                          "start": 6925,
+                          "end": 6955,
                           "loc": {
                             "start": {
                               "line": 162,
@@ -10169,8 +10169,8 @@
                           "properties": [
                             {
                               "type": "ObjectProperty",
-                              "start": 6970,
-                              "end": 6998,
+                              "start": 6926,
+                              "end": 6954,
                               "loc": {
                                 "start": {
                                   "line": 162,
@@ -10186,8 +10186,8 @@
                               "computed": false,
                               "key": {
                                 "type": "Identifier",
-                                "start": 6970,
-                                "end": 6974,
+                                "start": 6926,
+                                "end": 6930,
                                 "loc": {
                                   "start": {
                                     "line": 162,
@@ -10203,8 +10203,8 @@
                               },
                               "value": {
                                 "type": "CallExpression",
-                                "start": 6976,
-                                "end": 6998,
+                                "start": 6932,
+                                "end": 6954,
                                 "loc": {
                                   "start": {
                                     "line": 162,
@@ -10217,8 +10217,8 @@
                                 },
                                 "callee": {
                                   "type": "MemberExpression",
-                                  "start": 6976,
-                                  "end": 6989,
+                                  "start": 6932,
+                                  "end": 6945,
                                   "loc": {
                                     "start": {
                                       "line": 162,
@@ -10231,8 +10231,8 @@
                                   },
                                   "object": {
                                     "type": "Identifier",
-                                    "start": 6976,
-                                    "end": 6982,
+                                    "start": 6932,
+                                    "end": 6938,
                                     "loc": {
                                       "start": {
                                         "line": 162,
@@ -10248,8 +10248,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 6983,
-                                    "end": 6989,
+                                    "start": 6939,
+                                    "end": 6945,
                                     "loc": {
                                       "start": {
                                         "line": 162,
@@ -10268,8 +10268,8 @@
                                 "arguments": [
                                   {
                                     "type": "SpreadElement",
-                                    "start": 6990,
-                                    "end": 6997,
+                                    "start": 6946,
+                                    "end": 6953,
                                     "loc": {
                                       "start": {
                                         "line": 162,
@@ -10282,8 +10282,8 @@
                                     },
                                     "argument": {
                                       "type": "Identifier",
-                                      "start": 6993,
-                                      "end": 6997,
+                                      "start": 6949,
+                                      "end": 6953,
                                       "loc": {
                                         "start": {
                                           "line": 162,
@@ -10311,8 +10311,8 @@
               },
               "alternate": {
                 "type": "BlockStatement",
-                "start": 7012,
-                "end": 7043,
+                "start": 6968,
+                "end": 6999,
                 "loc": {
                   "start": {
                     "line": 163,
@@ -10326,8 +10326,8 @@
                 "body": [
                   {
                     "type": "ReturnStatement",
-                    "start": 7022,
-                    "end": 7037,
+                    "start": 6978,
+                    "end": 6993,
                     "loc": {
                       "start": {
                         "line": 164,
@@ -10340,8 +10340,8 @@
                     },
                     "argument": {
                       "type": "Identifier",
-                      "start": 7029,
-                      "end": 7037,
+                      "start": 6985,
+                      "end": 6993,
                       "loc": {
                         "start": {
                           "line": 164,
@@ -10370,9 +10370,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n ",
+      "value": "*\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n ",
       "start": 80,
-      "end": 169,
+      "end": 160,
       "loc": {
         "start": {
           "line": 4,
@@ -10387,8 +10387,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 227,
-      "end": 253,
+      "start": 218,
+      "end": 244,
       "loc": {
         "start": {
           "line": 9,
@@ -10403,8 +10403,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 336,
-      "end": 370,
+      "start": 327,
+      "end": 361,
       "loc": {
         "start": {
           "line": 15,
@@ -10419,8 +10419,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 422,
-      "end": 456,
+      "start": 413,
+      "end": 447,
       "loc": {
         "start": {
           "line": 20,
@@ -10435,8 +10435,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 493,
-      "end": 527,
+      "start": 484,
+      "end": 518,
       "loc": {
         "start": {
           "line": 25,
@@ -10451,8 +10451,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     ",
-      "start": 569,
-      "end": 1149,
+      "start": 560,
+      "end": 1140,
       "loc": {
         "start": {
           "line": 31,
@@ -10466,9 +10466,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n     ",
-      "start": 1416,
-      "end": 1864,
+      "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+      "start": 1407,
+      "end": 1848,
       "loc": {
         "start": {
           "line": 54,
@@ -10482,9 +10482,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search\n     ",
-      "start": 1993,
-      "end": 2367,
+      "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+      "start": 1977,
+      "end": 2323,
       "loc": {
         "start": {
           "line": 68,
@@ -10816,9 +10816,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n ",
+      "value": "*\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n ",
       "start": 80,
-      "end": 169,
+      "end": 160,
       "loc": {
         "start": {
           "line": 4,
@@ -10845,8 +10845,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 170,
-      "end": 176,
+      "start": 161,
+      "end": 167,
       "loc": {
         "start": {
           "line": 8,
@@ -10873,8 +10873,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 177,
-      "end": 184,
+      "start": 168,
+      "end": 175,
       "loc": {
         "start": {
           "line": 8,
@@ -10901,8 +10901,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 185,
-      "end": 190,
+      "start": 176,
+      "end": 181,
       "loc": {
         "start": {
           "line": 8,
@@ -10927,8 +10927,8 @@
         "binop": null
       },
       "value": "SearchFetcher",
-      "start": 191,
-      "end": 204,
+      "start": 182,
+      "end": 195,
       "loc": {
         "start": {
           "line": 8,
@@ -10955,8 +10955,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 205,
-      "end": 212,
+      "start": 196,
+      "end": 203,
       "loc": {
         "start": {
           "line": 8,
@@ -10981,8 +10981,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 213,
-      "end": 220,
+      "start": 204,
+      "end": 211,
       "loc": {
         "start": {
           "line": 8,
@@ -11006,8 +11006,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 221,
-      "end": 222,
+      "start": 212,
+      "end": 213,
       "loc": {
         "start": {
           "line": 8,
@@ -11022,8 +11022,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 227,
-      "end": 253,
+      "start": 218,
+      "end": 244,
       "loc": {
         "start": {
           "line": 9,
@@ -11048,8 +11048,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 258,
-      "end": 269,
+      "start": 249,
+      "end": 260,
       "loc": {
         "start": {
           "line": 12,
@@ -11073,8 +11073,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 269,
-      "end": 270,
+      "start": 260,
+      "end": 261,
       "loc": {
         "start": {
           "line": 12,
@@ -11099,8 +11099,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 270,
-      "end": 274,
+      "start": 261,
+      "end": 265,
       "loc": {
         "start": {
           "line": 12,
@@ -11125,8 +11125,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 274,
-      "end": 275,
+      "start": 265,
+      "end": 266,
       "loc": {
         "start": {
           "line": 12,
@@ -11151,8 +11151,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 276,
-      "end": 285,
+      "start": 267,
+      "end": 276,
       "loc": {
         "start": {
           "line": 12,
@@ -11178,8 +11178,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 286,
-      "end": 287,
+      "start": 277,
+      "end": 278,
       "loc": {
         "start": {
           "line": 12,
@@ -11205,8 +11205,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 288,
-      "end": 292,
+      "start": 279,
+      "end": 283,
       "loc": {
         "start": {
           "line": 12,
@@ -11230,8 +11230,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 292,
-      "end": 293,
+      "start": 283,
+      "end": 284,
       "loc": {
         "start": {
           "line": 12,
@@ -11255,8 +11255,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 294,
-      "end": 295,
+      "start": 285,
+      "end": 286,
       "loc": {
         "start": {
           "line": 12,
@@ -11283,8 +11283,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 304,
-      "end": 309,
+      "start": 295,
+      "end": 300,
       "loc": {
         "start": {
           "line": 13,
@@ -11308,8 +11308,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 309,
-      "end": 310,
+      "start": 300,
+      "end": 301,
       "loc": {
         "start": {
           "line": 13,
@@ -11334,8 +11334,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 310,
-      "end": 314,
+      "start": 301,
+      "end": 305,
       "loc": {
         "start": {
           "line": 13,
@@ -11360,8 +11360,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 314,
-      "end": 315,
+      "start": 305,
+      "end": 306,
       "loc": {
         "start": {
           "line": 13,
@@ -11386,8 +11386,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 316,
-      "end": 325,
+      "start": 307,
+      "end": 316,
       "loc": {
         "start": {
           "line": 13,
@@ -11411,8 +11411,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 325,
-      "end": 326,
+      "start": 316,
+      "end": 317,
       "loc": {
         "start": {
           "line": 13,
@@ -11427,8 +11427,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 336,
-      "end": 370,
+      "start": 327,
+      "end": 361,
       "loc": {
         "start": {
           "line": 15,
@@ -11455,8 +11455,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 379,
-      "end": 383,
+      "start": 370,
+      "end": 374,
       "loc": {
         "start": {
           "line": 18,
@@ -11481,8 +11481,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 383,
-      "end": 384,
+      "start": 374,
+      "end": 375,
       "loc": {
         "start": {
           "line": 18,
@@ -11507,8 +11507,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 384,
-      "end": 400,
+      "start": 375,
+      "end": 391,
       "loc": {
         "start": {
           "line": 18,
@@ -11534,8 +11534,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 401,
-      "end": 402,
+      "start": 392,
+      "end": 393,
       "loc": {
         "start": {
           "line": 18,
@@ -11560,8 +11560,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 403,
-      "end": 412,
+      "start": 394,
+      "end": 403,
       "loc": {
         "start": {
           "line": 18,
@@ -11576,8 +11576,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 422,
-      "end": 456,
+      "start": 413,
+      "end": 447,
       "loc": {
         "start": {
           "line": 20,
@@ -11604,8 +11604,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 465,
-      "end": 469,
+      "start": 456,
+      "end": 460,
       "loc": {
         "start": {
           "line": 23,
@@ -11630,8 +11630,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 469,
-      "end": 470,
+      "start": 460,
+      "end": 461,
       "loc": {
         "start": {
           "line": 23,
@@ -11656,8 +11656,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 470,
-      "end": 471,
+      "start": 461,
+      "end": 462,
       "loc": {
         "start": {
           "line": 23,
@@ -11683,8 +11683,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 472,
-      "end": 473,
+      "start": 463,
+      "end": 464,
       "loc": {
         "start": {
           "line": 23,
@@ -11709,8 +11709,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 474,
-      "end": 483,
+      "start": 465,
+      "end": 474,
       "loc": {
         "start": {
           "line": 23,
@@ -11725,8 +11725,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 493,
-      "end": 527,
+      "start": 484,
+      "end": 518,
       "loc": {
         "start": {
           "line": 25,
@@ -11753,8 +11753,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 536,
-      "end": 540,
+      "start": 527,
+      "end": 531,
       "loc": {
         "start": {
           "line": 28,
@@ -11779,8 +11779,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 540,
-      "end": 541,
+      "start": 531,
+      "end": 532,
       "loc": {
         "start": {
           "line": 28,
@@ -11805,8 +11805,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 541,
-      "end": 545,
+      "start": 532,
+      "end": 536,
       "loc": {
         "start": {
           "line": 28,
@@ -11832,8 +11832,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 546,
-      "end": 547,
+      "start": 537,
+      "end": 538,
       "loc": {
         "start": {
           "line": 28,
@@ -11858,8 +11858,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 548,
-      "end": 557,
+      "start": 539,
+      "end": 548,
       "loc": {
         "start": {
           "line": 28,
@@ -11883,8 +11883,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 562,
-      "end": 563,
+      "start": 553,
+      "end": 554,
       "loc": {
         "start": {
           "line": 29,
@@ -11899,8 +11899,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     ",
-      "start": 569,
-      "end": 1149,
+      "start": 560,
+      "end": 1140,
       "loc": {
         "start": {
           "line": 31,
@@ -11925,8 +11925,8 @@
         "binop": null
       },
       "value": "filter",
-      "start": 1154,
-      "end": 1160,
+      "start": 1145,
+      "end": 1151,
       "loc": {
         "start": {
           "line": 43,
@@ -11950,8 +11950,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1160,
-      "end": 1161,
+      "start": 1151,
+      "end": 1152,
       "loc": {
         "start": {
           "line": 43,
@@ -11976,8 +11976,8 @@
         "binop": null
       },
       "value": "conditions",
-      "start": 1161,
-      "end": 1171,
+      "start": 1152,
+      "end": 1162,
       "loc": {
         "start": {
           "line": 43,
@@ -12003,8 +12003,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1172,
-      "end": 1173,
+      "start": 1163,
+      "end": 1164,
       "loc": {
         "start": {
           "line": 43,
@@ -12028,8 +12028,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1174,
-      "end": 1175,
+      "start": 1165,
+      "end": 1166,
       "loc": {
         "start": {
           "line": 43,
@@ -12054,8 +12054,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 1184,
-      "end": 1189,
+      "start": 1175,
+      "end": 1180,
       "loc": {
         "start": {
           "line": 44,
@@ -12081,8 +12081,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1190,
-      "end": 1191,
+      "start": 1181,
+      "end": 1182,
       "loc": {
         "start": {
           "line": 44,
@@ -12107,8 +12107,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1192,
-      "end": 1201,
+      "start": 1183,
+      "end": 1192,
       "loc": {
         "start": {
           "line": 44,
@@ -12133,8 +12133,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1201,
-      "end": 1202,
+      "start": 1192,
+      "end": 1193,
       "loc": {
         "start": {
           "line": 44,
@@ -12159,8 +12159,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 1211,
-      "end": 1216,
+      "start": 1202,
+      "end": 1207,
       "loc": {
         "start": {
           "line": 45,
@@ -12186,8 +12186,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1217,
-      "end": 1218,
+      "start": 1208,
+      "end": 1209,
       "loc": {
         "start": {
           "line": 45,
@@ -12212,8 +12212,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1219,
-      "end": 1228,
+      "start": 1210,
+      "end": 1219,
       "loc": {
         "start": {
           "line": 45,
@@ -12238,8 +12238,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1228,
-      "end": 1229,
+      "start": 1219,
+      "end": 1220,
       "loc": {
         "start": {
           "line": 45,
@@ -12264,8 +12264,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 1238,
-      "end": 1244,
+      "start": 1229,
+      "end": 1235,
       "loc": {
         "start": {
           "line": 46,
@@ -12291,8 +12291,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1245,
-      "end": 1246,
+      "start": 1236,
+      "end": 1237,
       "loc": {
         "start": {
           "line": 46,
@@ -12317,8 +12317,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1247,
-      "end": 1256,
+      "start": 1238,
+      "end": 1247,
       "loc": {
         "start": {
           "line": 46,
@@ -12343,8 +12343,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1256,
-      "end": 1257,
+      "start": 1247,
+      "end": 1248,
       "loc": {
         "start": {
           "line": 46,
@@ -12369,8 +12369,8 @@
         "binop": null
       },
       "value": "playlist",
-      "start": 1266,
-      "end": 1274,
+      "start": 1257,
+      "end": 1265,
       "loc": {
         "start": {
           "line": 47,
@@ -12396,8 +12396,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1275,
-      "end": 1276,
+      "start": 1266,
+      "end": 1267,
       "loc": {
         "start": {
           "line": 47,
@@ -12422,8 +12422,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1277,
-      "end": 1286,
+      "start": 1268,
+      "end": 1277,
       "loc": {
         "start": {
           "line": 47,
@@ -12448,8 +12448,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1286,
-      "end": 1287,
+      "start": 1277,
+      "end": 1278,
       "loc": {
         "start": {
           "line": 47,
@@ -12474,8 +12474,8 @@
         "binop": null
       },
       "value": "available_territory",
-      "start": 1296,
-      "end": 1315,
+      "start": 1287,
+      "end": 1306,
       "loc": {
         "start": {
           "line": 48,
@@ -12501,8 +12501,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1316,
-      "end": 1317,
+      "start": 1307,
+      "end": 1308,
       "loc": {
         "start": {
           "line": 48,
@@ -12527,8 +12527,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1318,
-      "end": 1327,
+      "start": 1309,
+      "end": 1318,
       "loc": {
         "start": {
           "line": 48,
@@ -12552,8 +12552,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1332,
-      "end": 1333,
+      "start": 1323,
+      "end": 1324,
       "loc": {
         "start": {
           "line": 49,
@@ -12579,8 +12579,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1334,
-      "end": 1335,
+      "start": 1325,
+      "end": 1326,
       "loc": {
         "start": {
           "line": 49,
@@ -12604,8 +12604,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1336,
-      "end": 1337,
+      "start": 1327,
+      "end": 1328,
       "loc": {
         "start": {
           "line": 49,
@@ -12629,8 +12629,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1337,
-      "end": 1338,
+      "start": 1328,
+      "end": 1329,
       "loc": {
         "start": {
           "line": 49,
@@ -12654,8 +12654,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1338,
-      "end": 1339,
+      "start": 1329,
+      "end": 1330,
       "loc": {
         "start": {
           "line": 49,
@@ -12679,8 +12679,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1340,
-      "end": 1341,
+      "start": 1331,
+      "end": 1332,
       "loc": {
         "start": {
           "line": 49,
@@ -12707,8 +12707,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1350,
-      "end": 1354,
+      "start": 1341,
+      "end": 1345,
       "loc": {
         "start": {
           "line": 50,
@@ -12733,8 +12733,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1354,
-      "end": 1355,
+      "start": 1345,
+      "end": 1346,
       "loc": {
         "start": {
           "line": 50,
@@ -12759,8 +12759,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 1355,
-      "end": 1371,
+      "start": 1346,
+      "end": 1362,
       "loc": {
         "start": {
           "line": 50,
@@ -12786,8 +12786,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1372,
-      "end": 1373,
+      "start": 1363,
+      "end": 1364,
       "loc": {
         "start": {
           "line": 50,
@@ -12812,8 +12812,8 @@
         "binop": null
       },
       "value": "conditions",
-      "start": 1374,
-      "end": 1384,
+      "start": 1365,
+      "end": 1375,
       "loc": {
         "start": {
           "line": 50,
@@ -12840,8 +12840,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1393,
-      "end": 1399,
+      "start": 1384,
+      "end": 1390,
       "loc": {
         "start": {
           "line": 51,
@@ -12868,8 +12868,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1400,
-      "end": 1404,
+      "start": 1391,
+      "end": 1395,
       "loc": {
         "start": {
           "line": 51,
@@ -12893,8 +12893,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1409,
-      "end": 1410,
+      "start": 1400,
+      "end": 1401,
       "loc": {
         "start": {
           "line": 52,
@@ -12908,9 +12908,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n     ",
-      "start": 1416,
-      "end": 1864,
+      "value": "*\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+      "start": 1407,
+      "end": 1848,
       "loc": {
         "start": {
           "line": 54,
@@ -12935,8 +12935,8 @@
         "binop": null
       },
       "value": "setSearchCriteria",
-      "start": 1869,
-      "end": 1886,
+      "start": 1853,
+      "end": 1870,
       "loc": {
         "start": {
           "line": 62,
@@ -12960,8 +12960,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1886,
-      "end": 1887,
+      "start": 1870,
+      "end": 1871,
       "loc": {
         "start": {
           "line": 62,
@@ -12986,8 +12986,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 1887,
-      "end": 1888,
+      "start": 1871,
+      "end": 1872,
       "loc": {
         "start": {
           "line": 62,
@@ -13012,8 +13012,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1888,
-      "end": 1889,
+      "start": 1872,
+      "end": 1873,
       "loc": {
         "start": {
           "line": 62,
@@ -13038,8 +13038,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 1890,
-      "end": 1894,
+      "start": 1874,
+      "end": 1878,
       "loc": {
         "start": {
           "line": 62,
@@ -13065,8 +13065,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1895,
-      "end": 1896,
+      "start": 1879,
+      "end": 1880,
       "loc": {
         "start": {
           "line": 62,
@@ -13091,8 +13091,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 1897,
-      "end": 1906,
+      "start": 1881,
+      "end": 1890,
       "loc": {
         "start": {
           "line": 62,
@@ -13116,8 +13116,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1906,
-      "end": 1907,
+      "start": 1890,
+      "end": 1891,
       "loc": {
         "start": {
           "line": 62,
@@ -13141,8 +13141,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1908,
-      "end": 1909,
+      "start": 1892,
+      "end": 1893,
       "loc": {
         "start": {
           "line": 62,
@@ -13169,8 +13169,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1918,
-      "end": 1922,
+      "start": 1902,
+      "end": 1906,
       "loc": {
         "start": {
           "line": 63,
@@ -13195,8 +13195,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1922,
-      "end": 1923,
+      "start": 1906,
+      "end": 1907,
       "loc": {
         "start": {
           "line": 63,
@@ -13221,8 +13221,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 1923,
-      "end": 1924,
+      "start": 1907,
+      "end": 1908,
       "loc": {
         "start": {
           "line": 63,
@@ -13248,8 +13248,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1925,
-      "end": 1926,
+      "start": 1909,
+      "end": 1910,
       "loc": {
         "start": {
           "line": 63,
@@ -13274,8 +13274,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 1927,
-      "end": 1928,
+      "start": 1911,
+      "end": 1912,
       "loc": {
         "start": {
           "line": 63,
@@ -13302,8 +13302,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1937,
-      "end": 1941,
+      "start": 1921,
+      "end": 1925,
       "loc": {
         "start": {
           "line": 64,
@@ -13328,8 +13328,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1941,
-      "end": 1942,
+      "start": 1925,
+      "end": 1926,
       "loc": {
         "start": {
           "line": 64,
@@ -13354,8 +13354,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 1942,
-      "end": 1946,
+      "start": 1926,
+      "end": 1930,
       "loc": {
         "start": {
           "line": 64,
@@ -13381,8 +13381,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 1947,
-      "end": 1948,
+      "start": 1931,
+      "end": 1932,
       "loc": {
         "start": {
           "line": 64,
@@ -13407,8 +13407,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 1949,
-      "end": 1953,
+      "start": 1933,
+      "end": 1937,
       "loc": {
         "start": {
           "line": 64,
@@ -13435,8 +13435,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1970,
-      "end": 1976,
+      "start": 1954,
+      "end": 1960,
       "loc": {
         "start": {
           "line": 65,
@@ -13463,8 +13463,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1977,
-      "end": 1981,
+      "start": 1961,
+      "end": 1965,
       "loc": {
         "start": {
           "line": 65,
@@ -13488,8 +13488,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1986,
-      "end": 1987,
+      "start": 1970,
+      "end": 1971,
       "loc": {
         "start": {
           "line": 66,
@@ -13503,9 +13503,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search\n     ",
-      "start": 1993,
-      "end": 2367,
+      "value": "*\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     ",
+      "start": 1977,
+      "end": 2323,
       "loc": {
         "start": {
           "line": 68,
@@ -13530,8 +13530,8 @@
         "binop": null
       },
       "value": "fetchSearchResult",
-      "start": 2372,
-      "end": 2389,
+      "start": 2328,
+      "end": 2345,
       "loc": {
         "start": {
           "line": 77,
@@ -13555,8 +13555,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2389,
-      "end": 2390,
+      "start": 2345,
+      "end": 2346,
       "loc": {
         "start": {
           "line": 77,
@@ -13581,8 +13581,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2390,
-      "end": 2395,
+      "start": 2346,
+      "end": 2351,
       "loc": {
         "start": {
           "line": 77,
@@ -13608,8 +13608,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2396,
-      "end": 2397,
+      "start": 2352,
+      "end": 2353,
       "loc": {
         "start": {
           "line": 77,
@@ -13634,8 +13634,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2398,
-      "end": 2407,
+      "start": 2354,
+      "end": 2363,
       "loc": {
         "start": {
           "line": 77,
@@ -13660,8 +13660,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2407,
-      "end": 2408,
+      "start": 2363,
+      "end": 2364,
       "loc": {
         "start": {
           "line": 77,
@@ -13686,8 +13686,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2409,
-      "end": 2415,
+      "start": 2365,
+      "end": 2371,
       "loc": {
         "start": {
           "line": 77,
@@ -13713,8 +13713,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2416,
-      "end": 2417,
+      "start": 2372,
+      "end": 2373,
       "loc": {
         "start": {
           "line": 77,
@@ -13739,8 +13739,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2418,
-      "end": 2427,
+      "start": 2374,
+      "end": 2383,
       "loc": {
         "start": {
           "line": 77,
@@ -13764,8 +13764,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2427,
-      "end": 2428,
+      "start": 2383,
+      "end": 2384,
       "loc": {
         "start": {
           "line": 77,
@@ -13789,8 +13789,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2429,
-      "end": 2430,
+      "start": 2385,
+      "end": 2386,
       "loc": {
         "start": {
           "line": 77,
@@ -13817,8 +13817,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2439,
-      "end": 2445,
+      "start": 2395,
+      "end": 2401,
       "loc": {
         "start": {
           "line": 78,
@@ -13845,8 +13845,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2446,
-      "end": 2450,
+      "start": 2402,
+      "end": 2406,
       "loc": {
         "start": {
           "line": 78,
@@ -13871,8 +13871,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2450,
-      "end": 2451,
+      "start": 2406,
+      "end": 2407,
       "loc": {
         "start": {
           "line": 78,
@@ -13897,8 +13897,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 2451,
-      "end": 2455,
+      "start": 2407,
+      "end": 2411,
       "loc": {
         "start": {
           "line": 78,
@@ -13923,8 +13923,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2455,
-      "end": 2456,
+      "start": 2411,
+      "end": 2412,
       "loc": {
         "start": {
           "line": 78,
@@ -13949,8 +13949,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 2456,
-      "end": 2459,
+      "start": 2412,
+      "end": 2415,
       "loc": {
         "start": {
           "line": 78,
@@ -13974,8 +13974,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2459,
-      "end": 2460,
+      "start": 2415,
+      "end": 2416,
       "loc": {
         "start": {
           "line": 78,
@@ -14000,8 +14000,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 2460,
-      "end": 2468,
+      "start": 2416,
+      "end": 2424,
       "loc": {
         "start": {
           "line": 78,
@@ -14026,8 +14026,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2468,
-      "end": 2469,
+      "start": 2424,
+      "end": 2425,
       "loc": {
         "start": {
           "line": 78,
@@ -14051,8 +14051,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2470,
-      "end": 2471,
+      "start": 2426,
+      "end": 2427,
       "loc": {
         "start": {
           "line": 78,
@@ -14077,8 +14077,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 2484,
-      "end": 2485,
+      "start": 2440,
+      "end": 2441,
       "loc": {
         "start": {
           "line": 79,
@@ -14103,8 +14103,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2485,
-      "end": 2486,
+      "start": 2441,
+      "end": 2442,
       "loc": {
         "start": {
           "line": 79,
@@ -14131,8 +14131,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2487,
-      "end": 2491,
+      "start": 2443,
+      "end": 2447,
       "loc": {
         "start": {
           "line": 79,
@@ -14157,8 +14157,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2491,
-      "end": 2492,
+      "start": 2447,
+      "end": 2448,
       "loc": {
         "start": {
           "line": 79,
@@ -14183,8 +14183,8 @@
         "binop": null
       },
       "value": "q",
-      "start": 2492,
-      "end": 2493,
+      "start": 2448,
+      "end": 2449,
       "loc": {
         "start": {
           "line": 79,
@@ -14209,8 +14209,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2493,
-      "end": 2494,
+      "start": 2449,
+      "end": 2450,
       "loc": {
         "start": {
           "line": 79,
@@ -14235,8 +14235,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 2507,
-      "end": 2511,
+      "start": 2463,
+      "end": 2467,
       "loc": {
         "start": {
           "line": 80,
@@ -14261,8 +14261,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2511,
-      "end": 2512,
+      "start": 2467,
+      "end": 2468,
       "loc": {
         "start": {
           "line": 80,
@@ -14289,8 +14289,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2513,
-      "end": 2517,
+      "start": 2469,
+      "end": 2473,
       "loc": {
         "start": {
           "line": 80,
@@ -14315,8 +14315,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2517,
-      "end": 2518,
+      "start": 2473,
+      "end": 2474,
       "loc": {
         "start": {
           "line": 80,
@@ -14341,8 +14341,8 @@
         "binop": null
       },
       "value": "type",
-      "start": 2518,
-      "end": 2522,
+      "start": 2474,
+      "end": 2478,
       "loc": {
         "start": {
           "line": 80,
@@ -14367,8 +14367,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2522,
-      "end": 2523,
+      "start": 2478,
+      "end": 2479,
       "loc": {
         "start": {
           "line": 80,
@@ -14393,8 +14393,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2536,
-      "end": 2545,
+      "start": 2492,
+      "end": 2501,
       "loc": {
         "start": {
           "line": 81,
@@ -14419,8 +14419,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2545,
-      "end": 2546,
+      "start": 2501,
+      "end": 2502,
       "loc": {
         "start": {
           "line": 81,
@@ -14447,8 +14447,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2547,
-      "end": 2551,
+      "start": 2503,
+      "end": 2507,
       "loc": {
         "start": {
           "line": 81,
@@ -14473,8 +14473,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2551,
-      "end": 2552,
+      "start": 2507,
+      "end": 2508,
       "loc": {
         "start": {
           "line": 81,
@@ -14499,8 +14499,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2552,
-      "end": 2561,
+      "start": 2508,
+      "end": 2517,
       "loc": {
         "start": {
           "line": 81,
@@ -14525,8 +14525,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2561,
-      "end": 2562,
+      "start": 2517,
+      "end": 2518,
       "loc": {
         "start": {
           "line": 81,
@@ -14551,8 +14551,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2575,
-      "end": 2580,
+      "start": 2531,
+      "end": 2536,
       "loc": {
         "start": {
           "line": 82,
@@ -14577,8 +14577,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2580,
-      "end": 2581,
+      "start": 2536,
+      "end": 2537,
       "loc": {
         "start": {
           "line": 82,
@@ -14603,8 +14603,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2582,
-      "end": 2587,
+      "start": 2538,
+      "end": 2543,
       "loc": {
         "start": {
           "line": 82,
@@ -14629,8 +14629,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2587,
-      "end": 2588,
+      "start": 2543,
+      "end": 2544,
       "loc": {
         "start": {
           "line": 82,
@@ -14655,8 +14655,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2601,
-      "end": 2607,
+      "start": 2557,
+      "end": 2563,
       "loc": {
         "start": {
           "line": 83,
@@ -14681,8 +14681,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2607,
-      "end": 2608,
+      "start": 2563,
+      "end": 2564,
       "loc": {
         "start": {
           "line": 83,
@@ -14707,8 +14707,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2609,
-      "end": 2615,
+      "start": 2565,
+      "end": 2571,
       "loc": {
         "start": {
           "line": 83,
@@ -14732,8 +14732,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2636,
-      "end": 2637,
+      "start": 2592,
+      "end": 2593,
       "loc": {
         "start": {
           "line": 84,
@@ -14757,8 +14757,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2637,
-      "end": 2638,
+      "start": 2593,
+      "end": 2594,
       "loc": {
         "start": {
           "line": 84,
@@ -14783,8 +14783,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2638,
-      "end": 2639,
+      "start": 2594,
+      "end": 2595,
       "loc": {
         "start": {
           "line": 84,
@@ -14809,8 +14809,8 @@
         "binop": null
       },
       "value": "then",
-      "start": 2639,
-      "end": 2643,
+      "start": 2595,
+      "end": 2599,
       "loc": {
         "start": {
           "line": 84,
@@ -14834,8 +14834,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2643,
-      "end": 2644,
+      "start": 2599,
+      "end": 2600,
       "loc": {
         "start": {
           "line": 84,
@@ -14860,8 +14860,8 @@
         "binop": null
       },
       "value": "doFilter",
-      "start": 2644,
-      "end": 2652,
+      "start": 2600,
+      "end": 2608,
       "loc": {
         "start": {
           "line": 84,
@@ -14886,8 +14886,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2652,
-      "end": 2653,
+      "start": 2608,
+      "end": 2609,
       "loc": {
         "start": {
           "line": 84,
@@ -14912,8 +14912,8 @@
         "binop": null
       },
       "value": "bind",
-      "start": 2653,
-      "end": 2657,
+      "start": 2609,
+      "end": 2613,
       "loc": {
         "start": {
           "line": 84,
@@ -14937,8 +14937,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2657,
-      "end": 2658,
+      "start": 2613,
+      "end": 2614,
       "loc": {
         "start": {
           "line": 84,
@@ -14965,8 +14965,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2658,
-      "end": 2662,
+      "start": 2614,
+      "end": 2618,
       "loc": {
         "start": {
           "line": 84,
@@ -14990,8 +14990,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2662,
-      "end": 2663,
+      "start": 2618,
+      "end": 2619,
       "loc": {
         "start": {
           "line": 84,
@@ -15015,8 +15015,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2663,
-      "end": 2664,
+      "start": 2619,
+      "end": 2620,
       "loc": {
         "start": {
           "line": 84,
@@ -15040,8 +15040,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2669,
-      "end": 2670,
+      "start": 2625,
+      "end": 2626,
       "loc": {
         "start": {
           "line": 85,
@@ -15065,8 +15065,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2671,
-      "end": 2672,
+      "start": 2627,
+      "end": 2628,
       "loc": {
         "start": {
           "line": 86,
@@ -15092,8 +15092,8 @@
         "binop": null
       },
       "value": "function",
-      "start": 2674,
-      "end": 2682,
+      "start": 2630,
+      "end": 2638,
       "loc": {
         "start": {
           "line": 88,
@@ -15118,8 +15118,8 @@
         "binop": null
       },
       "value": "doFilter",
-      "start": 2683,
-      "end": 2691,
+      "start": 2639,
+      "end": 2647,
       "loc": {
         "start": {
           "line": 88,
@@ -15143,8 +15143,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2691,
-      "end": 2692,
+      "start": 2647,
+      "end": 2648,
       "loc": {
         "start": {
           "line": 88,
@@ -15169,8 +15169,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 2692,
-      "end": 2700,
+      "start": 2648,
+      "end": 2656,
       "loc": {
         "start": {
           "line": 88,
@@ -15194,8 +15194,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2700,
-      "end": 2701,
+      "start": 2656,
+      "end": 2657,
       "loc": {
         "start": {
           "line": 88,
@@ -15219,8 +15219,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2702,
-      "end": 2703,
+      "start": 2658,
+      "end": 2659,
       "loc": {
         "start": {
           "line": 88,
@@ -15247,8 +15247,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 2708,
-      "end": 2710,
+      "start": 2664,
+      "end": 2666,
       "loc": {
         "start": {
           "line": 89,
@@ -15272,8 +15272,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2711,
-      "end": 2712,
+      "start": 2667,
+      "end": 2668,
       "loc": {
         "start": {
           "line": 89,
@@ -15300,8 +15300,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2712,
-      "end": 2716,
+      "start": 2668,
+      "end": 2672,
       "loc": {
         "start": {
           "line": 89,
@@ -15326,8 +15326,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2716,
-      "end": 2717,
+      "start": 2672,
+      "end": 2673,
       "loc": {
         "start": {
           "line": 89,
@@ -15352,8 +15352,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 2717,
-      "end": 2733,
+      "start": 2673,
+      "end": 2689,
       "loc": {
         "start": {
           "line": 89,
@@ -15379,8 +15379,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 2734,
-      "end": 2737,
+      "start": 2690,
+      "end": 2693,
       "loc": {
         "start": {
           "line": 89,
@@ -15405,8 +15405,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2738,
-      "end": 2747,
+      "start": 2694,
+      "end": 2703,
       "loc": {
         "start": {
           "line": 89,
@@ -15430,8 +15430,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2747,
-      "end": 2748,
+      "start": 2703,
+      "end": 2704,
       "loc": {
         "start": {
           "line": 89,
@@ -15455,8 +15455,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2749,
-      "end": 2750,
+      "start": 2705,
+      "end": 2706,
       "loc": {
         "start": {
           "line": 89,
@@ -15483,8 +15483,8 @@
         "updateContext": null
       },
       "value": "const",
-      "start": 2759,
-      "end": 2764,
+      "start": 2715,
+      "end": 2720,
       "loc": {
         "start": {
           "line": 90,
@@ -15509,8 +15509,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 2765,
-      "end": 2769,
+      "start": 2721,
+      "end": 2725,
       "loc": {
         "start": {
           "line": 90,
@@ -15536,8 +15536,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2770,
-      "end": 2771,
+      "start": 2726,
+      "end": 2727,
       "loc": {
         "start": {
           "line": 90,
@@ -15562,8 +15562,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 2772,
-      "end": 2778,
+      "start": 2728,
+      "end": 2734,
       "loc": {
         "start": {
           "line": 90,
@@ -15588,8 +15588,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2778,
-      "end": 2779,
+      "start": 2734,
+      "end": 2735,
       "loc": {
         "start": {
           "line": 90,
@@ -15614,8 +15614,8 @@
         "binop": null
       },
       "value": "keys",
-      "start": 2779,
-      "end": 2783,
+      "start": 2735,
+      "end": 2739,
       "loc": {
         "start": {
           "line": 90,
@@ -15639,8 +15639,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2783,
-      "end": 2784,
+      "start": 2739,
+      "end": 2740,
       "loc": {
         "start": {
           "line": 90,
@@ -15665,8 +15665,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 2784,
-      "end": 2792,
+      "start": 2740,
+      "end": 2748,
       "loc": {
         "start": {
           "line": 90,
@@ -15691,8 +15691,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2792,
-      "end": 2793,
+      "start": 2748,
+      "end": 2749,
       "loc": {
         "start": {
           "line": 90,
@@ -15717,8 +15717,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 2793,
-      "end": 2797,
+      "start": 2749,
+      "end": 2753,
       "loc": {
         "start": {
           "line": 90,
@@ -15742,8 +15742,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2797,
-      "end": 2798,
+      "start": 2753,
+      "end": 2754,
       "loc": {
         "start": {
           "line": 90,
@@ -15768,8 +15768,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2798,
-      "end": 2799,
+      "start": 2754,
+      "end": 2755,
       "loc": {
         "start": {
           "line": 90,
@@ -15794,8 +15794,8 @@
         "binop": null
       },
       "value": "map",
-      "start": 2799,
-      "end": 2802,
+      "start": 2755,
+      "end": 2758,
       "loc": {
         "start": {
           "line": 90,
@@ -15819,8 +15819,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2802,
-      "end": 2803,
+      "start": 2758,
+      "end": 2759,
       "loc": {
         "start": {
           "line": 90,
@@ -15845,8 +15845,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 2803,
-      "end": 2806,
+      "start": 2759,
+      "end": 2762,
       "loc": {
         "start": {
           "line": 90,
@@ -15871,8 +15871,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2807,
-      "end": 2809,
+      "start": 2763,
+      "end": 2765,
       "loc": {
         "start": {
           "line": 90,
@@ -15896,8 +15896,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2810,
-      "end": 2811,
+      "start": 2766,
+      "end": 2767,
       "loc": {
         "start": {
           "line": 90,
@@ -15924,8 +15924,8 @@
         "updateContext": null
       },
       "value": "switch",
-      "start": 2824,
-      "end": 2830,
+      "start": 2780,
+      "end": 2786,
       "loc": {
         "start": {
           "line": 91,
@@ -15949,8 +15949,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2831,
-      "end": 2832,
+      "start": 2787,
+      "end": 2788,
       "loc": {
         "start": {
           "line": 91,
@@ -15975,8 +15975,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 2832,
-      "end": 2835,
+      "start": 2788,
+      "end": 2791,
       "loc": {
         "start": {
           "line": 91,
@@ -16000,8 +16000,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2835,
-      "end": 2836,
+      "start": 2791,
+      "end": 2792,
       "loc": {
         "start": {
           "line": 91,
@@ -16025,8 +16025,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2837,
-      "end": 2838,
+      "start": 2793,
+      "end": 2794,
       "loc": {
         "start": {
           "line": 91,
@@ -16053,8 +16053,8 @@
         "updateContext": null
       },
       "value": "case",
-      "start": 2855,
-      "end": 2859,
+      "start": 2811,
+      "end": 2815,
       "loc": {
         "start": {
           "line": 92,
@@ -16080,8 +16080,8 @@
         "updateContext": null
       },
       "value": "tracks",
-      "start": 2860,
-      "end": 2868,
+      "start": 2816,
+      "end": 2824,
       "loc": {
         "start": {
           "line": 92,
@@ -16106,8 +16106,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2868,
-      "end": 2869,
+      "start": 2824,
+      "end": 2825,
       "loc": {
         "start": {
           "line": 92,
@@ -16134,8 +16134,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2890,
-      "end": 2896,
+      "start": 2846,
+      "end": 2852,
       "loc": {
         "start": {
           "line": 93,
@@ -16159,8 +16159,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2897,
-      "end": 2898,
+      "start": 2853,
+      "end": 2854,
       "loc": {
         "start": {
           "line": 93,
@@ -16185,8 +16185,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2923,
-      "end": 2924,
+      "start": 2879,
+      "end": 2880,
       "loc": {
         "start": {
           "line": 94,
@@ -16211,8 +16211,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 2924,
-      "end": 2927,
+      "start": 2880,
+      "end": 2883,
       "loc": {
         "start": {
           "line": 94,
@@ -16237,8 +16237,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2927,
-      "end": 2928,
+      "start": 2883,
+      "end": 2884,
       "loc": {
         "start": {
           "line": 94,
@@ -16263,8 +16263,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2928,
-      "end": 2929,
+      "start": 2884,
+      "end": 2885,
       "loc": {
         "start": {
           "line": 94,
@@ -16289,8 +16289,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 2930,
-      "end": 2936,
+      "start": 2886,
+      "end": 2892,
       "loc": {
         "start": {
           "line": 94,
@@ -16315,8 +16315,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2936,
-      "end": 2937,
+      "start": 2892,
+      "end": 2893,
       "loc": {
         "start": {
           "line": 94,
@@ -16341,8 +16341,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 2937,
-      "end": 2943,
+      "start": 2893,
+      "end": 2899,
       "loc": {
         "start": {
           "line": 94,
@@ -16366,8 +16366,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2943,
-      "end": 2944,
+      "start": 2899,
+      "end": 2900,
       "loc": {
         "start": {
           "line": 94,
@@ -16392,8 +16392,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 2944,
-      "end": 2952,
+      "start": 2900,
+      "end": 2908,
       "loc": {
         "start": {
           "line": 94,
@@ -16418,8 +16418,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2952,
-      "end": 2953,
+      "start": 2908,
+      "end": 2909,
       "loc": {
         "start": {
           "line": 94,
@@ -16444,8 +16444,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 2953,
-      "end": 2957,
+      "start": 2909,
+      "end": 2913,
       "loc": {
         "start": {
           "line": 94,
@@ -16470,8 +16470,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2957,
-      "end": 2958,
+      "start": 2913,
+      "end": 2914,
       "loc": {
         "start": {
           "line": 94,
@@ -16496,8 +16496,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 2958,
-      "end": 2961,
+      "start": 2914,
+      "end": 2917,
       "loc": {
         "start": {
           "line": 94,
@@ -16522,8 +16522,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2961,
-      "end": 2962,
+      "start": 2917,
+      "end": 2918,
       "loc": {
         "start": {
           "line": 94,
@@ -16548,8 +16548,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2962,
-      "end": 2963,
+      "start": 2918,
+      "end": 2919,
       "loc": {
         "start": {
           "line": 94,
@@ -16573,8 +16573,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2964,
-      "end": 2965,
+      "start": 2920,
+      "end": 2921,
       "loc": {
         "start": {
           "line": 94,
@@ -16599,8 +16599,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 2994,
-      "end": 2998,
+      "start": 2950,
+      "end": 2954,
       "loc": {
         "start": {
           "line": 95,
@@ -16625,8 +16625,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2998,
-      "end": 2999,
+      "start": 2954,
+      "end": 2955,
       "loc": {
         "start": {
           "line": 95,
@@ -16651,8 +16651,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 3000,
-      "end": 3008,
+      "start": 2956,
+      "end": 2964,
       "loc": {
         "start": {
           "line": 95,
@@ -16677,8 +16677,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3008,
-      "end": 3009,
+      "start": 2964,
+      "end": 2965,
       "loc": {
         "start": {
           "line": 95,
@@ -16703,8 +16703,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 3009,
-      "end": 3013,
+      "start": 2965,
+      "end": 2969,
       "loc": {
         "start": {
           "line": 95,
@@ -16729,8 +16729,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3013,
-      "end": 3014,
+      "start": 2969,
+      "end": 2970,
       "loc": {
         "start": {
           "line": 95,
@@ -16755,8 +16755,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 3014,
-      "end": 3017,
+      "start": 2970,
+      "end": 2973,
       "loc": {
         "start": {
           "line": 95,
@@ -16781,8 +16781,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3017,
-      "end": 3018,
+      "start": 2973,
+      "end": 2974,
       "loc": {
         "start": {
           "line": 95,
@@ -16807,8 +16807,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3018,
-      "end": 3019,
+      "start": 2974,
+      "end": 2975,
       "loc": {
         "start": {
           "line": 95,
@@ -16833,8 +16833,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 3019,
-      "end": 3023,
+      "start": 2975,
+      "end": 2979,
       "loc": {
         "start": {
           "line": 95,
@@ -16859,8 +16859,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3056,
-      "end": 3057,
+      "start": 3012,
+      "end": 3013,
       "loc": {
         "start": {
           "line": 96,
@@ -16885,8 +16885,8 @@
         "binop": null
       },
       "value": "filter",
-      "start": 3057,
-      "end": 3063,
+      "start": 3013,
+      "end": 3019,
       "loc": {
         "start": {
           "line": 96,
@@ -16910,8 +16910,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3063,
-      "end": 3064,
+      "start": 3019,
+      "end": 3020,
       "loc": {
         "start": {
           "line": 96,
@@ -16936,8 +16936,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3064,
-      "end": 3069,
+      "start": 3020,
+      "end": 3025,
       "loc": {
         "start": {
           "line": 96,
@@ -16962,8 +16962,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3070,
-      "end": 3072,
+      "start": 3026,
+      "end": 3028,
       "loc": {
         "start": {
           "line": 96,
@@ -16987,8 +16987,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3073,
-      "end": 3074,
+      "start": 3029,
+      "end": 3030,
       "loc": {
         "start": {
           "line": 96,
@@ -17015,8 +17015,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 3111,
-      "end": 3113,
+      "start": 3067,
+      "end": 3069,
       "loc": {
         "start": {
           "line": 97,
@@ -17040,8 +17040,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3114,
-      "end": 3115,
+      "start": 3070,
+      "end": 3071,
       "loc": {
         "start": {
           "line": 97,
@@ -17068,8 +17068,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3115,
-      "end": 3119,
+      "start": 3071,
+      "end": 3075,
       "loc": {
         "start": {
           "line": 97,
@@ -17094,8 +17094,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3119,
-      "end": 3120,
+      "start": 3075,
+      "end": 3076,
       "loc": {
         "start": {
           "line": 97,
@@ -17120,8 +17120,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3120,
-      "end": 3136,
+      "start": 3076,
+      "end": 3092,
       "loc": {
         "start": {
           "line": 97,
@@ -17146,8 +17146,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3136,
-      "end": 3137,
+      "start": 3092,
+      "end": 3093,
       "loc": {
         "start": {
           "line": 97,
@@ -17172,8 +17172,8 @@
         "binop": null
       },
       "value": "available_territory",
-      "start": 3137,
-      "end": 3156,
+      "start": 3093,
+      "end": 3112,
       "loc": {
         "start": {
           "line": 97,
@@ -17199,8 +17199,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 3157,
-      "end": 3160,
+      "start": 3113,
+      "end": 3116,
       "loc": {
         "start": {
           "line": 97,
@@ -17225,8 +17225,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 3161,
-      "end": 3170,
+      "start": 3117,
+      "end": 3126,
       "loc": {
         "start": {
           "line": 97,
@@ -17252,8 +17252,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 3171,
-      "end": 3173,
+      "start": 3127,
+      "end": 3129,
       "loc": {
         "start": {
           "line": 97,
@@ -17279,8 +17279,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 3214,
-      "end": 3215,
+      "start": 3170,
+      "end": 3171,
       "loc": {
         "start": {
           "line": 98,
@@ -17305,8 +17305,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3215,
-      "end": 3220,
+      "start": 3171,
+      "end": 3176,
       "loc": {
         "start": {
           "line": 98,
@@ -17331,8 +17331,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3220,
-      "end": 3221,
+      "start": 3176,
+      "end": 3177,
       "loc": {
         "start": {
           "line": 98,
@@ -17357,8 +17357,8 @@
         "binop": null
       },
       "value": "available_territories",
-      "start": 3221,
-      "end": 3242,
+      "start": 3177,
+      "end": 3198,
       "loc": {
         "start": {
           "line": 98,
@@ -17383,8 +17383,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3242,
-      "end": 3243,
+      "start": 3198,
+      "end": 3199,
       "loc": {
         "start": {
           "line": 98,
@@ -17409,8 +17409,8 @@
         "binop": null
       },
       "value": "includes",
-      "start": 3243,
-      "end": 3251,
+      "start": 3199,
+      "end": 3207,
       "loc": {
         "start": {
           "line": 98,
@@ -17434,8 +17434,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3251,
-      "end": 3252,
+      "start": 3207,
+      "end": 3208,
       "loc": {
         "start": {
           "line": 98,
@@ -17462,8 +17462,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3252,
-      "end": 3256,
+      "start": 3208,
+      "end": 3212,
       "loc": {
         "start": {
           "line": 98,
@@ -17488,8 +17488,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3256,
-      "end": 3257,
+      "start": 3212,
+      "end": 3213,
       "loc": {
         "start": {
           "line": 98,
@@ -17514,8 +17514,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3257,
-      "end": 3273,
+      "start": 3213,
+      "end": 3229,
       "loc": {
         "start": {
           "line": 98,
@@ -17540,8 +17540,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3273,
-      "end": 3274,
+      "start": 3229,
+      "end": 3230,
       "loc": {
         "start": {
           "line": 98,
@@ -17566,8 +17566,8 @@
         "binop": null
       },
       "value": "available_territory",
-      "start": 3274,
-      "end": 3293,
+      "start": 3230,
+      "end": 3249,
       "loc": {
         "start": {
           "line": 98,
@@ -17591,8 +17591,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3293,
-      "end": 3294,
+      "start": 3249,
+      "end": 3250,
       "loc": {
         "start": {
           "line": 98,
@@ -17616,8 +17616,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3294,
-      "end": 3295,
+      "start": 3250,
+      "end": 3251,
       "loc": {
         "start": {
           "line": 98,
@@ -17641,8 +17641,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3296,
-      "end": 3297,
+      "start": 3252,
+      "end": 3253,
       "loc": {
         "start": {
           "line": 98,
@@ -17669,8 +17669,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 3338,
-      "end": 3344,
+      "start": 3294,
+      "end": 3300,
       "loc": {
         "start": {
           "line": 99,
@@ -17697,8 +17697,8 @@
         "updateContext": null
       },
       "value": "false",
-      "start": 3345,
-      "end": 3350,
+      "start": 3301,
+      "end": 3306,
       "loc": {
         "start": {
           "line": 99,
@@ -17722,8 +17722,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3387,
-      "end": 3388,
+      "start": 3343,
+      "end": 3344,
       "loc": {
         "start": {
           "line": 100,
@@ -17750,8 +17750,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 3425,
-      "end": 3427,
+      "start": 3381,
+      "end": 3383,
       "loc": {
         "start": {
           "line": 101,
@@ -17775,8 +17775,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3428,
-      "end": 3429,
+      "start": 3384,
+      "end": 3385,
       "loc": {
         "start": {
           "line": 101,
@@ -17803,8 +17803,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3429,
-      "end": 3433,
+      "start": 3385,
+      "end": 3389,
       "loc": {
         "start": {
           "line": 101,
@@ -17829,8 +17829,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3433,
-      "end": 3434,
+      "start": 3389,
+      "end": 3390,
       "loc": {
         "start": {
           "line": 101,
@@ -17855,8 +17855,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3434,
-      "end": 3450,
+      "start": 3390,
+      "end": 3406,
       "loc": {
         "start": {
           "line": 101,
@@ -17881,8 +17881,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3450,
-      "end": 3451,
+      "start": 3406,
+      "end": 3407,
       "loc": {
         "start": {
           "line": 101,
@@ -17907,8 +17907,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3451,
-      "end": 3456,
+      "start": 3407,
+      "end": 3412,
       "loc": {
         "start": {
           "line": 101,
@@ -17934,8 +17934,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 3457,
-      "end": 3460,
+      "start": 3413,
+      "end": 3416,
       "loc": {
         "start": {
           "line": 101,
@@ -17960,8 +17960,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 3461,
-      "end": 3470,
+      "start": 3417,
+      "end": 3426,
       "loc": {
         "start": {
           "line": 101,
@@ -17987,8 +17987,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 3471,
-      "end": 3473,
+      "start": 3427,
+      "end": 3429,
       "loc": {
         "start": {
           "line": 101,
@@ -18014,8 +18014,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 3514,
-      "end": 3515,
+      "start": 3470,
+      "end": 3471,
       "loc": {
         "start": {
           "line": 102,
@@ -18042,8 +18042,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 3515,
-      "end": 3518,
+      "start": 3471,
+      "end": 3474,
       "loc": {
         "start": {
           "line": 102,
@@ -18068,8 +18068,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 3519,
-      "end": 3525,
+      "start": 3475,
+      "end": 3481,
       "loc": {
         "start": {
           "line": 102,
@@ -18093,8 +18093,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3525,
-      "end": 3526,
+      "start": 3481,
+      "end": 3482,
       "loc": {
         "start": {
           "line": 102,
@@ -18120,8 +18120,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 3526,
-      "end": 3530,
+      "start": 3482,
+      "end": 3486,
       "loc": {
         "start": {
           "line": 102,
@@ -18147,8 +18147,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 3531,
-      "end": 3532,
+      "start": 3487,
+      "end": 3488,
       "loc": {
         "start": {
           "line": 102,
@@ -18175,8 +18175,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3533,
-      "end": 3537,
+      "start": 3489,
+      "end": 3493,
       "loc": {
         "start": {
           "line": 102,
@@ -18201,8 +18201,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3537,
-      "end": 3538,
+      "start": 3493,
+      "end": 3494,
       "loc": {
         "start": {
           "line": 102,
@@ -18227,8 +18227,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3538,
-      "end": 3554,
+      "start": 3494,
+      "end": 3510,
       "loc": {
         "start": {
           "line": 102,
@@ -18253,8 +18253,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3554,
-      "end": 3555,
+      "start": 3510,
+      "end": 3511,
       "loc": {
         "start": {
           "line": 102,
@@ -18279,8 +18279,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3555,
-      "end": 3560,
+      "start": 3511,
+      "end": 3516,
       "loc": {
         "start": {
           "line": 102,
@@ -18306,8 +18306,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 3561,
-      "end": 3562,
+      "start": 3517,
+      "end": 3518,
       "loc": {
         "start": {
           "line": 102,
@@ -18333,8 +18333,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 3563,
-      "end": 3567,
+      "start": 3519,
+      "end": 3523,
       "loc": {
         "start": {
           "line": 102,
@@ -18358,8 +18358,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3567,
-      "end": 3568,
+      "start": 3523,
+      "end": 3524,
       "loc": {
         "start": {
           "line": 102,
@@ -18384,8 +18384,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3568,
-      "end": 3569,
+      "start": 3524,
+      "end": 3525,
       "loc": {
         "start": {
           "line": 102,
@@ -18410,8 +18410,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 3569,
-      "end": 3573,
+      "start": 3525,
+      "end": 3529,
       "loc": {
         "start": {
           "line": 102,
@@ -18435,8 +18435,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3573,
-      "end": 3574,
+      "start": 3529,
+      "end": 3530,
       "loc": {
         "start": {
           "line": 102,
@@ -18461,8 +18461,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3574,
-      "end": 3579,
+      "start": 3530,
+      "end": 3535,
       "loc": {
         "start": {
           "line": 102,
@@ -18487,8 +18487,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3579,
-      "end": 3580,
+      "start": 3535,
+      "end": 3536,
       "loc": {
         "start": {
           "line": 102,
@@ -18513,8 +18513,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 3580,
-      "end": 3584,
+      "start": 3536,
+      "end": 3540,
       "loc": {
         "start": {
           "line": 102,
@@ -18538,8 +18538,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3584,
-      "end": 3585,
+      "start": 3540,
+      "end": 3541,
       "loc": {
         "start": {
           "line": 102,
@@ -18563,8 +18563,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3585,
-      "end": 3586,
+      "start": 3541,
+      "end": 3542,
       "loc": {
         "start": {
           "line": 102,
@@ -18588,8 +18588,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3587,
-      "end": 3588,
+      "start": 3543,
+      "end": 3544,
       "loc": {
         "start": {
           "line": 102,
@@ -18616,8 +18616,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 3629,
-      "end": 3635,
+      "start": 3585,
+      "end": 3591,
       "loc": {
         "start": {
           "line": 103,
@@ -18644,8 +18644,8 @@
         "updateContext": null
       },
       "value": "false",
-      "start": 3636,
-      "end": 3641,
+      "start": 3592,
+      "end": 3597,
       "loc": {
         "start": {
           "line": 103,
@@ -18669,8 +18669,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3678,
-      "end": 3679,
+      "start": 3634,
+      "end": 3635,
       "loc": {
         "start": {
           "line": 104,
@@ -18697,8 +18697,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 3716,
-      "end": 3718,
+      "start": 3672,
+      "end": 3674,
       "loc": {
         "start": {
           "line": 105,
@@ -18722,8 +18722,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3719,
-      "end": 3720,
+      "start": 3675,
+      "end": 3676,
       "loc": {
         "start": {
           "line": 105,
@@ -18750,8 +18750,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3720,
-      "end": 3724,
+      "start": 3676,
+      "end": 3680,
       "loc": {
         "start": {
           "line": 105,
@@ -18776,8 +18776,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3724,
-      "end": 3725,
+      "start": 3680,
+      "end": 3681,
       "loc": {
         "start": {
           "line": 105,
@@ -18802,8 +18802,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3725,
-      "end": 3741,
+      "start": 3681,
+      "end": 3697,
       "loc": {
         "start": {
           "line": 105,
@@ -18828,8 +18828,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3741,
-      "end": 3742,
+      "start": 3697,
+      "end": 3698,
       "loc": {
         "start": {
           "line": 105,
@@ -18854,8 +18854,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 3742,
-      "end": 3747,
+      "start": 3698,
+      "end": 3703,
       "loc": {
         "start": {
           "line": 105,
@@ -18881,8 +18881,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 3748,
-      "end": 3751,
+      "start": 3704,
+      "end": 3707,
       "loc": {
         "start": {
           "line": 105,
@@ -18907,8 +18907,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 3752,
-      "end": 3761,
+      "start": 3708,
+      "end": 3717,
       "loc": {
         "start": {
           "line": 105,
@@ -18934,8 +18934,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 3762,
-      "end": 3764,
+      "start": 3718,
+      "end": 3720,
       "loc": {
         "start": {
           "line": 105,
@@ -18961,8 +18961,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 3805,
-      "end": 3806,
+      "start": 3761,
+      "end": 3762,
       "loc": {
         "start": {
           "line": 106,
@@ -18989,8 +18989,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 3806,
-      "end": 3809,
+      "start": 3762,
+      "end": 3765,
       "loc": {
         "start": {
           "line": 106,
@@ -19015,8 +19015,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 3810,
-      "end": 3816,
+      "start": 3766,
+      "end": 3772,
       "loc": {
         "start": {
           "line": 106,
@@ -19040,8 +19040,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3816,
-      "end": 3817,
+      "start": 3772,
+      "end": 3773,
       "loc": {
         "start": {
           "line": 106,
@@ -19067,8 +19067,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 3817,
-      "end": 3821,
+      "start": 3773,
+      "end": 3777,
       "loc": {
         "start": {
           "line": 106,
@@ -19094,8 +19094,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 3822,
-      "end": 3823,
+      "start": 3778,
+      "end": 3779,
       "loc": {
         "start": {
           "line": 106,
@@ -19122,8 +19122,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 3824,
-      "end": 3828,
+      "start": 3780,
+      "end": 3784,
       "loc": {
         "start": {
           "line": 106,
@@ -19148,8 +19148,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3828,
-      "end": 3829,
+      "start": 3784,
+      "end": 3785,
       "loc": {
         "start": {
           "line": 106,
@@ -19174,8 +19174,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 3829,
-      "end": 3845,
+      "start": 3785,
+      "end": 3801,
       "loc": {
         "start": {
           "line": 106,
@@ -19200,8 +19200,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3845,
-      "end": 3846,
+      "start": 3801,
+      "end": 3802,
       "loc": {
         "start": {
           "line": 106,
@@ -19226,8 +19226,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 3846,
-      "end": 3851,
+      "start": 3802,
+      "end": 3807,
       "loc": {
         "start": {
           "line": 106,
@@ -19253,8 +19253,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 3852,
-      "end": 3853,
+      "start": 3808,
+      "end": 3809,
       "loc": {
         "start": {
           "line": 106,
@@ -19280,8 +19280,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 3854,
-      "end": 3858,
+      "start": 3810,
+      "end": 3814,
       "loc": {
         "start": {
           "line": 106,
@@ -19305,8 +19305,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3858,
-      "end": 3859,
+      "start": 3814,
+      "end": 3815,
       "loc": {
         "start": {
           "line": 106,
@@ -19331,8 +19331,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3859,
-      "end": 3860,
+      "start": 3815,
+      "end": 3816,
       "loc": {
         "start": {
           "line": 106,
@@ -19357,8 +19357,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 3860,
-      "end": 3864,
+      "start": 3816,
+      "end": 3820,
       "loc": {
         "start": {
           "line": 106,
@@ -19382,8 +19382,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3864,
-      "end": 3865,
+      "start": 3820,
+      "end": 3821,
       "loc": {
         "start": {
           "line": 106,
@@ -19408,8 +19408,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 3865,
-      "end": 3870,
+      "start": 3821,
+      "end": 3826,
       "loc": {
         "start": {
           "line": 106,
@@ -19434,8 +19434,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3870,
-      "end": 3871,
+      "start": 3826,
+      "end": 3827,
       "loc": {
         "start": {
           "line": 106,
@@ -19460,8 +19460,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 3871,
-      "end": 3876,
+      "start": 3827,
+      "end": 3832,
       "loc": {
         "start": {
           "line": 106,
@@ -19486,8 +19486,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 3876,
-      "end": 3877,
+      "start": 3832,
+      "end": 3833,
       "loc": {
         "start": {
           "line": 106,
@@ -19512,8 +19512,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 3877,
-      "end": 3881,
+      "start": 3833,
+      "end": 3837,
       "loc": {
         "start": {
           "line": 106,
@@ -19537,8 +19537,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3881,
-      "end": 3882,
+      "start": 3837,
+      "end": 3838,
       "loc": {
         "start": {
           "line": 106,
@@ -19562,8 +19562,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3882,
-      "end": 3883,
+      "start": 3838,
+      "end": 3839,
       "loc": {
         "start": {
           "line": 106,
@@ -19587,8 +19587,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3884,
-      "end": 3885,
+      "start": 3840,
+      "end": 3841,
       "loc": {
         "start": {
           "line": 106,
@@ -19615,8 +19615,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 3926,
-      "end": 3932,
+      "start": 3882,
+      "end": 3888,
       "loc": {
         "start": {
           "line": 107,
@@ -19643,8 +19643,8 @@
         "updateContext": null
       },
       "value": "false",
-      "start": 3933,
-      "end": 3938,
+      "start": 3889,
+      "end": 3894,
       "loc": {
         "start": {
           "line": 107,
@@ -19668,8 +19668,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 3975,
-      "end": 3976,
+      "start": 3931,
+      "end": 3932,
       "loc": {
         "start": {
           "line": 108,
@@ -19696,8 +19696,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 4013,
-      "end": 4019,
+      "start": 3969,
+      "end": 3975,
       "loc": {
         "start": {
           "line": 109,
@@ -19723,8 +19723,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 4020,
-      "end": 4021,
+      "start": 3976,
+      "end": 3977,
       "loc": {
         "start": {
           "line": 109,
@@ -19748,8 +19748,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4021,
-      "end": 4022,
+      "start": 3977,
+      "end": 3978,
       "loc": {
         "start": {
           "line": 109,
@@ -19776,8 +19776,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4022,
-      "end": 4026,
+      "start": 3978,
+      "end": 3982,
       "loc": {
         "start": {
           "line": 109,
@@ -19802,8 +19802,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4026,
-      "end": 4027,
+      "start": 3982,
+      "end": 3983,
       "loc": {
         "start": {
           "line": 109,
@@ -19828,8 +19828,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4027,
-      "end": 4043,
+      "start": 3983,
+      "end": 3999,
       "loc": {
         "start": {
           "line": 109,
@@ -19854,8 +19854,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4043,
-      "end": 4044,
+      "start": 3999,
+      "end": 4000,
       "loc": {
         "start": {
           "line": 109,
@@ -19880,8 +19880,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 4044,
-      "end": 4050,
+      "start": 4000,
+      "end": 4006,
       "loc": {
         "start": {
           "line": 109,
@@ -19907,8 +19907,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 4051,
-      "end": 4054,
+      "start": 4007,
+      "end": 4010,
       "loc": {
         "start": {
           "line": 109,
@@ -19933,8 +19933,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 4055,
-      "end": 4064,
+      "start": 4011,
+      "end": 4020,
       "loc": {
         "start": {
           "line": 109,
@@ -19960,8 +19960,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 4065,
-      "end": 4067,
+      "start": 4021,
+      "end": 4023,
       "loc": {
         "start": {
           "line": 109,
@@ -19987,8 +19987,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 4104,
-      "end": 4105,
+      "start": 4060,
+      "end": 4061,
       "loc": {
         "start": {
           "line": 110,
@@ -20015,8 +20015,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 4105,
-      "end": 4108,
+      "start": 4061,
+      "end": 4064,
       "loc": {
         "start": {
           "line": 110,
@@ -20041,8 +20041,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 4109,
-      "end": 4115,
+      "start": 4065,
+      "end": 4071,
       "loc": {
         "start": {
           "line": 110,
@@ -20066,8 +20066,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4115,
-      "end": 4116,
+      "start": 4071,
+      "end": 4072,
       "loc": {
         "start": {
           "line": 110,
@@ -20093,8 +20093,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 4116,
-      "end": 4120,
+      "start": 4072,
+      "end": 4076,
       "loc": {
         "start": {
           "line": 110,
@@ -20120,8 +20120,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 4121,
-      "end": 4122,
+      "start": 4077,
+      "end": 4078,
       "loc": {
         "start": {
           "line": 110,
@@ -20148,8 +20148,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4123,
-      "end": 4127,
+      "start": 4079,
+      "end": 4083,
       "loc": {
         "start": {
           "line": 110,
@@ -20174,8 +20174,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4127,
-      "end": 4128,
+      "start": 4083,
+      "end": 4084,
       "loc": {
         "start": {
           "line": 110,
@@ -20200,8 +20200,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4128,
-      "end": 4144,
+      "start": 4084,
+      "end": 4100,
       "loc": {
         "start": {
           "line": 110,
@@ -20226,8 +20226,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4144,
-      "end": 4145,
+      "start": 4100,
+      "end": 4101,
       "loc": {
         "start": {
           "line": 110,
@@ -20252,8 +20252,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 4145,
-      "end": 4151,
+      "start": 4101,
+      "end": 4107,
       "loc": {
         "start": {
           "line": 110,
@@ -20279,8 +20279,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 4152,
-      "end": 4153,
+      "start": 4108,
+      "end": 4109,
       "loc": {
         "start": {
           "line": 110,
@@ -20306,8 +20306,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 4154,
-      "end": 4158,
+      "start": 4110,
+      "end": 4114,
       "loc": {
         "start": {
           "line": 110,
@@ -20331,8 +20331,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4158,
-      "end": 4159,
+      "start": 4114,
+      "end": 4115,
       "loc": {
         "start": {
           "line": 110,
@@ -20357,8 +20357,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4159,
-      "end": 4160,
+      "start": 4115,
+      "end": 4116,
       "loc": {
         "start": {
           "line": 110,
@@ -20383,8 +20383,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 4160,
-      "end": 4164,
+      "start": 4116,
+      "end": 4120,
       "loc": {
         "start": {
           "line": 110,
@@ -20408,8 +20408,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4164,
-      "end": 4165,
+      "start": 4120,
+      "end": 4121,
       "loc": {
         "start": {
           "line": 110,
@@ -20434,8 +20434,8 @@
         "binop": null
       },
       "value": "track",
-      "start": 4165,
-      "end": 4170,
+      "start": 4121,
+      "end": 4126,
       "loc": {
         "start": {
           "line": 110,
@@ -20460,8 +20460,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4170,
-      "end": 4171,
+      "start": 4126,
+      "end": 4127,
       "loc": {
         "start": {
           "line": 110,
@@ -20486,8 +20486,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 4171,
-      "end": 4176,
+      "start": 4127,
+      "end": 4132,
       "loc": {
         "start": {
           "line": 110,
@@ -20512,8 +20512,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4176,
-      "end": 4177,
+      "start": 4132,
+      "end": 4133,
       "loc": {
         "start": {
           "line": 110,
@@ -20538,8 +20538,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 4177,
-      "end": 4183,
+      "start": 4133,
+      "end": 4139,
       "loc": {
         "start": {
           "line": 110,
@@ -20564,8 +20564,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4183,
-      "end": 4184,
+      "start": 4139,
+      "end": 4140,
       "loc": {
         "start": {
           "line": 110,
@@ -20590,8 +20590,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 4184,
-      "end": 4188,
+      "start": 4140,
+      "end": 4144,
       "loc": {
         "start": {
           "line": 110,
@@ -20615,8 +20615,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4188,
-      "end": 4189,
+      "start": 4144,
+      "end": 4145,
       "loc": {
         "start": {
           "line": 110,
@@ -20640,8 +20640,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4189,
-      "end": 4190,
+      "start": 4145,
+      "end": 4146,
       "loc": {
         "start": {
           "line": 110,
@@ -20665,8 +20665,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4223,
-      "end": 4224,
+      "start": 4179,
+      "end": 4180,
       "loc": {
         "start": {
           "line": 111,
@@ -20690,8 +20690,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4224,
-      "end": 4225,
+      "start": 4180,
+      "end": 4181,
       "loc": {
         "start": {
           "line": 111,
@@ -20715,8 +20715,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4250,
-      "end": 4251,
+      "start": 4206,
+      "end": 4207,
       "loc": {
         "start": {
           "line": 112,
@@ -20740,8 +20740,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4251,
-      "end": 4252,
+      "start": 4207,
+      "end": 4208,
       "loc": {
         "start": {
           "line": 112,
@@ -20765,8 +20765,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4273,
-      "end": 4274,
+      "start": 4229,
+      "end": 4230,
       "loc": {
         "start": {
           "line": 113,
@@ -20793,8 +20793,8 @@
         "updateContext": null
       },
       "value": "case",
-      "start": 4311,
-      "end": 4315,
+      "start": 4267,
+      "end": 4271,
       "loc": {
         "start": {
           "line": 114,
@@ -20820,8 +20820,8 @@
         "updateContext": null
       },
       "value": "albums",
-      "start": 4316,
-      "end": 4324,
+      "start": 4272,
+      "end": 4280,
       "loc": {
         "start": {
           "line": 114,
@@ -20846,8 +20846,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4324,
-      "end": 4325,
+      "start": 4280,
+      "end": 4281,
       "loc": {
         "start": {
           "line": 114,
@@ -20874,8 +20874,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 4346,
-      "end": 4352,
+      "start": 4302,
+      "end": 4308,
       "loc": {
         "start": {
           "line": 115,
@@ -20899,8 +20899,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4353,
-      "end": 4354,
+      "start": 4309,
+      "end": 4310,
       "loc": {
         "start": {
           "line": 115,
@@ -20925,8 +20925,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4379,
-      "end": 4380,
+      "start": 4335,
+      "end": 4336,
       "loc": {
         "start": {
           "line": 116,
@@ -20951,8 +20951,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 4380,
-      "end": 4383,
+      "start": 4336,
+      "end": 4339,
       "loc": {
         "start": {
           "line": 116,
@@ -20977,8 +20977,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4383,
-      "end": 4384,
+      "start": 4339,
+      "end": 4340,
       "loc": {
         "start": {
           "line": 116,
@@ -21003,8 +21003,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4384,
-      "end": 4385,
+      "start": 4340,
+      "end": 4341,
       "loc": {
         "start": {
           "line": 116,
@@ -21029,8 +21029,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 4386,
-      "end": 4392,
+      "start": 4342,
+      "end": 4348,
       "loc": {
         "start": {
           "line": 116,
@@ -21055,8 +21055,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4392,
-      "end": 4393,
+      "start": 4348,
+      "end": 4349,
       "loc": {
         "start": {
           "line": 116,
@@ -21081,8 +21081,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 4393,
-      "end": 4399,
+      "start": 4349,
+      "end": 4355,
       "loc": {
         "start": {
           "line": 116,
@@ -21106,8 +21106,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4399,
-      "end": 4400,
+      "start": 4355,
+      "end": 4356,
       "loc": {
         "start": {
           "line": 116,
@@ -21132,8 +21132,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 4400,
-      "end": 4408,
+      "start": 4356,
+      "end": 4364,
       "loc": {
         "start": {
           "line": 116,
@@ -21158,8 +21158,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4408,
-      "end": 4409,
+      "start": 4364,
+      "end": 4365,
       "loc": {
         "start": {
           "line": 116,
@@ -21184,8 +21184,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 4409,
-      "end": 4413,
+      "start": 4365,
+      "end": 4369,
       "loc": {
         "start": {
           "line": 116,
@@ -21210,8 +21210,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4413,
-      "end": 4414,
+      "start": 4369,
+      "end": 4370,
       "loc": {
         "start": {
           "line": 116,
@@ -21236,8 +21236,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 4414,
-      "end": 4417,
+      "start": 4370,
+      "end": 4373,
       "loc": {
         "start": {
           "line": 116,
@@ -21262,8 +21262,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4417,
-      "end": 4418,
+      "start": 4373,
+      "end": 4374,
       "loc": {
         "start": {
           "line": 116,
@@ -21288,8 +21288,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4418,
-      "end": 4419,
+      "start": 4374,
+      "end": 4375,
       "loc": {
         "start": {
           "line": 116,
@@ -21313,8 +21313,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4420,
-      "end": 4421,
+      "start": 4376,
+      "end": 4377,
       "loc": {
         "start": {
           "line": 116,
@@ -21339,8 +21339,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 4450,
-      "end": 4454,
+      "start": 4406,
+      "end": 4410,
       "loc": {
         "start": {
           "line": 117,
@@ -21365,8 +21365,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4454,
-      "end": 4455,
+      "start": 4410,
+      "end": 4411,
       "loc": {
         "start": {
           "line": 117,
@@ -21391,8 +21391,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 4456,
-      "end": 4464,
+      "start": 4412,
+      "end": 4420,
       "loc": {
         "start": {
           "line": 117,
@@ -21417,8 +21417,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4464,
-      "end": 4465,
+      "start": 4420,
+      "end": 4421,
       "loc": {
         "start": {
           "line": 117,
@@ -21443,8 +21443,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 4465,
-      "end": 4469,
+      "start": 4421,
+      "end": 4425,
       "loc": {
         "start": {
           "line": 117,
@@ -21469,8 +21469,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4469,
-      "end": 4470,
+      "start": 4425,
+      "end": 4426,
       "loc": {
         "start": {
           "line": 117,
@@ -21495,8 +21495,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 4470,
-      "end": 4473,
+      "start": 4426,
+      "end": 4429,
       "loc": {
         "start": {
           "line": 117,
@@ -21521,8 +21521,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4473,
-      "end": 4474,
+      "start": 4429,
+      "end": 4430,
       "loc": {
         "start": {
           "line": 117,
@@ -21547,8 +21547,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4474,
-      "end": 4475,
+      "start": 4430,
+      "end": 4431,
       "loc": {
         "start": {
           "line": 117,
@@ -21573,8 +21573,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 4475,
-      "end": 4479,
+      "start": 4431,
+      "end": 4435,
       "loc": {
         "start": {
           "line": 117,
@@ -21599,8 +21599,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4512,
-      "end": 4513,
+      "start": 4468,
+      "end": 4469,
       "loc": {
         "start": {
           "line": 118,
@@ -21625,8 +21625,8 @@
         "binop": null
       },
       "value": "filter",
-      "start": 4513,
-      "end": 4519,
+      "start": 4469,
+      "end": 4475,
       "loc": {
         "start": {
           "line": 118,
@@ -21650,8 +21650,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4519,
-      "end": 4520,
+      "start": 4475,
+      "end": 4476,
       "loc": {
         "start": {
           "line": 118,
@@ -21676,8 +21676,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 4520,
-      "end": 4525,
+      "start": 4476,
+      "end": 4481,
       "loc": {
         "start": {
           "line": 118,
@@ -21702,8 +21702,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4526,
-      "end": 4528,
+      "start": 4482,
+      "end": 4484,
       "loc": {
         "start": {
           "line": 118,
@@ -21727,8 +21727,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4529,
-      "end": 4530,
+      "start": 4485,
+      "end": 4486,
       "loc": {
         "start": {
           "line": 118,
@@ -21755,8 +21755,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 4567,
-      "end": 4569,
+      "start": 4523,
+      "end": 4525,
       "loc": {
         "start": {
           "line": 119,
@@ -21780,8 +21780,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4570,
-      "end": 4571,
+      "start": 4526,
+      "end": 4527,
       "loc": {
         "start": {
           "line": 119,
@@ -21808,8 +21808,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4571,
-      "end": 4575,
+      "start": 4527,
+      "end": 4531,
       "loc": {
         "start": {
           "line": 119,
@@ -21834,8 +21834,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4575,
-      "end": 4576,
+      "start": 4531,
+      "end": 4532,
       "loc": {
         "start": {
           "line": 119,
@@ -21860,8 +21860,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4576,
-      "end": 4592,
+      "start": 4532,
+      "end": 4548,
       "loc": {
         "start": {
           "line": 119,
@@ -21886,8 +21886,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4592,
-      "end": 4593,
+      "start": 4548,
+      "end": 4549,
       "loc": {
         "start": {
           "line": 119,
@@ -21912,8 +21912,8 @@
         "binop": null
       },
       "value": "available_territory",
-      "start": 4593,
-      "end": 4612,
+      "start": 4549,
+      "end": 4568,
       "loc": {
         "start": {
           "line": 119,
@@ -21939,8 +21939,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 4613,
-      "end": 4616,
+      "start": 4569,
+      "end": 4572,
       "loc": {
         "start": {
           "line": 119,
@@ -21965,8 +21965,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 4617,
-      "end": 4626,
+      "start": 4573,
+      "end": 4582,
       "loc": {
         "start": {
           "line": 119,
@@ -21992,8 +21992,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 4627,
-      "end": 4629,
+      "start": 4583,
+      "end": 4585,
       "loc": {
         "start": {
           "line": 119,
@@ -22019,8 +22019,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 4670,
-      "end": 4671,
+      "start": 4626,
+      "end": 4627,
       "loc": {
         "start": {
           "line": 120,
@@ -22045,8 +22045,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 4671,
-      "end": 4676,
+      "start": 4627,
+      "end": 4632,
       "loc": {
         "start": {
           "line": 120,
@@ -22071,8 +22071,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4676,
-      "end": 4677,
+      "start": 4632,
+      "end": 4633,
       "loc": {
         "start": {
           "line": 120,
@@ -22097,8 +22097,8 @@
         "binop": null
       },
       "value": "available_territories",
-      "start": 4677,
-      "end": 4698,
+      "start": 4633,
+      "end": 4654,
       "loc": {
         "start": {
           "line": 120,
@@ -22123,8 +22123,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4698,
-      "end": 4699,
+      "start": 4654,
+      "end": 4655,
       "loc": {
         "start": {
           "line": 120,
@@ -22149,8 +22149,8 @@
         "binop": null
       },
       "value": "includes",
-      "start": 4699,
-      "end": 4707,
+      "start": 4655,
+      "end": 4663,
       "loc": {
         "start": {
           "line": 120,
@@ -22174,8 +22174,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4707,
-      "end": 4708,
+      "start": 4663,
+      "end": 4664,
       "loc": {
         "start": {
           "line": 120,
@@ -22202,8 +22202,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4708,
-      "end": 4712,
+      "start": 4664,
+      "end": 4668,
       "loc": {
         "start": {
           "line": 120,
@@ -22228,8 +22228,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4712,
-      "end": 4713,
+      "start": 4668,
+      "end": 4669,
       "loc": {
         "start": {
           "line": 120,
@@ -22254,8 +22254,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4713,
-      "end": 4729,
+      "start": 4669,
+      "end": 4685,
       "loc": {
         "start": {
           "line": 120,
@@ -22280,8 +22280,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4729,
-      "end": 4730,
+      "start": 4685,
+      "end": 4686,
       "loc": {
         "start": {
           "line": 120,
@@ -22306,8 +22306,8 @@
         "binop": null
       },
       "value": "available_territory",
-      "start": 4730,
-      "end": 4749,
+      "start": 4686,
+      "end": 4705,
       "loc": {
         "start": {
           "line": 120,
@@ -22331,8 +22331,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4749,
-      "end": 4750,
+      "start": 4705,
+      "end": 4706,
       "loc": {
         "start": {
           "line": 120,
@@ -22356,8 +22356,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4750,
-      "end": 4751,
+      "start": 4706,
+      "end": 4707,
       "loc": {
         "start": {
           "line": 120,
@@ -22381,8 +22381,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4752,
-      "end": 4753,
+      "start": 4708,
+      "end": 4709,
       "loc": {
         "start": {
           "line": 120,
@@ -22409,8 +22409,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 4794,
-      "end": 4800,
+      "start": 4750,
+      "end": 4756,
       "loc": {
         "start": {
           "line": 121,
@@ -22437,8 +22437,8 @@
         "updateContext": null
       },
       "value": "false",
-      "start": 4801,
-      "end": 4806,
+      "start": 4757,
+      "end": 4762,
       "loc": {
         "start": {
           "line": 121,
@@ -22462,8 +22462,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4843,
-      "end": 4844,
+      "start": 4799,
+      "end": 4800,
       "loc": {
         "start": {
           "line": 122,
@@ -22490,8 +22490,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 4881,
-      "end": 4883,
+      "start": 4837,
+      "end": 4839,
       "loc": {
         "start": {
           "line": 123,
@@ -22515,8 +22515,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4884,
-      "end": 4885,
+      "start": 4840,
+      "end": 4841,
       "loc": {
         "start": {
           "line": 123,
@@ -22543,8 +22543,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4885,
-      "end": 4889,
+      "start": 4841,
+      "end": 4845,
       "loc": {
         "start": {
           "line": 123,
@@ -22569,8 +22569,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4889,
-      "end": 4890,
+      "start": 4845,
+      "end": 4846,
       "loc": {
         "start": {
           "line": 123,
@@ -22595,8 +22595,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4890,
-      "end": 4906,
+      "start": 4846,
+      "end": 4862,
       "loc": {
         "start": {
           "line": 123,
@@ -22621,8 +22621,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4906,
-      "end": 4907,
+      "start": 4862,
+      "end": 4863,
       "loc": {
         "start": {
           "line": 123,
@@ -22647,8 +22647,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 4907,
-      "end": 4912,
+      "start": 4863,
+      "end": 4868,
       "loc": {
         "start": {
           "line": 123,
@@ -22674,8 +22674,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 4913,
-      "end": 4916,
+      "start": 4869,
+      "end": 4872,
       "loc": {
         "start": {
           "line": 123,
@@ -22700,8 +22700,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 4917,
-      "end": 4926,
+      "start": 4873,
+      "end": 4882,
       "loc": {
         "start": {
           "line": 123,
@@ -22727,8 +22727,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 4927,
-      "end": 4929,
+      "start": 4883,
+      "end": 4885,
       "loc": {
         "start": {
           "line": 123,
@@ -22754,8 +22754,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 4970,
-      "end": 4971,
+      "start": 4926,
+      "end": 4927,
       "loc": {
         "start": {
           "line": 124,
@@ -22782,8 +22782,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 4971,
-      "end": 4974,
+      "start": 4927,
+      "end": 4930,
       "loc": {
         "start": {
           "line": 124,
@@ -22808,8 +22808,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 4975,
-      "end": 4981,
+      "start": 4931,
+      "end": 4937,
       "loc": {
         "start": {
           "line": 124,
@@ -22833,8 +22833,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 4981,
-      "end": 4982,
+      "start": 4937,
+      "end": 4938,
       "loc": {
         "start": {
           "line": 124,
@@ -22860,8 +22860,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 4982,
-      "end": 4986,
+      "start": 4938,
+      "end": 4942,
       "loc": {
         "start": {
           "line": 124,
@@ -22887,8 +22887,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 4987,
-      "end": 4988,
+      "start": 4943,
+      "end": 4944,
       "loc": {
         "start": {
           "line": 124,
@@ -22915,8 +22915,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 4989,
-      "end": 4993,
+      "start": 4945,
+      "end": 4949,
       "loc": {
         "start": {
           "line": 124,
@@ -22941,8 +22941,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 4993,
-      "end": 4994,
+      "start": 4949,
+      "end": 4950,
       "loc": {
         "start": {
           "line": 124,
@@ -22967,8 +22967,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 4994,
-      "end": 5010,
+      "start": 4950,
+      "end": 4966,
       "loc": {
         "start": {
           "line": 124,
@@ -22993,8 +22993,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5010,
-      "end": 5011,
+      "start": 4966,
+      "end": 4967,
       "loc": {
         "start": {
           "line": 124,
@@ -23019,8 +23019,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 5011,
-      "end": 5016,
+      "start": 4967,
+      "end": 4972,
       "loc": {
         "start": {
           "line": 124,
@@ -23046,8 +23046,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 5017,
-      "end": 5018,
+      "start": 4973,
+      "end": 4974,
       "loc": {
         "start": {
           "line": 124,
@@ -23073,8 +23073,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 5019,
-      "end": 5023,
+      "start": 4975,
+      "end": 4979,
       "loc": {
         "start": {
           "line": 124,
@@ -23098,8 +23098,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5023,
-      "end": 5024,
+      "start": 4979,
+      "end": 4980,
       "loc": {
         "start": {
           "line": 124,
@@ -23124,8 +23124,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5024,
-      "end": 5025,
+      "start": 4980,
+      "end": 4981,
       "loc": {
         "start": {
           "line": 124,
@@ -23150,8 +23150,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 5025,
-      "end": 5029,
+      "start": 4981,
+      "end": 4985,
       "loc": {
         "start": {
           "line": 124,
@@ -23175,8 +23175,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5029,
-      "end": 5030,
+      "start": 4985,
+      "end": 4986,
       "loc": {
         "start": {
           "line": 124,
@@ -23201,8 +23201,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 5030,
-      "end": 5035,
+      "start": 4986,
+      "end": 4991,
       "loc": {
         "start": {
           "line": 124,
@@ -23227,8 +23227,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5035,
-      "end": 5036,
+      "start": 4991,
+      "end": 4992,
       "loc": {
         "start": {
           "line": 124,
@@ -23253,8 +23253,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 5036,
-      "end": 5040,
+      "start": 4992,
+      "end": 4996,
       "loc": {
         "start": {
           "line": 124,
@@ -23278,8 +23278,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5040,
-      "end": 5041,
+      "start": 4996,
+      "end": 4997,
       "loc": {
         "start": {
           "line": 124,
@@ -23303,8 +23303,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5041,
-      "end": 5042,
+      "start": 4997,
+      "end": 4998,
       "loc": {
         "start": {
           "line": 124,
@@ -23328,8 +23328,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5043,
-      "end": 5044,
+      "start": 4999,
+      "end": 5000,
       "loc": {
         "start": {
           "line": 124,
@@ -23356,8 +23356,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 5085,
-      "end": 5091,
+      "start": 5041,
+      "end": 5047,
       "loc": {
         "start": {
           "line": 125,
@@ -23384,8 +23384,8 @@
         "updateContext": null
       },
       "value": "false",
-      "start": 5092,
-      "end": 5097,
+      "start": 5048,
+      "end": 5053,
       "loc": {
         "start": {
           "line": 125,
@@ -23409,8 +23409,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5134,
-      "end": 5135,
+      "start": 5090,
+      "end": 5091,
       "loc": {
         "start": {
           "line": 126,
@@ -23437,8 +23437,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 5172,
-      "end": 5178,
+      "start": 5128,
+      "end": 5134,
       "loc": {
         "start": {
           "line": 127,
@@ -23464,8 +23464,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 5179,
-      "end": 5180,
+      "start": 5135,
+      "end": 5136,
       "loc": {
         "start": {
           "line": 127,
@@ -23489,8 +23489,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5180,
-      "end": 5181,
+      "start": 5136,
+      "end": 5137,
       "loc": {
         "start": {
           "line": 127,
@@ -23517,8 +23517,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 5181,
-      "end": 5185,
+      "start": 5137,
+      "end": 5141,
       "loc": {
         "start": {
           "line": 127,
@@ -23543,8 +23543,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5185,
-      "end": 5186,
+      "start": 5141,
+      "end": 5142,
       "loc": {
         "start": {
           "line": 127,
@@ -23569,8 +23569,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 5186,
-      "end": 5202,
+      "start": 5142,
+      "end": 5158,
       "loc": {
         "start": {
           "line": 127,
@@ -23595,8 +23595,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5202,
-      "end": 5203,
+      "start": 5158,
+      "end": 5159,
       "loc": {
         "start": {
           "line": 127,
@@ -23621,8 +23621,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5203,
-      "end": 5209,
+      "start": 5159,
+      "end": 5165,
       "loc": {
         "start": {
           "line": 127,
@@ -23648,8 +23648,8 @@
         "updateContext": null
       },
       "value": "!==",
-      "start": 5210,
-      "end": 5213,
+      "start": 5166,
+      "end": 5169,
       "loc": {
         "start": {
           "line": 127,
@@ -23674,8 +23674,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 5214,
-      "end": 5223,
+      "start": 5170,
+      "end": 5179,
       "loc": {
         "start": {
           "line": 127,
@@ -23701,8 +23701,8 @@
         "updateContext": null
       },
       "value": "&&",
-      "start": 5224,
-      "end": 5226,
+      "start": 5180,
+      "end": 5182,
       "loc": {
         "start": {
           "line": 127,
@@ -23728,8 +23728,8 @@
         "updateContext": null
       },
       "value": "!",
-      "start": 5263,
-      "end": 5264,
+      "start": 5219,
+      "end": 5220,
       "loc": {
         "start": {
           "line": 128,
@@ -23756,8 +23756,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 5264,
-      "end": 5267,
+      "start": 5220,
+      "end": 5223,
       "loc": {
         "start": {
           "line": 128,
@@ -23782,8 +23782,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 5268,
-      "end": 5274,
+      "start": 5224,
+      "end": 5230,
       "loc": {
         "start": {
           "line": 128,
@@ -23807,8 +23807,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5274,
-      "end": 5275,
+      "start": 5230,
+      "end": 5231,
       "loc": {
         "start": {
           "line": 128,
@@ -23834,8 +23834,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 5275,
-      "end": 5279,
+      "start": 5231,
+      "end": 5235,
       "loc": {
         "start": {
           "line": 128,
@@ -23861,8 +23861,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 5280,
-      "end": 5281,
+      "start": 5236,
+      "end": 5237,
       "loc": {
         "start": {
           "line": 128,
@@ -23889,8 +23889,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 5282,
-      "end": 5286,
+      "start": 5238,
+      "end": 5242,
       "loc": {
         "start": {
           "line": 128,
@@ -23915,8 +23915,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5286,
-      "end": 5287,
+      "start": 5242,
+      "end": 5243,
       "loc": {
         "start": {
           "line": 128,
@@ -23941,8 +23941,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 5287,
-      "end": 5303,
+      "start": 5243,
+      "end": 5259,
       "loc": {
         "start": {
           "line": 128,
@@ -23967,8 +23967,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5303,
-      "end": 5304,
+      "start": 5259,
+      "end": 5260,
       "loc": {
         "start": {
           "line": 128,
@@ -23993,8 +23993,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5304,
-      "end": 5310,
+      "start": 5260,
+      "end": 5266,
       "loc": {
         "start": {
           "line": 128,
@@ -24020,8 +24020,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 5311,
-      "end": 5312,
+      "start": 5267,
+      "end": 5268,
       "loc": {
         "start": {
           "line": 128,
@@ -24047,8 +24047,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 5313,
-      "end": 5317,
+      "start": 5269,
+      "end": 5273,
       "loc": {
         "start": {
           "line": 128,
@@ -24072,8 +24072,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5317,
-      "end": 5318,
+      "start": 5273,
+      "end": 5274,
       "loc": {
         "start": {
           "line": 128,
@@ -24098,8 +24098,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5318,
-      "end": 5319,
+      "start": 5274,
+      "end": 5275,
       "loc": {
         "start": {
           "line": 128,
@@ -24124,8 +24124,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 5319,
-      "end": 5323,
+      "start": 5275,
+      "end": 5279,
       "loc": {
         "start": {
           "line": 128,
@@ -24149,8 +24149,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5323,
-      "end": 5324,
+      "start": 5279,
+      "end": 5280,
       "loc": {
         "start": {
           "line": 128,
@@ -24175,8 +24175,8 @@
         "binop": null
       },
       "value": "album",
-      "start": 5324,
-      "end": 5329,
+      "start": 5280,
+      "end": 5285,
       "loc": {
         "start": {
           "line": 128,
@@ -24201,8 +24201,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5329,
-      "end": 5330,
+      "start": 5285,
+      "end": 5286,
       "loc": {
         "start": {
           "line": 128,
@@ -24227,8 +24227,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5330,
-      "end": 5336,
+      "start": 5286,
+      "end": 5292,
       "loc": {
         "start": {
           "line": 128,
@@ -24253,8 +24253,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5336,
-      "end": 5337,
+      "start": 5292,
+      "end": 5293,
       "loc": {
         "start": {
           "line": 128,
@@ -24279,8 +24279,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 5337,
-      "end": 5341,
+      "start": 5293,
+      "end": 5297,
       "loc": {
         "start": {
           "line": 128,
@@ -24304,8 +24304,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5341,
-      "end": 5342,
+      "start": 5297,
+      "end": 5298,
       "loc": {
         "start": {
           "line": 128,
@@ -24329,8 +24329,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5342,
-      "end": 5343,
+      "start": 5298,
+      "end": 5299,
       "loc": {
         "start": {
           "line": 128,
@@ -24354,8 +24354,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5376,
-      "end": 5377,
+      "start": 5332,
+      "end": 5333,
       "loc": {
         "start": {
           "line": 129,
@@ -24379,8 +24379,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5377,
-      "end": 5378,
+      "start": 5333,
+      "end": 5334,
       "loc": {
         "start": {
           "line": 129,
@@ -24404,8 +24404,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5403,
-      "end": 5404,
+      "start": 5359,
+      "end": 5360,
       "loc": {
         "start": {
           "line": 130,
@@ -24429,8 +24429,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5404,
-      "end": 5405,
+      "start": 5360,
+      "end": 5361,
       "loc": {
         "start": {
           "line": 130,
@@ -24454,8 +24454,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5426,
-      "end": 5427,
+      "start": 5382,
+      "end": 5383,
       "loc": {
         "start": {
           "line": 131,
@@ -24482,8 +24482,8 @@
         "updateContext": null
       },
       "value": "case",
-      "start": 5464,
-      "end": 5468,
+      "start": 5420,
+      "end": 5424,
       "loc": {
         "start": {
           "line": 132,
@@ -24509,8 +24509,8 @@
         "updateContext": null
       },
       "value": "artists",
-      "start": 5469,
-      "end": 5478,
+      "start": 5425,
+      "end": 5434,
       "loc": {
         "start": {
           "line": 132,
@@ -24535,8 +24535,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5478,
-      "end": 5479,
+      "start": 5434,
+      "end": 5435,
       "loc": {
         "start": {
           "line": 132,
@@ -24563,8 +24563,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 5500,
-      "end": 5506,
+      "start": 5456,
+      "end": 5462,
       "loc": {
         "start": {
           "line": 133,
@@ -24588,8 +24588,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5507,
-      "end": 5508,
+      "start": 5463,
+      "end": 5464,
       "loc": {
         "start": {
           "line": 133,
@@ -24614,8 +24614,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5533,
-      "end": 5534,
+      "start": 5489,
+      "end": 5490,
       "loc": {
         "start": {
           "line": 134,
@@ -24640,8 +24640,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 5534,
-      "end": 5537,
+      "start": 5490,
+      "end": 5493,
       "loc": {
         "start": {
           "line": 134,
@@ -24666,8 +24666,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5537,
-      "end": 5538,
+      "start": 5493,
+      "end": 5494,
       "loc": {
         "start": {
           "line": 134,
@@ -24692,8 +24692,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5538,
-      "end": 5539,
+      "start": 5494,
+      "end": 5495,
       "loc": {
         "start": {
           "line": 134,
@@ -24718,8 +24718,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 5540,
-      "end": 5546,
+      "start": 5496,
+      "end": 5502,
       "loc": {
         "start": {
           "line": 134,
@@ -24744,8 +24744,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5546,
-      "end": 5547,
+      "start": 5502,
+      "end": 5503,
       "loc": {
         "start": {
           "line": 134,
@@ -24770,8 +24770,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 5547,
-      "end": 5553,
+      "start": 5503,
+      "end": 5509,
       "loc": {
         "start": {
           "line": 134,
@@ -24795,8 +24795,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5553,
-      "end": 5554,
+      "start": 5509,
+      "end": 5510,
       "loc": {
         "start": {
           "line": 134,
@@ -24821,8 +24821,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 5554,
-      "end": 5562,
+      "start": 5510,
+      "end": 5518,
       "loc": {
         "start": {
           "line": 134,
@@ -24847,8 +24847,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5562,
-      "end": 5563,
+      "start": 5518,
+      "end": 5519,
       "loc": {
         "start": {
           "line": 134,
@@ -24873,8 +24873,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 5563,
-      "end": 5567,
+      "start": 5519,
+      "end": 5523,
       "loc": {
         "start": {
           "line": 134,
@@ -24899,8 +24899,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5567,
-      "end": 5568,
+      "start": 5523,
+      "end": 5524,
       "loc": {
         "start": {
           "line": 134,
@@ -24925,8 +24925,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 5568,
-      "end": 5571,
+      "start": 5524,
+      "end": 5527,
       "loc": {
         "start": {
           "line": 134,
@@ -24951,8 +24951,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5571,
-      "end": 5572,
+      "start": 5527,
+      "end": 5528,
       "loc": {
         "start": {
           "line": 134,
@@ -24977,8 +24977,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5572,
-      "end": 5573,
+      "start": 5528,
+      "end": 5529,
       "loc": {
         "start": {
           "line": 134,
@@ -25002,8 +25002,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5574,
-      "end": 5575,
+      "start": 5530,
+      "end": 5531,
       "loc": {
         "start": {
           "line": 134,
@@ -25028,8 +25028,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 5604,
-      "end": 5608,
+      "start": 5560,
+      "end": 5564,
       "loc": {
         "start": {
           "line": 135,
@@ -25054,8 +25054,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5608,
-      "end": 5609,
+      "start": 5564,
+      "end": 5565,
       "loc": {
         "start": {
           "line": 135,
@@ -25080,8 +25080,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 5610,
-      "end": 5618,
+      "start": 5566,
+      "end": 5574,
       "loc": {
         "start": {
           "line": 135,
@@ -25106,8 +25106,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5618,
-      "end": 5619,
+      "start": 5574,
+      "end": 5575,
       "loc": {
         "start": {
           "line": 135,
@@ -25132,8 +25132,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 5619,
-      "end": 5623,
+      "start": 5575,
+      "end": 5579,
       "loc": {
         "start": {
           "line": 135,
@@ -25158,8 +25158,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5623,
-      "end": 5624,
+      "start": 5579,
+      "end": 5580,
       "loc": {
         "start": {
           "line": 135,
@@ -25184,8 +25184,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 5624,
-      "end": 5627,
+      "start": 5580,
+      "end": 5583,
       "loc": {
         "start": {
           "line": 135,
@@ -25210,8 +25210,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5627,
-      "end": 5628,
+      "start": 5583,
+      "end": 5584,
       "loc": {
         "start": {
           "line": 135,
@@ -25236,8 +25236,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5628,
-      "end": 5629,
+      "start": 5584,
+      "end": 5585,
       "loc": {
         "start": {
           "line": 135,
@@ -25262,8 +25262,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 5629,
-      "end": 5633,
+      "start": 5585,
+      "end": 5589,
       "loc": {
         "start": {
           "line": 135,
@@ -25288,8 +25288,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5666,
-      "end": 5667,
+      "start": 5622,
+      "end": 5623,
       "loc": {
         "start": {
           "line": 136,
@@ -25314,8 +25314,8 @@
         "binop": null
       },
       "value": "filter",
-      "start": 5667,
-      "end": 5673,
+      "start": 5623,
+      "end": 5629,
       "loc": {
         "start": {
           "line": 136,
@@ -25339,8 +25339,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5673,
-      "end": 5674,
+      "start": 5629,
+      "end": 5630,
       "loc": {
         "start": {
           "line": 136,
@@ -25365,8 +25365,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5674,
-      "end": 5680,
+      "start": 5630,
+      "end": 5636,
       "loc": {
         "start": {
           "line": 136,
@@ -25391,8 +25391,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5681,
-      "end": 5683,
+      "start": 5637,
+      "end": 5639,
       "loc": {
         "start": {
           "line": 136,
@@ -25416,8 +25416,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5684,
-      "end": 5685,
+      "start": 5640,
+      "end": 5641,
       "loc": {
         "start": {
           "line": 136,
@@ -25444,8 +25444,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 5722,
-      "end": 5724,
+      "start": 5678,
+      "end": 5680,
       "loc": {
         "start": {
           "line": 137,
@@ -25469,8 +25469,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5725,
-      "end": 5726,
+      "start": 5681,
+      "end": 5682,
       "loc": {
         "start": {
           "line": 137,
@@ -25497,8 +25497,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 5726,
-      "end": 5730,
+      "start": 5682,
+      "end": 5686,
       "loc": {
         "start": {
           "line": 137,
@@ -25523,8 +25523,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5730,
-      "end": 5731,
+      "start": 5686,
+      "end": 5687,
       "loc": {
         "start": {
           "line": 137,
@@ -25549,8 +25549,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 5731,
-      "end": 5747,
+      "start": 5687,
+      "end": 5703,
       "loc": {
         "start": {
           "line": 137,
@@ -25575,8 +25575,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5747,
-      "end": 5748,
+      "start": 5703,
+      "end": 5704,
       "loc": {
         "start": {
           "line": 137,
@@ -25601,8 +25601,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5748,
-      "end": 5754,
+      "start": 5704,
+      "end": 5710,
       "loc": {
         "start": {
           "line": 137,
@@ -25628,8 +25628,8 @@
         "updateContext": null
       },
       "value": "===",
-      "start": 5755,
-      "end": 5758,
+      "start": 5711,
+      "end": 5714,
       "loc": {
         "start": {
           "line": 137,
@@ -25654,8 +25654,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 5759,
-      "end": 5768,
+      "start": 5715,
+      "end": 5724,
       "loc": {
         "start": {
           "line": 137,
@@ -25679,8 +25679,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5768,
-      "end": 5769,
+      "start": 5724,
+      "end": 5725,
       "loc": {
         "start": {
           "line": 137,
@@ -25704,8 +25704,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5770,
-      "end": 5771,
+      "start": 5726,
+      "end": 5727,
       "loc": {
         "start": {
           "line": 137,
@@ -25732,8 +25732,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 5812,
-      "end": 5818,
+      "start": 5768,
+      "end": 5774,
       "loc": {
         "start": {
           "line": 138,
@@ -25760,8 +25760,8 @@
         "updateContext": null
       },
       "value": "true",
-      "start": 5819,
-      "end": 5823,
+      "start": 5775,
+      "end": 5779,
       "loc": {
         "start": {
           "line": 138,
@@ -25785,8 +25785,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5860,
-      "end": 5861,
+      "start": 5816,
+      "end": 5817,
       "loc": {
         "start": {
           "line": 139,
@@ -25813,8 +25813,8 @@
         "updateContext": null
       },
       "value": "else",
-      "start": 5862,
-      "end": 5866,
+      "start": 5818,
+      "end": 5822,
       "loc": {
         "start": {
           "line": 139,
@@ -25838,8 +25838,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5867,
-      "end": 5868,
+      "start": 5823,
+      "end": 5824,
       "loc": {
         "start": {
           "line": 139,
@@ -25866,8 +25866,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 5909,
-      "end": 5915,
+      "start": 5865,
+      "end": 5871,
       "loc": {
         "start": {
           "line": 140,
@@ -25894,8 +25894,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 5916,
-      "end": 5919,
+      "start": 5872,
+      "end": 5875,
       "loc": {
         "start": {
           "line": 140,
@@ -25920,8 +25920,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 5920,
-      "end": 5926,
+      "start": 5876,
+      "end": 5882,
       "loc": {
         "start": {
           "line": 140,
@@ -25945,8 +25945,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5926,
-      "end": 5927,
+      "start": 5882,
+      "end": 5883,
       "loc": {
         "start": {
           "line": 140,
@@ -25972,8 +25972,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 5927,
-      "end": 5931,
+      "start": 5883,
+      "end": 5887,
       "loc": {
         "start": {
           "line": 140,
@@ -25999,8 +25999,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 5932,
-      "end": 5933,
+      "start": 5888,
+      "end": 5889,
       "loc": {
         "start": {
           "line": 140,
@@ -26027,8 +26027,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 5934,
-      "end": 5938,
+      "start": 5890,
+      "end": 5894,
       "loc": {
         "start": {
           "line": 140,
@@ -26053,8 +26053,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5938,
-      "end": 5939,
+      "start": 5894,
+      "end": 5895,
       "loc": {
         "start": {
           "line": 140,
@@ -26079,8 +26079,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 5939,
-      "end": 5955,
+      "start": 5895,
+      "end": 5911,
       "loc": {
         "start": {
           "line": 140,
@@ -26105,8 +26105,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5955,
-      "end": 5956,
+      "start": 5911,
+      "end": 5912,
       "loc": {
         "start": {
           "line": 140,
@@ -26131,8 +26131,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5956,
-      "end": 5962,
+      "start": 5912,
+      "end": 5918,
       "loc": {
         "start": {
           "line": 140,
@@ -26158,8 +26158,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 5963,
-      "end": 5964,
+      "start": 5919,
+      "end": 5920,
       "loc": {
         "start": {
           "line": 140,
@@ -26185,8 +26185,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 5965,
-      "end": 5969,
+      "start": 5921,
+      "end": 5925,
       "loc": {
         "start": {
           "line": 140,
@@ -26210,8 +26210,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5969,
-      "end": 5970,
+      "start": 5925,
+      "end": 5926,
       "loc": {
         "start": {
           "line": 140,
@@ -26236,8 +26236,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5970,
-      "end": 5971,
+      "start": 5926,
+      "end": 5927,
       "loc": {
         "start": {
           "line": 140,
@@ -26262,8 +26262,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 5971,
-      "end": 5975,
+      "start": 5927,
+      "end": 5931,
       "loc": {
         "start": {
           "line": 140,
@@ -26287,8 +26287,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5975,
-      "end": 5976,
+      "start": 5931,
+      "end": 5932,
       "loc": {
         "start": {
           "line": 140,
@@ -26313,8 +26313,8 @@
         "binop": null
       },
       "value": "artist",
-      "start": 5976,
-      "end": 5982,
+      "start": 5932,
+      "end": 5938,
       "loc": {
         "start": {
           "line": 140,
@@ -26339,8 +26339,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 5982,
-      "end": 5983,
+      "start": 5938,
+      "end": 5939,
       "loc": {
         "start": {
           "line": 140,
@@ -26365,8 +26365,8 @@
         "binop": null
       },
       "value": "name",
-      "start": 5983,
-      "end": 5987,
+      "start": 5939,
+      "end": 5943,
       "loc": {
         "start": {
           "line": 140,
@@ -26390,8 +26390,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 5987,
-      "end": 5988,
+      "start": 5943,
+      "end": 5944,
       "loc": {
         "start": {
           "line": 140,
@@ -26415,8 +26415,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6025,
-      "end": 6026,
+      "start": 5981,
+      "end": 5982,
       "loc": {
         "start": {
           "line": 141,
@@ -26440,8 +26440,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6059,
-      "end": 6060,
+      "start": 6015,
+      "end": 6016,
       "loc": {
         "start": {
           "line": 142,
@@ -26465,8 +26465,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6060,
-      "end": 6061,
+      "start": 6016,
+      "end": 6017,
       "loc": {
         "start": {
           "line": 142,
@@ -26490,8 +26490,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6086,
-      "end": 6087,
+      "start": 6042,
+      "end": 6043,
       "loc": {
         "start": {
           "line": 143,
@@ -26515,8 +26515,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6087,
-      "end": 6088,
+      "start": 6043,
+      "end": 6044,
       "loc": {
         "start": {
           "line": 143,
@@ -26540,8 +26540,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6109,
-      "end": 6110,
+      "start": 6065,
+      "end": 6066,
       "loc": {
         "start": {
           "line": 144,
@@ -26568,8 +26568,8 @@
         "updateContext": null
       },
       "value": "case",
-      "start": 6147,
-      "end": 6151,
+      "start": 6103,
+      "end": 6107,
       "loc": {
         "start": {
           "line": 145,
@@ -26595,8 +26595,8 @@
         "updateContext": null
       },
       "value": "playlists",
-      "start": 6152,
-      "end": 6163,
+      "start": 6108,
+      "end": 6119,
       "loc": {
         "start": {
           "line": 145,
@@ -26621,8 +26621,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6163,
-      "end": 6164,
+      "start": 6119,
+      "end": 6120,
       "loc": {
         "start": {
           "line": 145,
@@ -26649,8 +26649,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 6185,
-      "end": 6191,
+      "start": 6141,
+      "end": 6147,
       "loc": {
         "start": {
           "line": 146,
@@ -26674,8 +26674,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6192,
-      "end": 6193,
+      "start": 6148,
+      "end": 6149,
       "loc": {
         "start": {
           "line": 146,
@@ -26700,8 +26700,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6218,
-      "end": 6219,
+      "start": 6174,
+      "end": 6175,
       "loc": {
         "start": {
           "line": 147,
@@ -26726,8 +26726,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 6219,
-      "end": 6222,
+      "start": 6175,
+      "end": 6178,
       "loc": {
         "start": {
           "line": 147,
@@ -26752,8 +26752,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6222,
-      "end": 6223,
+      "start": 6178,
+      "end": 6179,
       "loc": {
         "start": {
           "line": 147,
@@ -26778,8 +26778,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6223,
-      "end": 6224,
+      "start": 6179,
+      "end": 6180,
       "loc": {
         "start": {
           "line": 147,
@@ -26804,8 +26804,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 6225,
-      "end": 6231,
+      "start": 6181,
+      "end": 6187,
       "loc": {
         "start": {
           "line": 147,
@@ -26830,8 +26830,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6231,
-      "end": 6232,
+      "start": 6187,
+      "end": 6188,
       "loc": {
         "start": {
           "line": 147,
@@ -26856,8 +26856,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 6232,
-      "end": 6238,
+      "start": 6188,
+      "end": 6194,
       "loc": {
         "start": {
           "line": 147,
@@ -26881,8 +26881,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6238,
-      "end": 6239,
+      "start": 6194,
+      "end": 6195,
       "loc": {
         "start": {
           "line": 147,
@@ -26907,8 +26907,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 6239,
-      "end": 6247,
+      "start": 6195,
+      "end": 6203,
       "loc": {
         "start": {
           "line": 147,
@@ -26933,8 +26933,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6247,
-      "end": 6248,
+      "start": 6203,
+      "end": 6204,
       "loc": {
         "start": {
           "line": 147,
@@ -26959,8 +26959,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6248,
-      "end": 6252,
+      "start": 6204,
+      "end": 6208,
       "loc": {
         "start": {
           "line": 147,
@@ -26985,8 +26985,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6252,
-      "end": 6253,
+      "start": 6208,
+      "end": 6209,
       "loc": {
         "start": {
           "line": 147,
@@ -27011,8 +27011,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 6253,
-      "end": 6256,
+      "start": 6209,
+      "end": 6212,
       "loc": {
         "start": {
           "line": 147,
@@ -27037,8 +27037,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6256,
-      "end": 6257,
+      "start": 6212,
+      "end": 6213,
       "loc": {
         "start": {
           "line": 147,
@@ -27063,8 +27063,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6257,
-      "end": 6258,
+      "start": 6213,
+      "end": 6214,
       "loc": {
         "start": {
           "line": 147,
@@ -27088,8 +27088,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6259,
-      "end": 6260,
+      "start": 6215,
+      "end": 6216,
       "loc": {
         "start": {
           "line": 147,
@@ -27114,8 +27114,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6289,
-      "end": 6293,
+      "start": 6245,
+      "end": 6249,
       "loc": {
         "start": {
           "line": 148,
@@ -27140,8 +27140,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6293,
-      "end": 6294,
+      "start": 6249,
+      "end": 6250,
       "loc": {
         "start": {
           "line": 148,
@@ -27166,8 +27166,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 6295,
-      "end": 6303,
+      "start": 6251,
+      "end": 6259,
       "loc": {
         "start": {
           "line": 148,
@@ -27192,8 +27192,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6303,
-      "end": 6304,
+      "start": 6259,
+      "end": 6260,
       "loc": {
         "start": {
           "line": 148,
@@ -27218,8 +27218,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6304,
-      "end": 6308,
+      "start": 6260,
+      "end": 6264,
       "loc": {
         "start": {
           "line": 148,
@@ -27244,8 +27244,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6308,
-      "end": 6309,
+      "start": 6264,
+      "end": 6265,
       "loc": {
         "start": {
           "line": 148,
@@ -27270,8 +27270,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 6309,
-      "end": 6312,
+      "start": 6265,
+      "end": 6268,
       "loc": {
         "start": {
           "line": 148,
@@ -27296,8 +27296,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6312,
-      "end": 6313,
+      "start": 6268,
+      "end": 6269,
       "loc": {
         "start": {
           "line": 148,
@@ -27322,8 +27322,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6313,
-      "end": 6314,
+      "start": 6269,
+      "end": 6270,
       "loc": {
         "start": {
           "line": 148,
@@ -27348,8 +27348,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6314,
-      "end": 6318,
+      "start": 6270,
+      "end": 6274,
       "loc": {
         "start": {
           "line": 148,
@@ -27374,8 +27374,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6351,
-      "end": 6352,
+      "start": 6307,
+      "end": 6308,
       "loc": {
         "start": {
           "line": 149,
@@ -27400,8 +27400,8 @@
         "binop": null
       },
       "value": "filter",
-      "start": 6352,
-      "end": 6358,
+      "start": 6308,
+      "end": 6314,
       "loc": {
         "start": {
           "line": 149,
@@ -27425,8 +27425,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6358,
-      "end": 6359,
+      "start": 6314,
+      "end": 6315,
       "loc": {
         "start": {
           "line": 149,
@@ -27451,8 +27451,8 @@
         "binop": null
       },
       "value": "playlist",
-      "start": 6359,
-      "end": 6367,
+      "start": 6315,
+      "end": 6323,
       "loc": {
         "start": {
           "line": 149,
@@ -27477,8 +27477,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6368,
-      "end": 6370,
+      "start": 6324,
+      "end": 6326,
       "loc": {
         "start": {
           "line": 149,
@@ -27502,8 +27502,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6371,
-      "end": 6372,
+      "start": 6327,
+      "end": 6328,
       "loc": {
         "start": {
           "line": 149,
@@ -27530,8 +27530,8 @@
         "updateContext": null
       },
       "value": "if",
-      "start": 6409,
-      "end": 6411,
+      "start": 6365,
+      "end": 6367,
       "loc": {
         "start": {
           "line": 150,
@@ -27555,8 +27555,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6412,
-      "end": 6413,
+      "start": 6368,
+      "end": 6369,
       "loc": {
         "start": {
           "line": 150,
@@ -27583,8 +27583,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 6413,
-      "end": 6417,
+      "start": 6369,
+      "end": 6373,
       "loc": {
         "start": {
           "line": 150,
@@ -27609,8 +27609,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6417,
-      "end": 6418,
+      "start": 6373,
+      "end": 6374,
       "loc": {
         "start": {
           "line": 150,
@@ -27635,8 +27635,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 6418,
-      "end": 6434,
+      "start": 6374,
+      "end": 6390,
       "loc": {
         "start": {
           "line": 150,
@@ -27661,8 +27661,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6434,
-      "end": 6435,
+      "start": 6390,
+      "end": 6391,
       "loc": {
         "start": {
           "line": 150,
@@ -27687,8 +27687,8 @@
         "binop": null
       },
       "value": "playlist",
-      "start": 6435,
-      "end": 6443,
+      "start": 6391,
+      "end": 6399,
       "loc": {
         "start": {
           "line": 150,
@@ -27714,8 +27714,8 @@
         "updateContext": null
       },
       "value": "===",
-      "start": 6444,
-      "end": 6447,
+      "start": 6400,
+      "end": 6403,
       "loc": {
         "start": {
           "line": 150,
@@ -27740,8 +27740,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 6448,
-      "end": 6457,
+      "start": 6404,
+      "end": 6413,
       "loc": {
         "start": {
           "line": 150,
@@ -27765,8 +27765,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6457,
-      "end": 6458,
+      "start": 6413,
+      "end": 6414,
       "loc": {
         "start": {
           "line": 150,
@@ -27790,8 +27790,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6459,
-      "end": 6460,
+      "start": 6415,
+      "end": 6416,
       "loc": {
         "start": {
           "line": 150,
@@ -27818,8 +27818,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 6501,
-      "end": 6507,
+      "start": 6457,
+      "end": 6463,
       "loc": {
         "start": {
           "line": 151,
@@ -27846,8 +27846,8 @@
         "updateContext": null
       },
       "value": "true",
-      "start": 6508,
-      "end": 6512,
+      "start": 6464,
+      "end": 6468,
       "loc": {
         "start": {
           "line": 151,
@@ -27871,8 +27871,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6549,
-      "end": 6550,
+      "start": 6505,
+      "end": 6506,
       "loc": {
         "start": {
           "line": 152,
@@ -27899,8 +27899,8 @@
         "updateContext": null
       },
       "value": "else",
-      "start": 6551,
-      "end": 6555,
+      "start": 6507,
+      "end": 6511,
       "loc": {
         "start": {
           "line": 152,
@@ -27924,8 +27924,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6556,
-      "end": 6557,
+      "start": 6512,
+      "end": 6513,
       "loc": {
         "start": {
           "line": 152,
@@ -27952,8 +27952,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 6598,
-      "end": 6604,
+      "start": 6554,
+      "end": 6560,
       "loc": {
         "start": {
           "line": 153,
@@ -27980,8 +27980,8 @@
         "updateContext": null
       },
       "value": "new",
-      "start": 6605,
-      "end": 6608,
+      "start": 6561,
+      "end": 6564,
       "loc": {
         "start": {
           "line": 153,
@@ -28006,8 +28006,8 @@
         "binop": null
       },
       "value": "RegExp",
-      "start": 6609,
-      "end": 6615,
+      "start": 6565,
+      "end": 6571,
       "loc": {
         "start": {
           "line": 153,
@@ -28031,8 +28031,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6615,
-      "end": 6616,
+      "start": 6571,
+      "end": 6572,
       "loc": {
         "start": {
           "line": 153,
@@ -28058,8 +28058,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 6616,
-      "end": 6620,
+      "start": 6572,
+      "end": 6576,
       "loc": {
         "start": {
           "line": 153,
@@ -28085,8 +28085,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 6621,
-      "end": 6622,
+      "start": 6577,
+      "end": 6578,
       "loc": {
         "start": {
           "line": 153,
@@ -28113,8 +28113,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 6623,
-      "end": 6627,
+      "start": 6579,
+      "end": 6583,
       "loc": {
         "start": {
           "line": 153,
@@ -28139,8 +28139,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6627,
-      "end": 6628,
+      "start": 6583,
+      "end": 6584,
       "loc": {
         "start": {
           "line": 153,
@@ -28165,8 +28165,8 @@
         "binop": null
       },
       "value": "filterConditions",
-      "start": 6628,
-      "end": 6644,
+      "start": 6584,
+      "end": 6600,
       "loc": {
         "start": {
           "line": 153,
@@ -28191,8 +28191,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6644,
-      "end": 6645,
+      "start": 6600,
+      "end": 6601,
       "loc": {
         "start": {
           "line": 153,
@@ -28217,8 +28217,8 @@
         "binop": null
       },
       "value": "playlist",
-      "start": 6645,
-      "end": 6653,
+      "start": 6601,
+      "end": 6609,
       "loc": {
         "start": {
           "line": 153,
@@ -28244,8 +28244,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 6654,
-      "end": 6655,
+      "start": 6610,
+      "end": 6611,
       "loc": {
         "start": {
           "line": 153,
@@ -28271,8 +28271,8 @@
         "updateContext": null
       },
       "value": ".*",
-      "start": 6656,
-      "end": 6660,
+      "start": 6612,
+      "end": 6616,
       "loc": {
         "start": {
           "line": 153,
@@ -28296,8 +28296,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6660,
-      "end": 6661,
+      "start": 6616,
+      "end": 6617,
       "loc": {
         "start": {
           "line": 153,
@@ -28322,8 +28322,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6661,
-      "end": 6662,
+      "start": 6617,
+      "end": 6618,
       "loc": {
         "start": {
           "line": 153,
@@ -28348,8 +28348,8 @@
         "binop": null
       },
       "value": "test",
-      "start": 6662,
-      "end": 6666,
+      "start": 6618,
+      "end": 6622,
       "loc": {
         "start": {
           "line": 153,
@@ -28373,8 +28373,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6666,
-      "end": 6667,
+      "start": 6622,
+      "end": 6623,
       "loc": {
         "start": {
           "line": 153,
@@ -28399,8 +28399,8 @@
         "binop": null
       },
       "value": "playlist",
-      "start": 6667,
-      "end": 6675,
+      "start": 6623,
+      "end": 6631,
       "loc": {
         "start": {
           "line": 153,
@@ -28425,8 +28425,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6675,
-      "end": 6676,
+      "start": 6631,
+      "end": 6632,
       "loc": {
         "start": {
           "line": 153,
@@ -28451,8 +28451,8 @@
         "binop": null
       },
       "value": "title",
-      "start": 6676,
-      "end": 6681,
+      "start": 6632,
+      "end": 6637,
       "loc": {
         "start": {
           "line": 153,
@@ -28476,8 +28476,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6681,
-      "end": 6682,
+      "start": 6637,
+      "end": 6638,
       "loc": {
         "start": {
           "line": 153,
@@ -28501,8 +28501,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6719,
-      "end": 6720,
+      "start": 6675,
+      "end": 6676,
       "loc": {
         "start": {
           "line": 154,
@@ -28526,8 +28526,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6753,
-      "end": 6754,
+      "start": 6709,
+      "end": 6710,
       "loc": {
         "start": {
           "line": 155,
@@ -28551,8 +28551,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6754,
-      "end": 6755,
+      "start": 6710,
+      "end": 6711,
       "loc": {
         "start": {
           "line": 155,
@@ -28576,8 +28576,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6780,
-      "end": 6781,
+      "start": 6736,
+      "end": 6737,
       "loc": {
         "start": {
           "line": 156,
@@ -28601,8 +28601,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6781,
-      "end": 6782,
+      "start": 6737,
+      "end": 6738,
       "loc": {
         "start": {
           "line": 156,
@@ -28626,8 +28626,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6803,
-      "end": 6804,
+      "start": 6759,
+      "end": 6760,
       "loc": {
         "start": {
           "line": 157,
@@ -28654,8 +28654,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 6841,
-      "end": 6848,
+      "start": 6797,
+      "end": 6804,
       "loc": {
         "start": {
           "line": 158,
@@ -28680,8 +28680,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6848,
-      "end": 6849,
+      "start": 6804,
+      "end": 6805,
       "loc": {
         "start": {
           "line": 158,
@@ -28708,8 +28708,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 6870,
-      "end": 6876,
+      "start": 6826,
+      "end": 6832,
       "loc": {
         "start": {
           "line": 159,
@@ -28733,8 +28733,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6877,
-      "end": 6878,
+      "start": 6833,
+      "end": 6834,
       "loc": {
         "start": {
           "line": 159,
@@ -28759,8 +28759,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6878,
-      "end": 6879,
+      "start": 6834,
+      "end": 6835,
       "loc": {
         "start": {
           "line": 159,
@@ -28785,8 +28785,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 6879,
-      "end": 6882,
+      "start": 6835,
+      "end": 6838,
       "loc": {
         "start": {
           "line": 159,
@@ -28811,8 +28811,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6882,
-      "end": 6883,
+      "start": 6838,
+      "end": 6839,
       "loc": {
         "start": {
           "line": 159,
@@ -28837,8 +28837,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6883,
-      "end": 6884,
+      "start": 6839,
+      "end": 6840,
       "loc": {
         "start": {
           "line": 159,
@@ -28863,8 +28863,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 6885,
-      "end": 6893,
+      "start": 6841,
+      "end": 6849,
       "loc": {
         "start": {
           "line": 159,
@@ -28889,8 +28889,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6893,
-      "end": 6894,
+      "start": 6849,
+      "end": 6850,
       "loc": {
         "start": {
           "line": 159,
@@ -28915,8 +28915,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6894,
-      "end": 6898,
+      "start": 6850,
+      "end": 6854,
       "loc": {
         "start": {
           "line": 159,
@@ -28941,8 +28941,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6898,
-      "end": 6899,
+      "start": 6854,
+      "end": 6855,
       "loc": {
         "start": {
           "line": 159,
@@ -28967,8 +28967,8 @@
         "binop": null
       },
       "value": "key",
-      "start": 6899,
-      "end": 6902,
+      "start": 6855,
+      "end": 6858,
       "loc": {
         "start": {
           "line": 159,
@@ -28993,8 +28993,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6902,
-      "end": 6903,
+      "start": 6858,
+      "end": 6859,
       "loc": {
         "start": {
           "line": 159,
@@ -29018,8 +29018,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6903,
-      "end": 6904,
+      "start": 6859,
+      "end": 6860,
       "loc": {
         "start": {
           "line": 159,
@@ -29043,8 +29043,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6917,
-      "end": 6918,
+      "start": 6873,
+      "end": 6874,
       "loc": {
         "start": {
           "line": 160,
@@ -29068,8 +29068,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6927,
-      "end": 6928,
+      "start": 6883,
+      "end": 6884,
       "loc": {
         "start": {
           "line": 161,
@@ -29093,8 +29093,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6928,
-      "end": 6929,
+      "start": 6884,
+      "end": 6885,
       "loc": {
         "start": {
           "line": 161,
@@ -29121,8 +29121,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 6938,
-      "end": 6944,
+      "start": 6894,
+      "end": 6900,
       "loc": {
         "start": {
           "line": 162,
@@ -29147,8 +29147,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 6945,
-      "end": 6951,
+      "start": 6901,
+      "end": 6907,
       "loc": {
         "start": {
           "line": 162,
@@ -29173,8 +29173,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6951,
-      "end": 6952,
+      "start": 6907,
+      "end": 6908,
       "loc": {
         "start": {
           "line": 162,
@@ -29199,8 +29199,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 6952,
-      "end": 6958,
+      "start": 6908,
+      "end": 6914,
       "loc": {
         "start": {
           "line": 162,
@@ -29224,8 +29224,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6958,
-      "end": 6959,
+      "start": 6914,
+      "end": 6915,
       "loc": {
         "start": {
           "line": 162,
@@ -29250,8 +29250,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 6959,
-      "end": 6967,
+      "start": 6915,
+      "end": 6923,
       "loc": {
         "start": {
           "line": 162,
@@ -29276,8 +29276,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6967,
-      "end": 6968,
+      "start": 6923,
+      "end": 6924,
       "loc": {
         "start": {
           "line": 162,
@@ -29301,8 +29301,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6969,
-      "end": 6970,
+      "start": 6925,
+      "end": 6926,
       "loc": {
         "start": {
           "line": 162,
@@ -29327,8 +29327,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6970,
-      "end": 6974,
+      "start": 6926,
+      "end": 6930,
       "loc": {
         "start": {
           "line": 162,
@@ -29353,8 +29353,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6974,
-      "end": 6975,
+      "start": 6930,
+      "end": 6931,
       "loc": {
         "start": {
           "line": 162,
@@ -29379,8 +29379,8 @@
         "binop": null
       },
       "value": "Object",
-      "start": 6976,
-      "end": 6982,
+      "start": 6932,
+      "end": 6938,
       "loc": {
         "start": {
           "line": 162,
@@ -29405,8 +29405,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6982,
-      "end": 6983,
+      "start": 6938,
+      "end": 6939,
       "loc": {
         "start": {
           "line": 162,
@@ -29431,8 +29431,8 @@
         "binop": null
       },
       "value": "assign",
-      "start": 6983,
-      "end": 6989,
+      "start": 6939,
+      "end": 6945,
       "loc": {
         "start": {
           "line": 162,
@@ -29456,8 +29456,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6989,
-      "end": 6990,
+      "start": 6945,
+      "end": 6946,
       "loc": {
         "start": {
           "line": 162,
@@ -29482,8 +29482,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 6990,
-      "end": 6993,
+      "start": 6946,
+      "end": 6949,
       "loc": {
         "start": {
           "line": 162,
@@ -29508,8 +29508,8 @@
         "binop": null
       },
       "value": "data",
-      "start": 6993,
-      "end": 6997,
+      "start": 6949,
+      "end": 6953,
       "loc": {
         "start": {
           "line": 162,
@@ -29533,8 +29533,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6997,
-      "end": 6998,
+      "start": 6953,
+      "end": 6954,
       "loc": {
         "start": {
           "line": 162,
@@ -29558,8 +29558,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6998,
-      "end": 6999,
+      "start": 6954,
+      "end": 6955,
       "loc": {
         "start": {
           "line": 162,
@@ -29583,8 +29583,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 6999,
-      "end": 7000,
+      "start": 6955,
+      "end": 6956,
       "loc": {
         "start": {
           "line": 162,
@@ -29608,8 +29608,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 7005,
-      "end": 7006,
+      "start": 6961,
+      "end": 6962,
       "loc": {
         "start": {
           "line": 163,
@@ -29636,8 +29636,8 @@
         "updateContext": null
       },
       "value": "else",
-      "start": 7007,
-      "end": 7011,
+      "start": 6963,
+      "end": 6967,
       "loc": {
         "start": {
           "line": 163,
@@ -29661,8 +29661,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 7012,
-      "end": 7013,
+      "start": 6968,
+      "end": 6969,
       "loc": {
         "start": {
           "line": 163,
@@ -29689,8 +29689,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 7022,
-      "end": 7028,
+      "start": 6978,
+      "end": 6984,
       "loc": {
         "start": {
           "line": 164,
@@ -29715,8 +29715,8 @@
         "binop": null
       },
       "value": "response",
-      "start": 7029,
-      "end": 7037,
+      "start": 6985,
+      "end": 6993,
       "loc": {
         "start": {
           "line": 164,
@@ -29740,8 +29740,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 7042,
-      "end": 7043,
+      "start": 6998,
+      "end": 6999,
       "loc": {
         "start": {
           "line": 165,
@@ -29765,8 +29765,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 7044,
-      "end": 7045,
+      "start": 7000,
+      "end": 7001,
       "loc": {
         "start": {
           "line": 166,
@@ -29791,8 +29791,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 7045,
-      "end": 7045,
+      "start": 7001,
+      "end": 7001,
       "loc": {
         "start": {
           "line": 166,

--- a/docs/ast/source/api/SharedPlaylistFetcher.js.json
+++ b/docs/ast/source/api/SharedPlaylistFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2262,
+  "end": 2130,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2262,
+    "end": 2130,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n ",
+            "value": "*\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n ",
             "start": 90,
-            "end": 200,
+            "end": 191,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 201,
-        "end": 2262,
+        "start": 192,
+        "end": 2130,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 216,
-          "end": 2262,
+          "start": 207,
+          "end": 2130,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 222,
-            "end": 243,
+            "start": 213,
+            "end": 234,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 252,
-            "end": 259,
+            "start": 243,
+            "end": 250,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 260,
-            "end": 2262,
+            "start": 251,
+            "end": 2130,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 297,
-                "end": 452,
+                "start": 288,
+                "end": 443,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 297,
-                  "end": 308,
+                  "start": 288,
+                  "end": 299,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 309,
-                    "end": 313,
+                    "start": 300,
+                    "end": 304,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 315,
-                    "end": 331,
+                    "start": 306,
+                    "end": 322,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 315,
-                      "end": 324,
+                      "start": 306,
+                      "end": 315,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 327,
-                      "end": 331,
+                      "start": 318,
+                      "end": 322,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 333,
-                  "end": 452,
+                  "start": 324,
+                  "end": 443,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 343,
-                      "end": 365,
+                      "start": 334,
+                      "end": 356,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 343,
-                        "end": 365,
+                        "start": 334,
+                        "end": 356,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 343,
-                          "end": 348,
+                          "start": 334,
+                          "end": 339,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 349,
-                            "end": 353,
+                            "start": 340,
+                            "end": 344,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 355,
-                            "end": 364,
+                            "start": 346,
+                            "end": 355,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 375,
-                          "end": 409,
+                          "start": 366,
+                          "end": 400,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 418,
-                      "end": 446,
+                      "start": 409,
+                      "end": 437,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 418,
-                        "end": 446,
+                        "start": 409,
+                        "end": 437,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 418,
-                          "end": 434,
+                          "start": 409,
+                          "end": 425,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 418,
-                            "end": 422,
+                            "start": 409,
+                            "end": 413,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 423,
-                            "end": 434,
+                            "start": 414,
+                            "end": 425,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 437,
-                          "end": 446,
+                          "start": 428,
+                          "end": 437,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 375,
-                          "end": 409,
+                          "start": 366,
+                          "end": 400,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 266,
-                    "end": 292,
+                    "start": 257,
+                    "end": 283,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-                    "start": 458,
-                    "end": 739,
+                    "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+                    "start": 449,
+                    "end": 689,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 744,
-                "end": 837,
+                "start": 694,
+                "end": 787,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 744,
-                  "end": 757,
+                  "start": 694,
+                  "end": 707,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 758,
-                    "end": 769,
+                    "start": 708,
+                    "end": 719,
                     "loc": {
                       "start": {
                         "line": 28,
@@ -724,8 +724,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 771,
-                  "end": 837,
+                  "start": 721,
+                  "end": 787,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -739,8 +739,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 781,
-                      "end": 811,
+                      "start": 731,
+                      "end": 761,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -753,8 +753,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 781,
-                        "end": 811,
+                        "start": 731,
+                        "end": 761,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -768,8 +768,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 781,
-                          "end": 797,
+                          "start": 731,
+                          "end": 747,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -782,8 +782,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 781,
-                            "end": 785,
+                            "start": 731,
+                            "end": 735,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -797,8 +797,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 786,
-                            "end": 797,
+                            "start": 736,
+                            "end": 747,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -816,8 +816,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 800,
-                          "end": 811,
+                          "start": 750,
+                          "end": 761,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -835,8 +835,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 820,
-                      "end": 831,
+                      "start": 770,
+                      "end": 781,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -849,8 +849,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 827,
-                        "end": 831,
+                        "start": 777,
+                        "end": 781,
                         "loc": {
                           "start": {
                             "line": 30,
@@ -870,9 +870,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-                    "start": 458,
-                    "end": 739,
+                    "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+                    "start": 449,
+                    "end": 689,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -888,9 +888,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-                    "start": 843,
-                    "end": 1183,
+                    "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+                    "start": 793,
+                    "end": 1092,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -906,8 +906,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1188,
-                "end": 1298,
+                "start": 1097,
+                "end": 1207,
                 "loc": {
                   "start": {
                     "line": 40,
@@ -921,8 +921,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1188,
-                  "end": 1201,
+                  "start": 1097,
+                  "end": 1110,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -946,8 +946,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1204,
-                  "end": 1298,
+                  "start": 1113,
+                  "end": 1207,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -961,8 +961,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1214,
-                      "end": 1292,
+                      "start": 1123,
+                      "end": 1201,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -975,8 +975,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1221,
-                        "end": 1292,
+                        "start": 1130,
+                        "end": 1201,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -989,8 +989,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1221,
-                          "end": 1234,
+                          "start": 1130,
+                          "end": 1143,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1003,8 +1003,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1221,
-                            "end": 1230,
+                            "start": 1130,
+                            "end": 1139,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1017,8 +1017,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1221,
-                              "end": 1225,
+                              "start": 1130,
+                              "end": 1134,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1032,8 +1032,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1226,
-                              "end": 1230,
+                              "start": 1135,
+                              "end": 1139,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1051,8 +1051,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1231,
-                            "end": 1234,
+                            "start": 1140,
+                            "end": 1143,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1071,8 +1071,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1235,
-                            "end": 1262,
+                            "start": 1144,
+                            "end": 1171,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1085,8 +1085,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1235,
-                              "end": 1243,
+                              "start": 1144,
+                              "end": 1152,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1103,8 +1103,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1246,
-                              "end": 1262,
+                              "start": 1155,
+                              "end": 1171,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1117,8 +1117,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1246,
-                                "end": 1250,
+                                "start": 1155,
+                                "end": 1159,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1132,8 +1132,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1251,
-                                "end": 1262,
+                                "start": 1160,
+                                "end": 1171,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1152,8 +1152,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1264,
-                            "end": 1291,
+                            "start": 1173,
+                            "end": 1200,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1167,8 +1167,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1265,
-                                "end": 1290,
+                                "start": 1174,
+                                "end": 1199,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1184,8 +1184,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1265,
-                                  "end": 1274,
+                                  "start": 1174,
+                                  "end": 1183,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1201,8 +1201,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1276,
-                                  "end": 1290,
+                                  "start": 1185,
+                                  "end": 1199,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1215,8 +1215,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1276,
-                                    "end": 1280,
+                                    "start": 1185,
+                                    "end": 1189,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1230,8 +1230,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1281,
-                                    "end": 1290,
+                                    "start": 1190,
+                                    "end": 1199,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1260,9 +1260,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-                    "start": 843,
-                    "end": 1183,
+                    "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+                    "start": 793,
+                    "end": 1092,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -1279,8 +1279,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     ",
-                    "start": 1304,
-                    "end": 1469,
+                    "start": 1213,
+                    "end": 1378,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1296,8 +1296,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1474,
-                "end": 1578,
+                "start": 1383,
+                "end": 1487,
                 "loc": {
                   "start": {
                     "line": 49,
@@ -1311,8 +1311,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1474,
-                  "end": 1486,
+                  "start": 1383,
+                  "end": 1395,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1336,8 +1336,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1488,
-                  "end": 1578,
+                  "start": 1397,
+                  "end": 1487,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1351,8 +1351,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1498,
-                      "end": 1572,
+                      "start": 1407,
+                      "end": 1481,
                       "loc": {
                         "start": {
                           "line": 50,
@@ -1365,8 +1365,8 @@
                       },
                       "argument": {
                         "type": "TemplateLiteral",
-                        "start": 1505,
-                        "end": 1572,
+                        "start": 1414,
+                        "end": 1481,
                         "loc": {
                           "start": {
                             "line": 50,
@@ -1380,8 +1380,8 @@
                         "expressions": [
                           {
                             "type": "MemberExpression",
-                            "start": 1540,
-                            "end": 1556,
+                            "start": 1449,
+                            "end": 1465,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1394,8 +1394,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1540,
-                              "end": 1544,
+                              "start": 1449,
+                              "end": 1453,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1409,8 +1409,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1545,
-                              "end": 1556,
+                              "start": 1454,
+                              "end": 1465,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1430,8 +1430,8 @@
                         "quasis": [
                           {
                             "type": "TemplateElement",
-                            "start": 1506,
-                            "end": 1538,
+                            "start": 1415,
+                            "end": 1447,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1450,8 +1450,8 @@
                           },
                           {
                             "type": "TemplateElement",
-                            "start": 1557,
-                            "end": 1571,
+                            "start": 1466,
+                            "end": 1480,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1479,8 +1479,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     ",
-                    "start": 1304,
-                    "end": 1469,
+                    "start": 1213,
+                    "end": 1378,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1496,9 +1496,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks\n     ",
-                    "start": 1584,
-                    "end": 2022,
+                    "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks\n     ",
+                    "start": 1493,
+                    "end": 1890,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -1514,8 +1514,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 2027,
-                "end": 2260,
+                "start": 1895,
+                "end": 2128,
                 "loc": {
                   "start": {
                     "line": 62,
@@ -1529,8 +1529,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 2027,
-                  "end": 2038,
+                  "start": 1895,
+                  "end": 1906,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1554,8 +1554,8 @@
                 "params": [
                   {
                     "type": "AssignmentPattern",
-                    "start": 2039,
-                    "end": 2056,
+                    "start": 1907,
+                    "end": 1924,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1568,8 +1568,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2039,
-                      "end": 2044,
+                      "start": 1907,
+                      "end": 1912,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1585,8 +1585,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2047,
-                      "end": 2056,
+                      "start": 1915,
+                      "end": 1924,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1603,8 +1603,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 2058,
-                    "end": 2076,
+                    "start": 1926,
+                    "end": 1944,
                     "loc": {
                       "start": {
                         "line": 62,
@@ -1617,8 +1617,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 2058,
-                      "end": 2064,
+                      "start": 1926,
+                      "end": 1932,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1634,8 +1634,8 @@
                     },
                     "right": {
                       "type": "Identifier",
-                      "start": 2067,
-                      "end": 2076,
+                      "start": 1935,
+                      "end": 1944,
                       "loc": {
                         "start": {
                           "line": 62,
@@ -1653,8 +1653,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 2078,
-                  "end": 2260,
+                  "start": 1946,
+                  "end": 2128,
                   "loc": {
                     "start": {
                       "line": 62,
@@ -1668,8 +1668,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 2088,
-                      "end": 2254,
+                      "start": 1956,
+                      "end": 2122,
                       "loc": {
                         "start": {
                           "line": 63,
@@ -1682,8 +1682,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 2095,
-                        "end": 2254,
+                        "start": 1963,
+                        "end": 2122,
                         "loc": {
                           "start": {
                             "line": 63,
@@ -1696,8 +1696,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 2095,
-                          "end": 2108,
+                          "start": 1963,
+                          "end": 1976,
                           "loc": {
                             "start": {
                               "line": 63,
@@ -1710,8 +1710,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 2095,
-                            "end": 2104,
+                            "start": 1963,
+                            "end": 1972,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1724,8 +1724,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 2095,
-                              "end": 2099,
+                              "start": 1963,
+                              "end": 1967,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1739,8 +1739,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 2100,
-                              "end": 2104,
+                              "start": 1968,
+                              "end": 1972,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1758,8 +1758,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 2105,
-                            "end": 2108,
+                            "start": 1973,
+                            "end": 1976,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1778,8 +1778,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 2109,
-                            "end": 2148,
+                            "start": 1977,
+                            "end": 2016,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1792,8 +1792,8 @@
                             },
                             "left": {
                               "type": "BinaryExpression",
-                              "start": 2109,
-                              "end": 2136,
+                              "start": 1977,
+                              "end": 2004,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1806,8 +1806,8 @@
                               },
                               "left": {
                                 "type": "Identifier",
-                                "start": 2109,
-                                "end": 2117,
+                                "start": 1977,
+                                "end": 1985,
                                 "loc": {
                                   "start": {
                                     "line": 63,
@@ -1824,8 +1824,8 @@
                               "operator": "+",
                               "right": {
                                 "type": "MemberExpression",
-                                "start": 2120,
-                                "end": 2136,
+                                "start": 1988,
+                                "end": 2004,
                                 "loc": {
                                   "start": {
                                     "line": 63,
@@ -1838,8 +1838,8 @@
                                 },
                                 "object": {
                                   "type": "ThisExpression",
-                                  "start": 2120,
-                                  "end": 2124,
+                                  "start": 1988,
+                                  "end": 1992,
                                   "loc": {
                                     "start": {
                                       "line": 63,
@@ -1853,8 +1853,8 @@
                                 },
                                 "property": {
                                   "type": "Identifier",
-                                  "start": 2125,
-                                  "end": 2136,
+                                  "start": 1993,
+                                  "end": 2004,
                                   "loc": {
                                     "start": {
                                       "line": 63,
@@ -1874,8 +1874,8 @@
                             "operator": "+",
                             "right": {
                               "type": "StringLiteral",
-                              "start": 2139,
-                              "end": 2148,
+                              "start": 2007,
+                              "end": 2016,
                               "loc": {
                                 "start": {
                                   "line": 63,
@@ -1895,8 +1895,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 2150,
-                            "end": 2253,
+                            "start": 2018,
+                            "end": 2121,
                             "loc": {
                               "start": {
                                 "line": 63,
@@ -1910,8 +1910,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 2164,
-                                "end": 2189,
+                                "start": 2032,
+                                "end": 2057,
                                 "loc": {
                                   "start": {
                                     "line": 64,
@@ -1927,8 +1927,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2164,
-                                  "end": 2173,
+                                  "start": 2032,
+                                  "end": 2041,
                                   "loc": {
                                     "start": {
                                       "line": 64,
@@ -1944,8 +1944,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 2175,
-                                  "end": 2189,
+                                  "start": 2043,
+                                  "end": 2057,
                                   "loc": {
                                     "start": {
                                       "line": 64,
@@ -1958,8 +1958,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 2175,
-                                    "end": 2179,
+                                    "start": 2043,
+                                    "end": 2047,
                                     "loc": {
                                       "start": {
                                         "line": 64,
@@ -1973,8 +1973,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 2180,
-                                    "end": 2189,
+                                    "start": 2048,
+                                    "end": 2057,
                                     "loc": {
                                       "start": {
                                         "line": 64,
@@ -1993,8 +1993,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2203,
-                                "end": 2215,
+                                "start": 2071,
+                                "end": 2083,
                                 "loc": {
                                   "start": {
                                     "line": 65,
@@ -2010,8 +2010,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2203,
-                                  "end": 2208,
+                                  "start": 2071,
+                                  "end": 2076,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -2027,8 +2027,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2210,
-                                  "end": 2215,
+                                  "start": 2078,
+                                  "end": 2083,
                                   "loc": {
                                     "start": {
                                       "line": 65,
@@ -2045,8 +2045,8 @@
                               },
                               {
                                 "type": "ObjectProperty",
-                                "start": 2229,
-                                "end": 2243,
+                                "start": 2097,
+                                "end": 2111,
                                 "loc": {
                                   "start": {
                                     "line": 66,
@@ -2062,8 +2062,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 2229,
-                                  "end": 2235,
+                                  "start": 2097,
+                                  "end": 2103,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2079,8 +2079,8 @@
                                 },
                                 "value": {
                                   "type": "Identifier",
-                                  "start": 2237,
-                                  "end": 2243,
+                                  "start": 2105,
+                                  "end": 2111,
                                   "loc": {
                                     "start": {
                                       "line": 66,
@@ -2106,9 +2106,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks\n     ",
-                    "start": 1584,
-                    "end": 2022,
+                    "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks\n     ",
+                    "start": 1493,
+                    "end": 1890,
                     "loc": {
                       "start": {
                         "line": 53,
@@ -2127,9 +2127,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n ",
+              "value": "*\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n ",
               "start": 90,
-              "end": 200,
+              "end": 191,
               "loc": {
                 "start": {
                   "line": 4,
@@ -2147,9 +2147,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n ",
+            "value": "*\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n ",
             "start": 90,
-            "end": 200,
+            "end": 191,
             "loc": {
               "start": {
                 "line": 4,
@@ -2169,9 +2169,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n ",
+      "value": "*\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n ",
       "start": 90,
-      "end": 200,
+      "end": 191,
       "loc": {
         "start": {
           "line": 4,
@@ -2186,8 +2186,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 266,
-      "end": 292,
+      "start": 257,
+      "end": 283,
       "loc": {
         "start": {
           "line": 9,
@@ -2202,8 +2202,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 375,
-      "end": 409,
+      "start": 366,
+      "end": 400,
       "loc": {
         "start": {
           "line": 15,
@@ -2217,9 +2217,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-      "start": 458,
-      "end": 739,
+      "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+      "start": 449,
+      "end": 689,
       "loc": {
         "start": {
           "line": 21,
@@ -2233,9 +2233,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-      "start": 843,
-      "end": 1183,
+      "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+      "start": 793,
+      "end": 1092,
       "loc": {
         "start": {
           "line": 33,
@@ -2250,8 +2250,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     ",
-      "start": 1304,
-      "end": 1469,
+      "start": 1213,
+      "end": 1378,
       "loc": {
         "start": {
           "line": 44,
@@ -2265,9 +2265,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks\n     ",
-      "start": 1584,
-      "end": 2022,
+      "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks\n     ",
+      "start": 1493,
+      "end": 1890,
       "loc": {
         "start": {
           "line": 53,
@@ -2599,9 +2599,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n ",
+      "value": "*\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n ",
       "start": 90,
-      "end": 200,
+      "end": 191,
       "loc": {
         "start": {
           "line": 4,
@@ -2628,8 +2628,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 201,
-      "end": 207,
+      "start": 192,
+      "end": 198,
       "loc": {
         "start": {
           "line": 8,
@@ -2656,8 +2656,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 208,
-      "end": 215,
+      "start": 199,
+      "end": 206,
       "loc": {
         "start": {
           "line": 8,
@@ -2684,8 +2684,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 216,
-      "end": 221,
+      "start": 207,
+      "end": 212,
       "loc": {
         "start": {
           "line": 8,
@@ -2710,8 +2710,8 @@
         "binop": null
       },
       "value": "SharedPlaylistFetcher",
-      "start": 222,
-      "end": 243,
+      "start": 213,
+      "end": 234,
       "loc": {
         "start": {
           "line": 8,
@@ -2738,8 +2738,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 244,
-      "end": 251,
+      "start": 235,
+      "end": 242,
       "loc": {
         "start": {
           "line": 8,
@@ -2764,8 +2764,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 252,
-      "end": 259,
+      "start": 243,
+      "end": 250,
       "loc": {
         "start": {
           "line": 8,
@@ -2789,8 +2789,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 260,
-      "end": 261,
+      "start": 251,
+      "end": 252,
       "loc": {
         "start": {
           "line": 8,
@@ -2805,8 +2805,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 266,
-      "end": 292,
+      "start": 257,
+      "end": 283,
       "loc": {
         "start": {
           "line": 9,
@@ -2831,8 +2831,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 297,
-      "end": 308,
+      "start": 288,
+      "end": 299,
       "loc": {
         "start": {
           "line": 12,
@@ -2856,8 +2856,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 308,
-      "end": 309,
+      "start": 299,
+      "end": 300,
       "loc": {
         "start": {
           "line": 12,
@@ -2882,8 +2882,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 309,
-      "end": 313,
+      "start": 300,
+      "end": 304,
       "loc": {
         "start": {
           "line": 12,
@@ -2908,8 +2908,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 313,
-      "end": 314,
+      "start": 304,
+      "end": 305,
       "loc": {
         "start": {
           "line": 12,
@@ -2934,8 +2934,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 315,
-      "end": 324,
+      "start": 306,
+      "end": 315,
       "loc": {
         "start": {
           "line": 12,
@@ -2961,8 +2961,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 325,
-      "end": 326,
+      "start": 316,
+      "end": 317,
       "loc": {
         "start": {
           "line": 12,
@@ -2988,8 +2988,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 327,
-      "end": 331,
+      "start": 318,
+      "end": 322,
       "loc": {
         "start": {
           "line": 12,
@@ -3013,8 +3013,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 331,
-      "end": 332,
+      "start": 322,
+      "end": 323,
       "loc": {
         "start": {
           "line": 12,
@@ -3038,8 +3038,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 333,
-      "end": 334,
+      "start": 324,
+      "end": 325,
       "loc": {
         "start": {
           "line": 12,
@@ -3066,8 +3066,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 343,
-      "end": 348,
+      "start": 334,
+      "end": 339,
       "loc": {
         "start": {
           "line": 13,
@@ -3091,8 +3091,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 348,
-      "end": 349,
+      "start": 339,
+      "end": 340,
       "loc": {
         "start": {
           "line": 13,
@@ -3117,8 +3117,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 349,
-      "end": 353,
+      "start": 340,
+      "end": 344,
       "loc": {
         "start": {
           "line": 13,
@@ -3143,8 +3143,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 353,
-      "end": 354,
+      "start": 344,
+      "end": 345,
       "loc": {
         "start": {
           "line": 13,
@@ -3169,8 +3169,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 355,
-      "end": 364,
+      "start": 346,
+      "end": 355,
       "loc": {
         "start": {
           "line": 13,
@@ -3194,8 +3194,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 364,
-      "end": 365,
+      "start": 355,
+      "end": 356,
       "loc": {
         "start": {
           "line": 13,
@@ -3210,8 +3210,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 375,
-      "end": 409,
+      "start": 366,
+      "end": 400,
       "loc": {
         "start": {
           "line": 15,
@@ -3238,8 +3238,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 418,
-      "end": 422,
+      "start": 409,
+      "end": 413,
       "loc": {
         "start": {
           "line": 18,
@@ -3264,8 +3264,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 422,
-      "end": 423,
+      "start": 413,
+      "end": 414,
       "loc": {
         "start": {
           "line": 18,
@@ -3290,8 +3290,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 423,
-      "end": 434,
+      "start": 414,
+      "end": 425,
       "loc": {
         "start": {
           "line": 18,
@@ -3317,8 +3317,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 435,
-      "end": 436,
+      "start": 426,
+      "end": 427,
       "loc": {
         "start": {
           "line": 18,
@@ -3343,8 +3343,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 437,
-      "end": 446,
+      "start": 428,
+      "end": 437,
       "loc": {
         "start": {
           "line": 18,
@@ -3368,8 +3368,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 451,
-      "end": 452,
+      "start": 442,
+      "end": 443,
       "loc": {
         "start": {
           "line": 19,
@@ -3383,9 +3383,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-      "start": 458,
-      "end": 739,
+      "value": "*\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+      "start": 449,
+      "end": 689,
       "loc": {
         "start": {
           "line": 21,
@@ -3410,8 +3410,8 @@
         "binop": null
       },
       "value": "setPlaylistID",
-      "start": 744,
-      "end": 757,
+      "start": 694,
+      "end": 707,
       "loc": {
         "start": {
           "line": 28,
@@ -3435,8 +3435,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 757,
-      "end": 758,
+      "start": 707,
+      "end": 708,
       "loc": {
         "start": {
           "line": 28,
@@ -3461,8 +3461,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 758,
-      "end": 769,
+      "start": 708,
+      "end": 719,
       "loc": {
         "start": {
           "line": 28,
@@ -3486,8 +3486,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 769,
-      "end": 770,
+      "start": 719,
+      "end": 720,
       "loc": {
         "start": {
           "line": 28,
@@ -3511,8 +3511,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 771,
-      "end": 772,
+      "start": 721,
+      "end": 722,
       "loc": {
         "start": {
           "line": 28,
@@ -3539,8 +3539,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 781,
-      "end": 785,
+      "start": 731,
+      "end": 735,
       "loc": {
         "start": {
           "line": 29,
@@ -3565,8 +3565,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 785,
-      "end": 786,
+      "start": 735,
+      "end": 736,
       "loc": {
         "start": {
           "line": 29,
@@ -3591,8 +3591,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 786,
-      "end": 797,
+      "start": 736,
+      "end": 747,
       "loc": {
         "start": {
           "line": 29,
@@ -3618,8 +3618,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 798,
-      "end": 799,
+      "start": 748,
+      "end": 749,
       "loc": {
         "start": {
           "line": 29,
@@ -3644,8 +3644,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 800,
-      "end": 811,
+      "start": 750,
+      "end": 761,
       "loc": {
         "start": {
           "line": 29,
@@ -3672,8 +3672,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 820,
-      "end": 826,
+      "start": 770,
+      "end": 776,
       "loc": {
         "start": {
           "line": 30,
@@ -3700,8 +3700,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 827,
-      "end": 831,
+      "start": 777,
+      "end": 781,
       "loc": {
         "start": {
           "line": 30,
@@ -3725,8 +3725,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 836,
-      "end": 837,
+      "start": 786,
+      "end": 787,
       "loc": {
         "start": {
           "line": 31,
@@ -3740,9 +3740,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     ",
-      "start": 843,
-      "end": 1183,
+      "value": "*\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     ",
+      "start": 793,
+      "end": 1092,
       "loc": {
         "start": {
           "line": 33,
@@ -3767,8 +3767,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1188,
-      "end": 1201,
+      "start": 1097,
+      "end": 1110,
       "loc": {
         "start": {
           "line": 40,
@@ -3792,8 +3792,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1201,
-      "end": 1202,
+      "start": 1110,
+      "end": 1111,
       "loc": {
         "start": {
           "line": 40,
@@ -3817,8 +3817,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1202,
-      "end": 1203,
+      "start": 1111,
+      "end": 1112,
       "loc": {
         "start": {
           "line": 40,
@@ -3842,8 +3842,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1204,
-      "end": 1205,
+      "start": 1113,
+      "end": 1114,
       "loc": {
         "start": {
           "line": 40,
@@ -3870,8 +3870,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1214,
-      "end": 1220,
+      "start": 1123,
+      "end": 1129,
       "loc": {
         "start": {
           "line": 41,
@@ -3898,8 +3898,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1221,
-      "end": 1225,
+      "start": 1130,
+      "end": 1134,
       "loc": {
         "start": {
           "line": 41,
@@ -3924,8 +3924,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1225,
-      "end": 1226,
+      "start": 1134,
+      "end": 1135,
       "loc": {
         "start": {
           "line": 41,
@@ -3950,8 +3950,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1226,
-      "end": 1230,
+      "start": 1135,
+      "end": 1139,
       "loc": {
         "start": {
           "line": 41,
@@ -3976,8 +3976,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1230,
-      "end": 1231,
+      "start": 1139,
+      "end": 1140,
       "loc": {
         "start": {
           "line": 41,
@@ -4002,8 +4002,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1231,
-      "end": 1234,
+      "start": 1140,
+      "end": 1143,
       "loc": {
         "start": {
           "line": 41,
@@ -4027,8 +4027,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1234,
-      "end": 1235,
+      "start": 1143,
+      "end": 1144,
       "loc": {
         "start": {
           "line": 41,
@@ -4053,8 +4053,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1235,
-      "end": 1243,
+      "start": 1144,
+      "end": 1152,
       "loc": {
         "start": {
           "line": 41,
@@ -4080,8 +4080,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1244,
-      "end": 1245,
+      "start": 1153,
+      "end": 1154,
       "loc": {
         "start": {
           "line": 41,
@@ -4108,8 +4108,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1246,
-      "end": 1250,
+      "start": 1155,
+      "end": 1159,
       "loc": {
         "start": {
           "line": 41,
@@ -4134,8 +4134,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1250,
-      "end": 1251,
+      "start": 1159,
+      "end": 1160,
       "loc": {
         "start": {
           "line": 41,
@@ -4160,8 +4160,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1251,
-      "end": 1262,
+      "start": 1160,
+      "end": 1171,
       "loc": {
         "start": {
           "line": 41,
@@ -4186,8 +4186,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1262,
-      "end": 1263,
+      "start": 1171,
+      "end": 1172,
       "loc": {
         "start": {
           "line": 41,
@@ -4211,8 +4211,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1264,
-      "end": 1265,
+      "start": 1173,
+      "end": 1174,
       "loc": {
         "start": {
           "line": 41,
@@ -4237,8 +4237,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1265,
-      "end": 1274,
+      "start": 1174,
+      "end": 1183,
       "loc": {
         "start": {
           "line": 41,
@@ -4263,8 +4263,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1274,
-      "end": 1275,
+      "start": 1183,
+      "end": 1184,
       "loc": {
         "start": {
           "line": 41,
@@ -4291,8 +4291,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1276,
-      "end": 1280,
+      "start": 1185,
+      "end": 1189,
       "loc": {
         "start": {
           "line": 41,
@@ -4317,8 +4317,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1280,
-      "end": 1281,
+      "start": 1189,
+      "end": 1190,
       "loc": {
         "start": {
           "line": 41,
@@ -4343,8 +4343,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1281,
-      "end": 1290,
+      "start": 1190,
+      "end": 1199,
       "loc": {
         "start": {
           "line": 41,
@@ -4368,8 +4368,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1290,
-      "end": 1291,
+      "start": 1199,
+      "end": 1200,
       "loc": {
         "start": {
           "line": 41,
@@ -4393,8 +4393,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1291,
-      "end": 1292,
+      "start": 1200,
+      "end": 1201,
       "loc": {
         "start": {
           "line": 41,
@@ -4418,8 +4418,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1297,
-      "end": 1298,
+      "start": 1206,
+      "end": 1207,
       "loc": {
         "start": {
           "line": 42,
@@ -4434,8 +4434,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     ",
-      "start": 1304,
-      "end": 1469,
+      "start": 1213,
+      "end": 1378,
       "loc": {
         "start": {
           "line": 44,
@@ -4460,8 +4460,8 @@
         "binop": null
       },
       "value": "getWidgetUri",
-      "start": 1474,
-      "end": 1486,
+      "start": 1383,
+      "end": 1395,
       "loc": {
         "start": {
           "line": 49,
@@ -4485,8 +4485,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1486,
-      "end": 1487,
+      "start": 1395,
+      "end": 1396,
       "loc": {
         "start": {
           "line": 49,
@@ -4510,8 +4510,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1487,
-      "end": 1488,
+      "start": 1396,
+      "end": 1397,
       "loc": {
         "start": {
           "line": 49,
@@ -4535,8 +4535,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1488,
-      "end": 1489,
+      "start": 1397,
+      "end": 1398,
       "loc": {
         "start": {
           "line": 49,
@@ -4563,8 +4563,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1498,
-      "end": 1504,
+      "start": 1407,
+      "end": 1413,
       "loc": {
         "start": {
           "line": 50,
@@ -4588,8 +4588,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1505,
-      "end": 1506,
+      "start": 1414,
+      "end": 1415,
       "loc": {
         "start": {
           "line": 50,
@@ -4615,8 +4615,8 @@
         "updateContext": null
       },
       "value": "https://widget.kkbox.com/v1/?id=",
-      "start": 1506,
-      "end": 1538,
+      "start": 1415,
+      "end": 1447,
       "loc": {
         "start": {
           "line": 50,
@@ -4640,8 +4640,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1538,
-      "end": 1540,
+      "start": 1447,
+      "end": 1449,
       "loc": {
         "start": {
           "line": 50,
@@ -4668,8 +4668,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1540,
-      "end": 1544,
+      "start": 1449,
+      "end": 1453,
       "loc": {
         "start": {
           "line": 50,
@@ -4694,8 +4694,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1544,
-      "end": 1545,
+      "start": 1453,
+      "end": 1454,
       "loc": {
         "start": {
           "line": 50,
@@ -4720,8 +4720,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 1545,
-      "end": 1556,
+      "start": 1454,
+      "end": 1465,
       "loc": {
         "start": {
           "line": 50,
@@ -4745,8 +4745,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1556,
-      "end": 1557,
+      "start": 1465,
+      "end": 1466,
       "loc": {
         "start": {
           "line": 50,
@@ -4772,8 +4772,8 @@
         "updateContext": null
       },
       "value": "&type=playlist",
-      "start": 1557,
-      "end": 1571,
+      "start": 1466,
+      "end": 1480,
       "loc": {
         "start": {
           "line": 50,
@@ -4797,8 +4797,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1571,
-      "end": 1572,
+      "start": 1480,
+      "end": 1481,
       "loc": {
         "start": {
           "line": 50,
@@ -4822,8 +4822,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1577,
-      "end": 1578,
+      "start": 1486,
+      "end": 1487,
       "loc": {
         "start": {
           "line": 51,
@@ -4837,9 +4837,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks\n     ",
-      "start": 1584,
-      "end": 2022,
+      "value": "*\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks\n     ",
+      "start": 1493,
+      "end": 1890,
       "loc": {
         "start": {
           "line": 53,
@@ -4864,8 +4864,8 @@
         "binop": null
       },
       "value": "fetchTracks",
-      "start": 2027,
-      "end": 2038,
+      "start": 1895,
+      "end": 1906,
       "loc": {
         "start": {
           "line": 62,
@@ -4889,8 +4889,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2038,
-      "end": 2039,
+      "start": 1906,
+      "end": 1907,
       "loc": {
         "start": {
           "line": 62,
@@ -4915,8 +4915,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2039,
-      "end": 2044,
+      "start": 1907,
+      "end": 1912,
       "loc": {
         "start": {
           "line": 62,
@@ -4942,8 +4942,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2045,
-      "end": 2046,
+      "start": 1913,
+      "end": 1914,
       "loc": {
         "start": {
           "line": 62,
@@ -4968,8 +4968,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2047,
-      "end": 2056,
+      "start": 1915,
+      "end": 1924,
       "loc": {
         "start": {
           "line": 62,
@@ -4994,8 +4994,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2056,
-      "end": 2057,
+      "start": 1924,
+      "end": 1925,
       "loc": {
         "start": {
           "line": 62,
@@ -5020,8 +5020,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2058,
-      "end": 2064,
+      "start": 1926,
+      "end": 1932,
       "loc": {
         "start": {
           "line": 62,
@@ -5047,8 +5047,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2065,
-      "end": 2066,
+      "start": 1933,
+      "end": 1934,
       "loc": {
         "start": {
           "line": 62,
@@ -5073,8 +5073,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 2067,
-      "end": 2076,
+      "start": 1935,
+      "end": 1944,
       "loc": {
         "start": {
           "line": 62,
@@ -5098,8 +5098,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2076,
-      "end": 2077,
+      "start": 1944,
+      "end": 1945,
       "loc": {
         "start": {
           "line": 62,
@@ -5123,8 +5123,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2078,
-      "end": 2079,
+      "start": 1946,
+      "end": 1947,
       "loc": {
         "start": {
           "line": 62,
@@ -5151,8 +5151,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2088,
-      "end": 2094,
+      "start": 1956,
+      "end": 1962,
       "loc": {
         "start": {
           "line": 63,
@@ -5179,8 +5179,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2095,
-      "end": 2099,
+      "start": 1963,
+      "end": 1967,
       "loc": {
         "start": {
           "line": 63,
@@ -5205,8 +5205,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2099,
-      "end": 2100,
+      "start": 1967,
+      "end": 1968,
       "loc": {
         "start": {
           "line": 63,
@@ -5231,8 +5231,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 2100,
-      "end": 2104,
+      "start": 1968,
+      "end": 1972,
       "loc": {
         "start": {
           "line": 63,
@@ -5257,8 +5257,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2104,
-      "end": 2105,
+      "start": 1972,
+      "end": 1973,
       "loc": {
         "start": {
           "line": 63,
@@ -5283,8 +5283,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 2105,
-      "end": 2108,
+      "start": 1973,
+      "end": 1976,
       "loc": {
         "start": {
           "line": 63,
@@ -5308,8 +5308,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2108,
-      "end": 2109,
+      "start": 1976,
+      "end": 1977,
       "loc": {
         "start": {
           "line": 63,
@@ -5334,8 +5334,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 2109,
-      "end": 2117,
+      "start": 1977,
+      "end": 1985,
       "loc": {
         "start": {
           "line": 63,
@@ -5361,8 +5361,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2118,
-      "end": 2119,
+      "start": 1986,
+      "end": 1987,
       "loc": {
         "start": {
           "line": 63,
@@ -5389,8 +5389,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2120,
-      "end": 2124,
+      "start": 1988,
+      "end": 1992,
       "loc": {
         "start": {
           "line": 63,
@@ -5415,8 +5415,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2124,
-      "end": 2125,
+      "start": 1992,
+      "end": 1993,
       "loc": {
         "start": {
           "line": 63,
@@ -5441,8 +5441,8 @@
         "binop": null
       },
       "value": "playlist_id",
-      "start": 2125,
-      "end": 2136,
+      "start": 1993,
+      "end": 2004,
       "loc": {
         "start": {
           "line": 63,
@@ -5468,8 +5468,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 2137,
-      "end": 2138,
+      "start": 2005,
+      "end": 2006,
       "loc": {
         "start": {
           "line": 63,
@@ -5495,8 +5495,8 @@
         "updateContext": null
       },
       "value": "/tracks",
-      "start": 2139,
-      "end": 2148,
+      "start": 2007,
+      "end": 2016,
       "loc": {
         "start": {
           "line": 63,
@@ -5521,8 +5521,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2148,
-      "end": 2149,
+      "start": 2016,
+      "end": 2017,
       "loc": {
         "start": {
           "line": 63,
@@ -5546,8 +5546,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2150,
-      "end": 2151,
+      "start": 2018,
+      "end": 2019,
       "loc": {
         "start": {
           "line": 63,
@@ -5572,8 +5572,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2164,
-      "end": 2173,
+      "start": 2032,
+      "end": 2041,
       "loc": {
         "start": {
           "line": 64,
@@ -5598,8 +5598,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2173,
-      "end": 2174,
+      "start": 2041,
+      "end": 2042,
       "loc": {
         "start": {
           "line": 64,
@@ -5626,8 +5626,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 2175,
-      "end": 2179,
+      "start": 2043,
+      "end": 2047,
       "loc": {
         "start": {
           "line": 64,
@@ -5652,8 +5652,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2179,
-      "end": 2180,
+      "start": 2047,
+      "end": 2048,
       "loc": {
         "start": {
           "line": 64,
@@ -5678,8 +5678,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 2180,
-      "end": 2189,
+      "start": 2048,
+      "end": 2057,
       "loc": {
         "start": {
           "line": 64,
@@ -5704,8 +5704,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2189,
-      "end": 2190,
+      "start": 2057,
+      "end": 2058,
       "loc": {
         "start": {
           "line": 64,
@@ -5730,8 +5730,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2203,
-      "end": 2208,
+      "start": 2071,
+      "end": 2076,
       "loc": {
         "start": {
           "line": 65,
@@ -5756,8 +5756,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2208,
-      "end": 2209,
+      "start": 2076,
+      "end": 2077,
       "loc": {
         "start": {
           "line": 65,
@@ -5782,8 +5782,8 @@
         "binop": null
       },
       "value": "limit",
-      "start": 2210,
-      "end": 2215,
+      "start": 2078,
+      "end": 2083,
       "loc": {
         "start": {
           "line": 65,
@@ -5808,8 +5808,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2215,
-      "end": 2216,
+      "start": 2083,
+      "end": 2084,
       "loc": {
         "start": {
           "line": 65,
@@ -5834,8 +5834,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2229,
-      "end": 2235,
+      "start": 2097,
+      "end": 2103,
       "loc": {
         "start": {
           "line": 66,
@@ -5860,8 +5860,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2235,
-      "end": 2236,
+      "start": 2103,
+      "end": 2104,
       "loc": {
         "start": {
           "line": 66,
@@ -5886,8 +5886,8 @@
         "binop": null
       },
       "value": "offset",
-      "start": 2237,
-      "end": 2243,
+      "start": 2105,
+      "end": 2111,
       "loc": {
         "start": {
           "line": 66,
@@ -5911,8 +5911,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2252,
-      "end": 2253,
+      "start": 2120,
+      "end": 2121,
       "loc": {
         "start": {
           "line": 67,
@@ -5936,8 +5936,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2253,
-      "end": 2254,
+      "start": 2121,
+      "end": 2122,
       "loc": {
         "start": {
           "line": 67,
@@ -5961,8 +5961,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2259,
-      "end": 2260,
+      "start": 2127,
+      "end": 2128,
       "loc": {
         "start": {
           "line": 68,
@@ -5986,8 +5986,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2261,
-      "end": 2262,
+      "start": 2129,
+      "end": 2130,
       "loc": {
         "start": {
           "line": 69,
@@ -6012,8 +6012,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2262,
-      "end": 2262,
+      "start": 2130,
+      "end": 2130,
       "loc": {
         "start": {
           "line": 69,

--- a/docs/ast/source/api/TrackFetcher.js.json
+++ b/docs/ast/source/api/TrackFetcher.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 1412,
+  "end": 1343,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 1412,
+    "end": 1343,
     "loc": {
       "start": {
         "line": 1,
@@ -187,9 +187,9 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n ",
+            "value": "*\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n ",
             "start": 80,
-            "end": 182,
+            "end": 173,
             "loc": {
               "start": {
                 "line": 4,
@@ -205,8 +205,8 @@
       },
       {
         "type": "ExportDefaultDeclaration",
-        "start": 183,
-        "end": 1412,
+        "start": 174,
+        "end": 1343,
         "loc": {
           "start": {
             "line": 8,
@@ -219,8 +219,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 198,
-          "end": 1412,
+          "start": 189,
+          "end": 1343,
           "loc": {
             "start": {
               "line": 8,
@@ -233,8 +233,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 204,
-            "end": 216,
+            "start": 195,
+            "end": 207,
             "loc": {
               "start": {
                 "line": 8,
@@ -251,8 +251,8 @@
           },
           "superClass": {
             "type": "Identifier",
-            "start": 225,
-            "end": 232,
+            "start": 216,
+            "end": 223,
             "loc": {
               "start": {
                 "line": 8,
@@ -268,8 +268,8 @@
           },
           "body": {
             "type": "ClassBody",
-            "start": 233,
-            "end": 1412,
+            "start": 224,
+            "end": 1343,
             "loc": {
               "start": {
                 "line": 8,
@@ -283,8 +283,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 270,
-                "end": 422,
+                "start": 261,
+                "end": 413,
                 "loc": {
                   "start": {
                     "line": 12,
@@ -298,8 +298,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 270,
-                  "end": 281,
+                  "start": 261,
+                  "end": 272,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -323,8 +323,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 282,
-                    "end": 286,
+                    "start": 273,
+                    "end": 277,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -340,8 +340,8 @@
                   },
                   {
                     "type": "AssignmentPattern",
-                    "start": 288,
-                    "end": 304,
+                    "start": 279,
+                    "end": 295,
                     "loc": {
                       "start": {
                         "line": 12,
@@ -354,8 +354,8 @@
                     },
                     "left": {
                       "type": "Identifier",
-                      "start": 288,
-                      "end": 297,
+                      "start": 279,
+                      "end": 288,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -371,8 +371,8 @@
                     },
                     "right": {
                       "type": "StringLiteral",
-                      "start": 300,
-                      "end": 304,
+                      "start": 291,
+                      "end": 295,
                       "loc": {
                         "start": {
                           "line": 12,
@@ -393,8 +393,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 306,
-                  "end": 422,
+                  "start": 297,
+                  "end": 413,
                   "loc": {
                     "start": {
                       "line": 12,
@@ -408,8 +408,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 316,
-                      "end": 338,
+                      "start": 307,
+                      "end": 329,
                       "loc": {
                         "start": {
                           "line": 13,
@@ -422,8 +422,8 @@
                       },
                       "expression": {
                         "type": "CallExpression",
-                        "start": 316,
-                        "end": 338,
+                        "start": 307,
+                        "end": 329,
                         "loc": {
                           "start": {
                             "line": 13,
@@ -436,8 +436,8 @@
                         },
                         "callee": {
                           "type": "Super",
-                          "start": 316,
-                          "end": 321,
+                          "start": 307,
+                          "end": 312,
                           "loc": {
                             "start": {
                               "line": 13,
@@ -452,8 +452,8 @@
                         "arguments": [
                           {
                             "type": "Identifier",
-                            "start": 322,
-                            "end": 326,
+                            "start": 313,
+                            "end": 317,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -469,8 +469,8 @@
                           },
                           {
                             "type": "Identifier",
-                            "start": 328,
-                            "end": 337,
+                            "start": 319,
+                            "end": 328,
                             "loc": {
                               "start": {
                                 "line": 13,
@@ -491,8 +491,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 348,
-                          "end": 382,
+                          "start": 339,
+                          "end": 373,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -508,8 +508,8 @@
                     },
                     {
                       "type": "ExpressionStatement",
-                      "start": 391,
-                      "end": 416,
+                      "start": 382,
+                      "end": 407,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -522,8 +522,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 391,
-                        "end": 416,
+                        "start": 382,
+                        "end": 407,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -537,8 +537,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 391,
-                          "end": 404,
+                          "start": 382,
+                          "end": 395,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -551,8 +551,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 391,
-                            "end": 395,
+                            "start": 382,
+                            "end": 386,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -567,8 +567,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 396,
-                            "end": 404,
+                            "start": 387,
+                            "end": 395,
                             "loc": {
                               "start": {
                                 "line": 18,
@@ -587,8 +587,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 407,
-                          "end": 416,
+                          "start": 398,
+                          "end": 407,
                           "loc": {
                             "start": {
                               "line": 18,
@@ -608,8 +608,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 348,
-                          "end": 382,
+                          "start": 339,
+                          "end": 373,
                           "loc": {
                             "start": {
                               "line": 15,
@@ -631,8 +631,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 239,
-                    "end": 265,
+                    "start": 230,
+                    "end": 256,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -648,9 +648,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-                    "start": 428,
-                    "end": 664,
+                    "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+                    "start": 419,
+                    "end": 625,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -666,8 +666,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 669,
-                "end": 750,
+                "start": 630,
+                "end": 711,
                 "loc": {
                   "start": {
                     "line": 28,
@@ -681,8 +681,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 669,
-                  "end": 679,
+                  "start": 630,
+                  "end": 640,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -706,8 +706,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 680,
-                    "end": 688,
+                    "start": 641,
+                    "end": 649,
                     "loc": {
                       "start": {
                         "line": 28,
@@ -724,8 +724,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 690,
-                  "end": 750,
+                  "start": 651,
+                  "end": 711,
                   "loc": {
                     "start": {
                       "line": 28,
@@ -739,8 +739,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 700,
-                      "end": 724,
+                      "start": 661,
+                      "end": 685,
                       "loc": {
                         "start": {
                           "line": 29,
@@ -753,8 +753,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 700,
-                        "end": 724,
+                        "start": 661,
+                        "end": 685,
                         "loc": {
                           "start": {
                             "line": 29,
@@ -768,8 +768,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 700,
-                          "end": 713,
+                          "start": 661,
+                          "end": 674,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -782,8 +782,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 700,
-                            "end": 704,
+                            "start": 661,
+                            "end": 665,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -797,8 +797,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 705,
-                            "end": 713,
+                            "start": 666,
+                            "end": 674,
                             "loc": {
                               "start": {
                                 "line": 29,
@@ -816,8 +816,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 716,
-                          "end": 724,
+                          "start": 677,
+                          "end": 685,
                           "loc": {
                             "start": {
                               "line": 29,
@@ -835,8 +835,8 @@
                     },
                     {
                       "type": "ReturnStatement",
-                      "start": 733,
-                      "end": 744,
+                      "start": 694,
+                      "end": 705,
                       "loc": {
                         "start": {
                           "line": 30,
@@ -849,8 +849,8 @@
                       },
                       "argument": {
                         "type": "ThisExpression",
-                        "start": 740,
-                        "end": 744,
+                        "start": 701,
+                        "end": 705,
                         "loc": {
                           "start": {
                             "line": 30,
@@ -870,9 +870,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-                    "start": 428,
-                    "end": 664,
+                    "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+                    "start": 419,
+                    "end": 625,
                     "loc": {
                       "start": {
                         "line": 21,
@@ -888,9 +888,9 @@
                 "trailingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-                    "start": 756,
-                    "end": 1032,
+                    "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+                    "start": 717,
+                    "end": 963,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -906,8 +906,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1037,
-                "end": 1144,
+                "start": 968,
+                "end": 1075,
                 "loc": {
                   "start": {
                     "line": 40,
@@ -921,8 +921,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1037,
-                  "end": 1050,
+                  "start": 968,
+                  "end": 981,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -946,8 +946,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1053,
-                  "end": 1144,
+                  "start": 984,
+                  "end": 1075,
                   "loc": {
                     "start": {
                       "line": 40,
@@ -961,8 +961,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1063,
-                      "end": 1138,
+                      "start": 994,
+                      "end": 1069,
                       "loc": {
                         "start": {
                           "line": 41,
@@ -975,8 +975,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 1070,
-                        "end": 1138,
+                        "start": 1001,
+                        "end": 1069,
                         "loc": {
                           "start": {
                             "line": 41,
@@ -989,8 +989,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 1070,
-                          "end": 1083,
+                          "start": 1001,
+                          "end": 1014,
                           "loc": {
                             "start": {
                               "line": 41,
@@ -1003,8 +1003,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 1070,
-                            "end": 1079,
+                            "start": 1001,
+                            "end": 1010,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1017,8 +1017,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1070,
-                              "end": 1074,
+                              "start": 1001,
+                              "end": 1005,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1032,8 +1032,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1075,
-                              "end": 1079,
+                              "start": 1006,
+                              "end": 1010,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1051,8 +1051,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 1080,
-                            "end": 1083,
+                            "start": 1011,
+                            "end": 1014,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1071,8 +1071,8 @@
                         "arguments": [
                           {
                             "type": "BinaryExpression",
-                            "start": 1084,
-                            "end": 1108,
+                            "start": 1015,
+                            "end": 1039,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1085,8 +1085,8 @@
                             },
                             "left": {
                               "type": "Identifier",
-                              "start": 1084,
-                              "end": 1092,
+                              "start": 1015,
+                              "end": 1023,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1103,8 +1103,8 @@
                             "operator": "+",
                             "right": {
                               "type": "MemberExpression",
-                              "start": 1095,
-                              "end": 1108,
+                              "start": 1026,
+                              "end": 1039,
                               "loc": {
                                 "start": {
                                   "line": 41,
@@ -1117,8 +1117,8 @@
                               },
                               "object": {
                                 "type": "ThisExpression",
-                                "start": 1095,
-                                "end": 1099,
+                                "start": 1026,
+                                "end": 1030,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1132,8 +1132,8 @@
                               },
                               "property": {
                                 "type": "Identifier",
-                                "start": 1100,
-                                "end": 1108,
+                                "start": 1031,
+                                "end": 1039,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1152,8 +1152,8 @@
                           },
                           {
                             "type": "ObjectExpression",
-                            "start": 1110,
-                            "end": 1137,
+                            "start": 1041,
+                            "end": 1068,
                             "loc": {
                               "start": {
                                 "line": 41,
@@ -1167,8 +1167,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 1111,
-                                "end": 1136,
+                                "start": 1042,
+                                "end": 1067,
                                 "loc": {
                                   "start": {
                                     "line": 41,
@@ -1184,8 +1184,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 1111,
-                                  "end": 1120,
+                                  "start": 1042,
+                                  "end": 1051,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1201,8 +1201,8 @@
                                 },
                                 "value": {
                                   "type": "MemberExpression",
-                                  "start": 1122,
-                                  "end": 1136,
+                                  "start": 1053,
+                                  "end": 1067,
                                   "loc": {
                                     "start": {
                                       "line": 41,
@@ -1215,8 +1215,8 @@
                                   },
                                   "object": {
                                     "type": "ThisExpression",
-                                    "start": 1122,
-                                    "end": 1126,
+                                    "start": 1053,
+                                    "end": 1057,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1230,8 +1230,8 @@
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "start": 1127,
-                                    "end": 1136,
+                                    "start": 1058,
+                                    "end": 1067,
                                     "loc": {
                                       "start": {
                                         "line": 41,
@@ -1260,9 +1260,9 @@
                 "leadingComments": [
                   {
                     "type": "CommentBlock",
-                    "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-                    "start": 756,
-                    "end": 1032,
+                    "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+                    "start": 717,
+                    "end": 963,
                     "loc": {
                       "start": {
                         "line": 33,
@@ -1279,8 +1279,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     ",
-                    "start": 1150,
-                    "end": 1308,
+                    "start": 1081,
+                    "end": 1239,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1296,8 +1296,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 1313,
-                "end": 1410,
+                "start": 1244,
+                "end": 1341,
                 "loc": {
                   "start": {
                     "line": 49,
@@ -1311,8 +1311,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 1313,
-                  "end": 1325,
+                  "start": 1244,
+                  "end": 1256,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1336,8 +1336,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 1327,
-                  "end": 1410,
+                  "start": 1258,
+                  "end": 1341,
                   "loc": {
                     "start": {
                       "line": 49,
@@ -1351,8 +1351,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 1337,
-                      "end": 1404,
+                      "start": 1268,
+                      "end": 1335,
                       "loc": {
                         "start": {
                           "line": 50,
@@ -1365,8 +1365,8 @@
                       },
                       "argument": {
                         "type": "TemplateLiteral",
-                        "start": 1344,
-                        "end": 1404,
+                        "start": 1275,
+                        "end": 1335,
                         "loc": {
                           "start": {
                             "line": 50,
@@ -1380,8 +1380,8 @@
                         "expressions": [
                           {
                             "type": "MemberExpression",
-                            "start": 1379,
-                            "end": 1392,
+                            "start": 1310,
+                            "end": 1323,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1394,8 +1394,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 1379,
-                              "end": 1383,
+                              "start": 1310,
+                              "end": 1314,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1409,8 +1409,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 1384,
-                              "end": 1392,
+                              "start": 1315,
+                              "end": 1323,
                               "loc": {
                                 "start": {
                                   "line": 50,
@@ -1430,8 +1430,8 @@
                         "quasis": [
                           {
                             "type": "TemplateElement",
-                            "start": 1345,
-                            "end": 1377,
+                            "start": 1276,
+                            "end": 1308,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1450,8 +1450,8 @@
                           },
                           {
                             "type": "TemplateElement",
-                            "start": 1393,
-                            "end": 1403,
+                            "start": 1324,
+                            "end": 1334,
                             "loc": {
                               "start": {
                                 "line": 50,
@@ -1478,8 +1478,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     ",
-                    "start": 1150,
-                    "end": 1308,
+                    "start": 1081,
+                    "end": 1239,
                     "loc": {
                       "start": {
                         "line": 44,
@@ -1498,9 +1498,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n ",
+              "value": "*\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n ",
               "start": 80,
-              "end": 182,
+              "end": 173,
               "loc": {
                 "start": {
                   "line": 4,
@@ -1518,9 +1518,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n ",
+            "value": "*\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n ",
             "start": 80,
-            "end": 182,
+            "end": 173,
             "loc": {
               "start": {
                 "line": 4,
@@ -1540,9 +1540,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n ",
+      "value": "*\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n ",
       "start": 80,
-      "end": 182,
+      "end": 173,
       "loc": {
         "start": {
           "line": 4,
@@ -1557,8 +1557,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 239,
-      "end": 265,
+      "start": 230,
+      "end": 256,
       "loc": {
         "start": {
           "line": 9,
@@ -1573,8 +1573,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 348,
-      "end": 382,
+      "start": 339,
+      "end": 373,
       "loc": {
         "start": {
           "line": 15,
@@ -1588,9 +1588,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-      "start": 428,
-      "end": 664,
+      "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+      "start": 419,
+      "end": 625,
       "loc": {
         "start": {
           "line": 21,
@@ -1604,9 +1604,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-      "start": 756,
-      "end": 1032,
+      "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+      "start": 717,
+      "end": 963,
       "loc": {
         "start": {
           "line": 33,
@@ -1621,8 +1621,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     ",
-      "start": 1150,
-      "end": 1308,
+      "start": 1081,
+      "end": 1239,
       "loc": {
         "start": {
           "line": 44,
@@ -1954,9 +1954,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n ",
+      "value": "*\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n ",
       "start": 80,
-      "end": 182,
+      "end": 173,
       "loc": {
         "start": {
           "line": 4,
@@ -1983,8 +1983,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 183,
-      "end": 189,
+      "start": 174,
+      "end": 180,
       "loc": {
         "start": {
           "line": 8,
@@ -2011,8 +2011,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 190,
-      "end": 197,
+      "start": 181,
+      "end": 188,
       "loc": {
         "start": {
           "line": 8,
@@ -2039,8 +2039,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 198,
-      "end": 203,
+      "start": 189,
+      "end": 194,
       "loc": {
         "start": {
           "line": 8,
@@ -2065,8 +2065,8 @@
         "binop": null
       },
       "value": "TrackFetcher",
-      "start": 204,
-      "end": 216,
+      "start": 195,
+      "end": 207,
       "loc": {
         "start": {
           "line": 8,
@@ -2093,8 +2093,8 @@
         "updateContext": null
       },
       "value": "extends",
-      "start": 217,
-      "end": 224,
+      "start": 208,
+      "end": 215,
       "loc": {
         "start": {
           "line": 8,
@@ -2119,8 +2119,8 @@
         "binop": null
       },
       "value": "Fetcher",
-      "start": 225,
-      "end": 232,
+      "start": 216,
+      "end": 223,
       "loc": {
         "start": {
           "line": 8,
@@ -2144,8 +2144,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 233,
-      "end": 234,
+      "start": 224,
+      "end": 225,
       "loc": {
         "start": {
           "line": 8,
@@ -2160,8 +2160,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 239,
-      "end": 265,
+      "start": 230,
+      "end": 256,
       "loc": {
         "start": {
           "line": 9,
@@ -2186,8 +2186,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 270,
-      "end": 281,
+      "start": 261,
+      "end": 272,
       "loc": {
         "start": {
           "line": 12,
@@ -2211,8 +2211,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 281,
-      "end": 282,
+      "start": 272,
+      "end": 273,
       "loc": {
         "start": {
           "line": 12,
@@ -2237,8 +2237,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 282,
-      "end": 286,
+      "start": 273,
+      "end": 277,
       "loc": {
         "start": {
           "line": 12,
@@ -2263,8 +2263,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 286,
-      "end": 287,
+      "start": 277,
+      "end": 278,
       "loc": {
         "start": {
           "line": 12,
@@ -2289,8 +2289,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 288,
-      "end": 297,
+      "start": 279,
+      "end": 288,
       "loc": {
         "start": {
           "line": 12,
@@ -2316,8 +2316,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 298,
-      "end": 299,
+      "start": 289,
+      "end": 290,
       "loc": {
         "start": {
           "line": 12,
@@ -2343,8 +2343,8 @@
         "updateContext": null
       },
       "value": "TW",
-      "start": 300,
-      "end": 304,
+      "start": 291,
+      "end": 295,
       "loc": {
         "start": {
           "line": 12,
@@ -2368,8 +2368,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 304,
-      "end": 305,
+      "start": 295,
+      "end": 296,
       "loc": {
         "start": {
           "line": 12,
@@ -2393,8 +2393,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 306,
-      "end": 307,
+      "start": 297,
+      "end": 298,
       "loc": {
         "start": {
           "line": 12,
@@ -2421,8 +2421,8 @@
         "updateContext": null
       },
       "value": "super",
-      "start": 316,
-      "end": 321,
+      "start": 307,
+      "end": 312,
       "loc": {
         "start": {
           "line": 13,
@@ -2446,8 +2446,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 321,
-      "end": 322,
+      "start": 312,
+      "end": 313,
       "loc": {
         "start": {
           "line": 13,
@@ -2472,8 +2472,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 322,
-      "end": 326,
+      "start": 313,
+      "end": 317,
       "loc": {
         "start": {
           "line": 13,
@@ -2498,8 +2498,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 326,
-      "end": 327,
+      "start": 317,
+      "end": 318,
       "loc": {
         "start": {
           "line": 13,
@@ -2524,8 +2524,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 328,
-      "end": 337,
+      "start": 319,
+      "end": 328,
       "loc": {
         "start": {
           "line": 13,
@@ -2549,8 +2549,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 337,
-      "end": 338,
+      "start": 328,
+      "end": 329,
       "loc": {
         "start": {
           "line": 13,
@@ -2565,8 +2565,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 348,
-      "end": 382,
+      "start": 339,
+      "end": 373,
       "loc": {
         "start": {
           "line": 15,
@@ -2593,8 +2593,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 391,
-      "end": 395,
+      "start": 382,
+      "end": 386,
       "loc": {
         "start": {
           "line": 18,
@@ -2619,8 +2619,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 395,
-      "end": 396,
+      "start": 386,
+      "end": 387,
       "loc": {
         "start": {
           "line": 18,
@@ -2645,8 +2645,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 396,
-      "end": 404,
+      "start": 387,
+      "end": 395,
       "loc": {
         "start": {
           "line": 18,
@@ -2672,8 +2672,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 405,
-      "end": 406,
+      "start": 396,
+      "end": 397,
       "loc": {
         "start": {
           "line": 18,
@@ -2698,8 +2698,8 @@
         "binop": null
       },
       "value": "undefined",
-      "start": 407,
-      "end": 416,
+      "start": 398,
+      "end": 407,
       "loc": {
         "start": {
           "line": 18,
@@ -2723,8 +2723,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 421,
-      "end": 422,
+      "start": 412,
+      "end": 413,
       "loc": {
         "start": {
           "line": 19,
@@ -2738,9 +2738,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-      "start": 428,
-      "end": 664,
+      "value": "*\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+      "start": 419,
+      "end": 625,
       "loc": {
         "start": {
           "line": 21,
@@ -2765,8 +2765,8 @@
         "binop": null
       },
       "value": "setTrackID",
-      "start": 669,
-      "end": 679,
+      "start": 630,
+      "end": 640,
       "loc": {
         "start": {
           "line": 28,
@@ -2790,8 +2790,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 679,
-      "end": 680,
+      "start": 640,
+      "end": 641,
       "loc": {
         "start": {
           "line": 28,
@@ -2816,8 +2816,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 680,
-      "end": 688,
+      "start": 641,
+      "end": 649,
       "loc": {
         "start": {
           "line": 28,
@@ -2841,8 +2841,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 688,
-      "end": 689,
+      "start": 649,
+      "end": 650,
       "loc": {
         "start": {
           "line": 28,
@@ -2866,8 +2866,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 690,
-      "end": 691,
+      "start": 651,
+      "end": 652,
       "loc": {
         "start": {
           "line": 28,
@@ -2894,8 +2894,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 700,
-      "end": 704,
+      "start": 661,
+      "end": 665,
       "loc": {
         "start": {
           "line": 29,
@@ -2920,8 +2920,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 704,
-      "end": 705,
+      "start": 665,
+      "end": 666,
       "loc": {
         "start": {
           "line": 29,
@@ -2946,8 +2946,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 705,
-      "end": 713,
+      "start": 666,
+      "end": 674,
       "loc": {
         "start": {
           "line": 29,
@@ -2973,8 +2973,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 714,
-      "end": 715,
+      "start": 675,
+      "end": 676,
       "loc": {
         "start": {
           "line": 29,
@@ -2999,8 +2999,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 716,
-      "end": 724,
+      "start": 677,
+      "end": 685,
       "loc": {
         "start": {
           "line": 29,
@@ -3027,8 +3027,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 733,
-      "end": 739,
+      "start": 694,
+      "end": 700,
       "loc": {
         "start": {
           "line": 30,
@@ -3055,8 +3055,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 740,
-      "end": 744,
+      "start": 701,
+      "end": 705,
       "loc": {
         "start": {
           "line": 30,
@@ -3080,8 +3080,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 749,
-      "end": 750,
+      "start": 710,
+      "end": 711,
       "loc": {
         "start": {
           "line": 31,
@@ -3095,9 +3095,9 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     ",
-      "start": 756,
-      "end": 1032,
+      "value": "*\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     ",
+      "start": 717,
+      "end": 963,
       "loc": {
         "start": {
           "line": 33,
@@ -3122,8 +3122,8 @@
         "binop": null
       },
       "value": "fetchMetadata",
-      "start": 1037,
-      "end": 1050,
+      "start": 968,
+      "end": 981,
       "loc": {
         "start": {
           "line": 40,
@@ -3147,8 +3147,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1050,
-      "end": 1051,
+      "start": 981,
+      "end": 982,
       "loc": {
         "start": {
           "line": 40,
@@ -3172,8 +3172,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1051,
-      "end": 1052,
+      "start": 982,
+      "end": 983,
       "loc": {
         "start": {
           "line": 40,
@@ -3197,8 +3197,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1053,
-      "end": 1054,
+      "start": 984,
+      "end": 985,
       "loc": {
         "start": {
           "line": 40,
@@ -3225,8 +3225,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1063,
-      "end": 1069,
+      "start": 994,
+      "end": 1000,
       "loc": {
         "start": {
           "line": 41,
@@ -3253,8 +3253,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1070,
-      "end": 1074,
+      "start": 1001,
+      "end": 1005,
       "loc": {
         "start": {
           "line": 41,
@@ -3279,8 +3279,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1074,
-      "end": 1075,
+      "start": 1005,
+      "end": 1006,
       "loc": {
         "start": {
           "line": 41,
@@ -3305,8 +3305,8 @@
         "binop": null
       },
       "value": "http",
-      "start": 1075,
-      "end": 1079,
+      "start": 1006,
+      "end": 1010,
       "loc": {
         "start": {
           "line": 41,
@@ -3331,8 +3331,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1079,
-      "end": 1080,
+      "start": 1010,
+      "end": 1011,
       "loc": {
         "start": {
           "line": 41,
@@ -3357,8 +3357,8 @@
         "binop": null
       },
       "value": "get",
-      "start": 1080,
-      "end": 1083,
+      "start": 1011,
+      "end": 1014,
       "loc": {
         "start": {
           "line": 41,
@@ -3382,8 +3382,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1083,
-      "end": 1084,
+      "start": 1014,
+      "end": 1015,
       "loc": {
         "start": {
           "line": 41,
@@ -3408,8 +3408,8 @@
         "binop": null
       },
       "value": "ENDPOINT",
-      "start": 1084,
-      "end": 1092,
+      "start": 1015,
+      "end": 1023,
       "loc": {
         "start": {
           "line": 41,
@@ -3435,8 +3435,8 @@
         "updateContext": null
       },
       "value": "+",
-      "start": 1093,
-      "end": 1094,
+      "start": 1024,
+      "end": 1025,
       "loc": {
         "start": {
           "line": 41,
@@ -3463,8 +3463,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1095,
-      "end": 1099,
+      "start": 1026,
+      "end": 1030,
       "loc": {
         "start": {
           "line": 41,
@@ -3489,8 +3489,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1099,
-      "end": 1100,
+      "start": 1030,
+      "end": 1031,
       "loc": {
         "start": {
           "line": 41,
@@ -3515,8 +3515,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 1100,
-      "end": 1108,
+      "start": 1031,
+      "end": 1039,
       "loc": {
         "start": {
           "line": 41,
@@ -3541,8 +3541,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1108,
-      "end": 1109,
+      "start": 1039,
+      "end": 1040,
       "loc": {
         "start": {
           "line": 41,
@@ -3566,8 +3566,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1110,
-      "end": 1111,
+      "start": 1041,
+      "end": 1042,
       "loc": {
         "start": {
           "line": 41,
@@ -3592,8 +3592,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1111,
-      "end": 1120,
+      "start": 1042,
+      "end": 1051,
       "loc": {
         "start": {
           "line": 41,
@@ -3618,8 +3618,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1120,
-      "end": 1121,
+      "start": 1051,
+      "end": 1052,
       "loc": {
         "start": {
           "line": 41,
@@ -3646,8 +3646,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1122,
-      "end": 1126,
+      "start": 1053,
+      "end": 1057,
       "loc": {
         "start": {
           "line": 41,
@@ -3672,8 +3672,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1126,
-      "end": 1127,
+      "start": 1057,
+      "end": 1058,
       "loc": {
         "start": {
           "line": 41,
@@ -3698,8 +3698,8 @@
         "binop": null
       },
       "value": "territory",
-      "start": 1127,
-      "end": 1136,
+      "start": 1058,
+      "end": 1067,
       "loc": {
         "start": {
           "line": 41,
@@ -3723,8 +3723,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1136,
-      "end": 1137,
+      "start": 1067,
+      "end": 1068,
       "loc": {
         "start": {
           "line": 41,
@@ -3748,8 +3748,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1137,
-      "end": 1138,
+      "start": 1068,
+      "end": 1069,
       "loc": {
         "start": {
           "line": 41,
@@ -3773,8 +3773,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1143,
-      "end": 1144,
+      "start": 1074,
+      "end": 1075,
       "loc": {
         "start": {
           "line": 42,
@@ -3789,8 +3789,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     ",
-      "start": 1150,
-      "end": 1308,
+      "start": 1081,
+      "end": 1239,
       "loc": {
         "start": {
           "line": 44,
@@ -3815,8 +3815,8 @@
         "binop": null
       },
       "value": "getWidgetUri",
-      "start": 1313,
-      "end": 1325,
+      "start": 1244,
+      "end": 1256,
       "loc": {
         "start": {
           "line": 49,
@@ -3840,8 +3840,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1325,
-      "end": 1326,
+      "start": 1256,
+      "end": 1257,
       "loc": {
         "start": {
           "line": 49,
@@ -3865,8 +3865,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1326,
-      "end": 1327,
+      "start": 1257,
+      "end": 1258,
       "loc": {
         "start": {
           "line": 49,
@@ -3890,8 +3890,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1327,
-      "end": 1328,
+      "start": 1258,
+      "end": 1259,
       "loc": {
         "start": {
           "line": 49,
@@ -3918,8 +3918,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1337,
-      "end": 1343,
+      "start": 1268,
+      "end": 1274,
       "loc": {
         "start": {
           "line": 50,
@@ -3943,8 +3943,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1344,
-      "end": 1345,
+      "start": 1275,
+      "end": 1276,
       "loc": {
         "start": {
           "line": 50,
@@ -3970,8 +3970,8 @@
         "updateContext": null
       },
       "value": "https://widget.kkbox.com/v1/?id=",
-      "start": 1345,
-      "end": 1377,
+      "start": 1276,
+      "end": 1308,
       "loc": {
         "start": {
           "line": 50,
@@ -3995,8 +3995,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1377,
-      "end": 1379,
+      "start": 1308,
+      "end": 1310,
       "loc": {
         "start": {
           "line": 50,
@@ -4023,8 +4023,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 1379,
-      "end": 1383,
+      "start": 1310,
+      "end": 1314,
       "loc": {
         "start": {
           "line": 50,
@@ -4049,8 +4049,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1383,
-      "end": 1384,
+      "start": 1314,
+      "end": 1315,
       "loc": {
         "start": {
           "line": 50,
@@ -4075,8 +4075,8 @@
         "binop": null
       },
       "value": "track_id",
-      "start": 1384,
-      "end": 1392,
+      "start": 1315,
+      "end": 1323,
       "loc": {
         "start": {
           "line": 50,
@@ -4100,8 +4100,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1392,
-      "end": 1393,
+      "start": 1323,
+      "end": 1324,
       "loc": {
         "start": {
           "line": 50,
@@ -4127,8 +4127,8 @@
         "updateContext": null
       },
       "value": "&type=song",
-      "start": 1393,
-      "end": 1403,
+      "start": 1324,
+      "end": 1334,
       "loc": {
         "start": {
           "line": 50,
@@ -4152,8 +4152,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1403,
-      "end": 1404,
+      "start": 1334,
+      "end": 1335,
       "loc": {
         "start": {
           "line": 50,
@@ -4177,8 +4177,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1409,
-      "end": 1410,
+      "start": 1340,
+      "end": 1341,
       "loc": {
         "start": {
           "line": 51,
@@ -4202,8 +4202,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1411,
-      "end": 1412,
+      "start": 1342,
+      "end": 1343,
       "loc": {
         "start": {
           "line": 52,
@@ -4228,8 +4228,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1412,
-      "end": 1412,
+      "start": 1343,
+      "end": 1343,
       "loc": {
         "start": {
           "line": 52,

--- a/docs/ast/source/auth/ClientCredentialsFlow.js.json
+++ b/docs/ast/source/auth/ClientCredentialsFlow.js.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 617,
+  "end": 609,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 617,
+    "end": 609,
     "loc": {
       "start": {
         "line": 1,
@@ -30,8 +30,8 @@
     "body": [
       {
         "type": "ExportDefaultDeclaration",
-        "start": 191,
-        "end": 617,
+        "start": 183,
+        "end": 609,
         "loc": {
           "start": {
             "line": 6,
@@ -44,8 +44,8 @@
         },
         "declaration": {
           "type": "ClassDeclaration",
-          "start": 206,
-          "end": 617,
+          "start": 198,
+          "end": 609,
           "loc": {
             "start": {
               "line": 6,
@@ -58,8 +58,8 @@
           },
           "id": {
             "type": "Identifier",
-            "start": 212,
-            "end": 233,
+            "start": 204,
+            "end": 225,
             "loc": {
               "start": {
                 "line": 6,
@@ -77,8 +77,8 @@
           "superClass": null,
           "body": {
             "type": "ClassBody",
-            "start": 234,
-            "end": 617,
+            "start": 226,
+            "end": 609,
             "loc": {
               "start": {
                 "line": 6,
@@ -92,8 +92,8 @@
             "body": [
               {
                 "type": "ClassMethod",
-                "start": 271,
-                "end": 367,
+                "start": 263,
+                "end": 359,
                 "loc": {
                   "start": {
                     "line": 10,
@@ -107,8 +107,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 271,
-                  "end": 282,
+                  "start": 263,
+                  "end": 274,
                   "loc": {
                     "start": {
                       "line": 10,
@@ -132,8 +132,8 @@
                 "params": [
                   {
                     "type": "Identifier",
-                    "start": 283,
-                    "end": 288,
+                    "start": 275,
+                    "end": 280,
                     "loc": {
                       "start": {
                         "line": 10,
@@ -150,8 +150,8 @@
                 ],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 290,
-                  "end": 367,
+                  "start": 282,
+                  "end": 359,
                   "loc": {
                     "start": {
                       "line": 10,
@@ -165,8 +165,8 @@
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "start": 343,
-                      "end": 361,
+                      "start": 335,
+                      "end": 353,
                       "loc": {
                         "start": {
                           "line": 14,
@@ -179,8 +179,8 @@
                       },
                       "expression": {
                         "type": "AssignmentExpression",
-                        "start": 343,
-                        "end": 361,
+                        "start": 335,
+                        "end": 353,
                         "loc": {
                           "start": {
                             "line": 14,
@@ -194,8 +194,8 @@
                         "operator": "=",
                         "left": {
                           "type": "MemberExpression",
-                          "start": 343,
-                          "end": 353,
+                          "start": 335,
+                          "end": 345,
                           "loc": {
                             "start": {
                               "line": 14,
@@ -208,8 +208,8 @@
                           },
                           "object": {
                             "type": "ThisExpression",
-                            "start": 343,
-                            "end": 347,
+                            "start": 335,
+                            "end": 339,
                             "loc": {
                               "start": {
                                 "line": 14,
@@ -224,8 +224,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 348,
-                            "end": 353,
+                            "start": 340,
+                            "end": 345,
                             "loc": {
                               "start": {
                                 "line": 14,
@@ -244,8 +244,8 @@
                         },
                         "right": {
                           "type": "Identifier",
-                          "start": 356,
-                          "end": 361,
+                          "start": 348,
+                          "end": 353,
                           "loc": {
                             "start": {
                               "line": 14,
@@ -265,8 +265,8 @@
                         {
                           "type": "CommentBlock",
                           "value": "*\n         * @ignore\n         ",
-                          "start": 300,
-                          "end": 334,
+                          "start": 292,
+                          "end": 326,
                           "loc": {
                             "start": {
                               "line": 11,
@@ -288,8 +288,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * @ignore\n     ",
-                    "start": 240,
-                    "end": 266,
+                    "start": 232,
+                    "end": 258,
                     "loc": {
                       "start": {
                         "line": 7,
@@ -306,8 +306,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     ",
-                    "start": 373,
-                    "end": 505,
+                    "start": 365,
+                    "end": 497,
                     "loc": {
                       "start": {
                         "line": 17,
@@ -323,8 +323,8 @@
               },
               {
                 "type": "ClassMethod",
-                "start": 510,
-                "end": 615,
+                "start": 502,
+                "end": 607,
                 "loc": {
                   "start": {
                     "line": 23,
@@ -338,8 +338,8 @@
                 "computed": false,
                 "key": {
                   "type": "Identifier",
-                  "start": 510,
-                  "end": 526,
+                  "start": 502,
+                  "end": 518,
                   "loc": {
                     "start": {
                       "line": 23,
@@ -363,8 +363,8 @@
                 "params": [],
                 "body": {
                   "type": "BlockStatement",
-                  "start": 529,
-                  "end": 615,
+                  "start": 521,
+                  "end": 607,
                   "loc": {
                     "start": {
                       "line": 23,
@@ -378,8 +378,8 @@
                   "body": [
                     {
                       "type": "ReturnStatement",
-                      "start": 539,
-                      "end": 609,
+                      "start": 531,
+                      "end": 601,
                       "loc": {
                         "start": {
                           "line": 24,
@@ -392,8 +392,8 @@
                       },
                       "argument": {
                         "type": "CallExpression",
-                        "start": 546,
-                        "end": 609,
+                        "start": 538,
+                        "end": 601,
                         "loc": {
                           "start": {
                             "line": 24,
@@ -406,8 +406,8 @@
                         },
                         "callee": {
                           "type": "MemberExpression",
-                          "start": 546,
-                          "end": 573,
+                          "start": 538,
+                          "end": 565,
                           "loc": {
                             "start": {
                               "line": 24,
@@ -420,8 +420,8 @@
                           },
                           "object": {
                             "type": "MemberExpression",
-                            "start": 546,
-                            "end": 556,
+                            "start": 538,
+                            "end": 548,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -434,8 +434,8 @@
                             },
                             "object": {
                               "type": "ThisExpression",
-                              "start": 546,
-                              "end": 550,
+                              "start": 538,
+                              "end": 542,
                               "loc": {
                                 "start": {
                                   "line": 24,
@@ -449,8 +449,8 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 551,
-                              "end": 556,
+                              "start": 543,
+                              "end": 548,
                               "loc": {
                                 "start": {
                                   "line": 24,
@@ -468,8 +468,8 @@
                           },
                           "property": {
                             "type": "Identifier",
-                            "start": 557,
-                            "end": 573,
+                            "start": 549,
+                            "end": 565,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -488,8 +488,8 @@
                         "arguments": [
                           {
                             "type": "ObjectExpression",
-                            "start": 574,
-                            "end": 608,
+                            "start": 566,
+                            "end": 600,
                             "loc": {
                               "start": {
                                 "line": 24,
@@ -503,8 +503,8 @@
                             "properties": [
                               {
                                 "type": "ObjectProperty",
-                                "start": 575,
-                                "end": 607,
+                                "start": 567,
+                                "end": 599,
                                 "loc": {
                                   "start": {
                                     "line": 24,
@@ -520,8 +520,8 @@
                                 "computed": false,
                                 "key": {
                                   "type": "Identifier",
-                                  "start": 575,
-                                  "end": 585,
+                                  "start": 567,
+                                  "end": 577,
                                   "loc": {
                                     "start": {
                                       "line": 24,
@@ -537,8 +537,8 @@
                                 },
                                 "value": {
                                   "type": "StringLiteral",
-                                  "start": 587,
-                                  "end": 607,
+                                  "start": 579,
+                                  "end": 599,
                                   "loc": {
                                     "start": {
                                       "line": 24,
@@ -568,8 +568,8 @@
                   {
                     "type": "CommentBlock",
                     "value": "*\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     ",
-                    "start": 373,
-                    "end": 505,
+                    "start": 365,
+                    "end": 497,
                     "loc": {
                       "start": {
                         "line": 17,
@@ -588,9 +588,9 @@
           "leadingComments": [
             {
               "type": "CommentBlock",
-              "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://kkbox.gelato.io/docs/versions/1.1/authentication\n ",
+              "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://docs-en.kkbox.codes/docs/getting-started\n ",
               "start": 0,
-              "end": 190,
+              "end": 182,
               "loc": {
                 "start": {
                   "line": 1,
@@ -608,9 +608,9 @@
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://kkbox.gelato.io/docs/versions/1.1/authentication\n ",
+            "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://docs-en.kkbox.codes/docs/getting-started\n ",
             "start": 0,
-            "end": 190,
+            "end": 182,
             "loc": {
               "start": {
                 "line": 1,
@@ -630,9 +630,9 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://kkbox.gelato.io/docs/versions/1.1/authentication\n ",
+      "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://docs-en.kkbox.codes/docs/getting-started\n ",
       "start": 0,
-      "end": 190,
+      "end": 182,
       "loc": {
         "start": {
           "line": 1,
@@ -647,8 +647,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 240,
-      "end": 266,
+      "start": 232,
+      "end": 258,
       "loc": {
         "start": {
           "line": 7,
@@ -663,8 +663,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 300,
-      "end": 334,
+      "start": 292,
+      "end": 326,
       "loc": {
         "start": {
           "line": 11,
@@ -679,8 +679,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     ",
-      "start": 373,
-      "end": 505,
+      "start": 365,
+      "end": 497,
       "loc": {
         "start": {
           "line": 17,
@@ -696,9 +696,9 @@
   "tokens": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://kkbox.gelato.io/docs/versions/1.1/authentication\n ",
+      "value": "*\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://docs-en.kkbox.codes/docs/getting-started\n ",
       "start": 0,
-      "end": 190,
+      "end": 182,
       "loc": {
         "start": {
           "line": 1,
@@ -725,8 +725,8 @@
         "updateContext": null
       },
       "value": "export",
-      "start": 191,
-      "end": 197,
+      "start": 183,
+      "end": 189,
       "loc": {
         "start": {
           "line": 6,
@@ -753,8 +753,8 @@
         "updateContext": null
       },
       "value": "default",
-      "start": 198,
-      "end": 205,
+      "start": 190,
+      "end": 197,
       "loc": {
         "start": {
           "line": 6,
@@ -781,8 +781,8 @@
         "updateContext": null
       },
       "value": "class",
-      "start": 206,
-      "end": 211,
+      "start": 198,
+      "end": 203,
       "loc": {
         "start": {
           "line": 6,
@@ -807,8 +807,8 @@
         "binop": null
       },
       "value": "ClientCredentialsFlow",
-      "start": 212,
-      "end": 233,
+      "start": 204,
+      "end": 225,
       "loc": {
         "start": {
           "line": 6,
@@ -832,8 +832,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 234,
-      "end": 235,
+      "start": 226,
+      "end": 227,
       "loc": {
         "start": {
           "line": 6,
@@ -848,8 +848,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * @ignore\n     ",
-      "start": 240,
-      "end": 266,
+      "start": 232,
+      "end": 258,
       "loc": {
         "start": {
           "line": 7,
@@ -874,8 +874,8 @@
         "binop": null
       },
       "value": "constructor",
-      "start": 271,
-      "end": 282,
+      "start": 263,
+      "end": 274,
       "loc": {
         "start": {
           "line": 10,
@@ -899,8 +899,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 282,
-      "end": 283,
+      "start": 274,
+      "end": 275,
       "loc": {
         "start": {
           "line": 10,
@@ -925,8 +925,8 @@
         "binop": null
       },
       "value": "token",
-      "start": 283,
-      "end": 288,
+      "start": 275,
+      "end": 280,
       "loc": {
         "start": {
           "line": 10,
@@ -950,8 +950,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 288,
-      "end": 289,
+      "start": 280,
+      "end": 281,
       "loc": {
         "start": {
           "line": 10,
@@ -975,8 +975,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 290,
-      "end": 291,
+      "start": 282,
+      "end": 283,
       "loc": {
         "start": {
           "line": 10,
@@ -991,8 +991,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n         * @ignore\n         ",
-      "start": 300,
-      "end": 334,
+      "start": 292,
+      "end": 326,
       "loc": {
         "start": {
           "line": 11,
@@ -1019,8 +1019,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 343,
-      "end": 347,
+      "start": 335,
+      "end": 339,
       "loc": {
         "start": {
           "line": 14,
@@ -1045,8 +1045,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 347,
-      "end": 348,
+      "start": 339,
+      "end": 340,
       "loc": {
         "start": {
           "line": 14,
@@ -1071,8 +1071,8 @@
         "binop": null
       },
       "value": "token",
-      "start": 348,
-      "end": 353,
+      "start": 340,
+      "end": 345,
       "loc": {
         "start": {
           "line": 14,
@@ -1098,8 +1098,8 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 354,
-      "end": 355,
+      "start": 346,
+      "end": 347,
       "loc": {
         "start": {
           "line": 14,
@@ -1124,8 +1124,8 @@
         "binop": null
       },
       "value": "token",
-      "start": 356,
-      "end": 361,
+      "start": 348,
+      "end": 353,
       "loc": {
         "start": {
           "line": 14,
@@ -1149,8 +1149,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 366,
-      "end": 367,
+      "start": 358,
+      "end": 359,
       "loc": {
         "start": {
           "line": 15,
@@ -1165,8 +1165,8 @@
     {
       "type": "CommentBlock",
       "value": "*\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     ",
-      "start": 373,
-      "end": 505,
+      "start": 365,
+      "end": 497,
       "loc": {
         "start": {
           "line": 17,
@@ -1191,8 +1191,8 @@
         "binop": null
       },
       "value": "fetchAccessToken",
-      "start": 510,
-      "end": 526,
+      "start": 502,
+      "end": 518,
       "loc": {
         "start": {
           "line": 23,
@@ -1216,8 +1216,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 526,
-      "end": 527,
+      "start": 518,
+      "end": 519,
       "loc": {
         "start": {
           "line": 23,
@@ -1241,8 +1241,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 527,
-      "end": 528,
+      "start": 519,
+      "end": 520,
       "loc": {
         "start": {
           "line": 23,
@@ -1266,8 +1266,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 529,
-      "end": 530,
+      "start": 521,
+      "end": 522,
       "loc": {
         "start": {
           "line": 23,
@@ -1294,8 +1294,8 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 539,
-      "end": 545,
+      "start": 531,
+      "end": 537,
       "loc": {
         "start": {
           "line": 24,
@@ -1322,8 +1322,8 @@
         "updateContext": null
       },
       "value": "this",
-      "start": 546,
-      "end": 550,
+      "start": 538,
+      "end": 542,
       "loc": {
         "start": {
           "line": 24,
@@ -1348,8 +1348,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 550,
-      "end": 551,
+      "start": 542,
+      "end": 543,
       "loc": {
         "start": {
           "line": 24,
@@ -1374,8 +1374,8 @@
         "binop": null
       },
       "value": "token",
-      "start": 551,
-      "end": 556,
+      "start": 543,
+      "end": 548,
       "loc": {
         "start": {
           "line": 24,
@@ -1400,8 +1400,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 556,
-      "end": 557,
+      "start": 548,
+      "end": 549,
       "loc": {
         "start": {
           "line": 24,
@@ -1426,8 +1426,8 @@
         "binop": null
       },
       "value": "fetchAccessToken",
-      "start": 557,
-      "end": 573,
+      "start": 549,
+      "end": 565,
       "loc": {
         "start": {
           "line": 24,
@@ -1451,8 +1451,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 573,
-      "end": 574,
+      "start": 565,
+      "end": 566,
       "loc": {
         "start": {
           "line": 24,
@@ -1476,8 +1476,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 574,
-      "end": 575,
+      "start": 566,
+      "end": 567,
       "loc": {
         "start": {
           "line": 24,
@@ -1502,8 +1502,8 @@
         "binop": null
       },
       "value": "grant_type",
-      "start": 575,
-      "end": 585,
+      "start": 567,
+      "end": 577,
       "loc": {
         "start": {
           "line": 24,
@@ -1528,8 +1528,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 585,
-      "end": 586,
+      "start": 577,
+      "end": 578,
       "loc": {
         "start": {
           "line": 24,
@@ -1555,8 +1555,8 @@
         "updateContext": null
       },
       "value": "client_credentials",
-      "start": 587,
-      "end": 607,
+      "start": 579,
+      "end": 599,
       "loc": {
         "start": {
           "line": 24,
@@ -1580,8 +1580,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 607,
-      "end": 608,
+      "start": 599,
+      "end": 600,
       "loc": {
         "start": {
           "line": 24,
@@ -1605,8 +1605,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 608,
-      "end": 609,
+      "start": 600,
+      "end": 601,
       "loc": {
         "start": {
           "line": 24,
@@ -1630,8 +1630,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 614,
-      "end": 615,
+      "start": 606,
+      "end": 607,
       "loc": {
         "start": {
           "line": 25,
@@ -1655,8 +1655,8 @@
         "postfix": false,
         "binop": null
       },
-      "start": 616,
-      "end": 617,
+      "start": 608,
+      "end": 609,
       "loc": {
         "start": {
           "line": 26,
@@ -1681,8 +1681,8 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 617,
-      "end": 617,
+      "start": 609,
+      "end": 609,
       "loc": {
         "start": {
           "line": 26,

--- a/docs/class/src/api/AlbumFetcher.js~AlbumFetcher.html
+++ b/docs/class/src/api/AlbumFetcher.js~AlbumFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/albums">https://kkbox.gelato.io/docs/versions/v1.1/resources/albums</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#albums">https://docs-en.kkbox.codes/v1.1/reference#albums</a></span></li></ul></div>
 
   
 
@@ -348,7 +348,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#albums-album_id">https://docs-en.kkbox.codes/v1.1/reference#albums-album_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -435,7 +435,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks">https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks">https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -571,7 +571,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#albums-album_id">https://docs-en.kkbox.codes/v1.1/reference#albums-album_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/ArtistFetcher.js~ArtistFetcher.html
+++ b/docs/class/src/api/ArtistFetcher.js~ArtistFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/artists">https://kkbox.gelato.io/docs/versions/v1.1/resources/artists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#artists">https://docs-en.kkbox.codes/v1.1/reference#artists</a></span></li></ul></div>
 
   
 
@@ -372,7 +372,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums">https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums">https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -435,7 +435,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id">https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -522,7 +522,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks">https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks">https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -595,7 +595,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id">https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/ChartFetcher.js~ChartFetcher.html
+++ b/docs/class/src/api/ChartFetcher.js~ChartFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/charts">https://kkbox.gelato.io/docs/versions/1.1/resources/charts</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#charts">https://docs-en.kkbox.codes/v1.1/reference#charts</a></span></li></ul></div>
 
   
 
@@ -264,7 +264,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts">https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#charts_1">https://docs-en.kkbox.codes/v1.1/reference#charts_1</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/FeaturedPlaylistCategoryFetcher.js~FeaturedPlaylistCategoryFetcher.html
+++ b/docs/class/src/api/FeaturedPlaylistCategoryFetcher.js~FeaturedPlaylistCategoryFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories">https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories</a></span></li></ul></div>
 
   
 
@@ -348,7 +348,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories">https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -411,7 +411,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id">https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -498,7 +498,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists">https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -571,7 +571,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id">https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/FeaturedPlaylistFetcher.js~FeaturedPlaylistFetcher.html
+++ b/docs/class/src/api/FeaturedPlaylistFetcher.js~FeaturedPlaylistFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featured-playlists">https://docs-en.kkbox.codes/v1.1/reference#featured-playlists</a></span></li></ul></div>
 
   
 
@@ -288,7 +288,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists">https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists">https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/GenreStationFetcher.js~GenreStationFetcher.html
+++ b/docs/class/src/api/GenreStationFetcher.js~GenreStationFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations">https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#genre-stations">https://docs-en.kkbox.codes/v1.1/reference#genre-stations</a></span></li></ul></div>
 
   
 
@@ -344,7 +344,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations">https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#genrestations">https://docs-en.kkbox.codes/v1.1/reference#genrestations</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -407,7 +407,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id">https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -480,7 +480,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id">https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id">https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/MoodStationFetcher.js~MoodStationFetcher.html
+++ b/docs/class/src/api/MoodStationFetcher.js~MoodStationFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations">https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#mood-stations">https://docs-en.kkbox.codes/v1.1/reference#mood-stations</a></span></li></ul></div>
 
   
 
@@ -398,7 +398,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations">https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#moodstations">https://docs-en.kkbox.codes/v1.1/reference#moodstations</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -413,7 +413,7 @@
     <span class="right-info">
       
       
-      <span data-ice="source"><span><a href="file/src/api/MoodStationFetcher.js.html#lineNumber52">source</a></span></span>
+      <span data-ice="source"><span><a href="file/src/api/MoodStationFetcher.js.html#lineNumber53">source</a></span></span>
     </span>
   </h3>
 
@@ -461,7 +461,7 @@
 
   
 
-  
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id">https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -542,7 +542,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id">https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id">https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/NewHitsPlaylistFetcher.js~NewHitsPlaylistFetcher.html
+++ b/docs/class/src/api/NewHitsPlaylistFetcher.js~NewHitsPlaylistFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists">https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists">https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists</a></span></li></ul></div>
 
   
 
@@ -344,7 +344,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists">https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists">https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -407,7 +407,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id">https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id">https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -480,7 +480,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id">https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id">https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/NewReleaseCategoryFetcher.js~NewReleaseCategoryFetcher.html
+++ b/docs/class/src/api/NewReleaseCategoryFetcher.js~NewReleaseCategoryFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories">https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#new-release-categories">https://docs-en.kkbox.codes/v1.1/reference#new-release-categories</a></span></li></ul></div>
 
   
 
@@ -372,7 +372,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums">https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums">https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -459,7 +459,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories">https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories">https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -522,7 +522,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id">https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id">https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -595,7 +595,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id">https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id">https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/SearchFetcher.js~SearchFetcher.html
+++ b/docs/class/src/api/SearchFetcher.js~SearchFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/search">https://kkbox.gelato.io/docs/versions/1.1/resources/search</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#search">https://docs-en.kkbox.codes/v1.1/reference#search</a></span></li></ul></div>
 
   
 
@@ -344,7 +344,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search">https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#search_1">https://docs-en.kkbox.codes/v1.1/reference#search_1</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -539,7 +539,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/search">https://kkbox.gelato.io/docs/versions/1.1/resources/search</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#search_1">https://docs-en.kkbox.codes/v1.1/reference#search_1</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/SharedPlaylistFetcher.js~SharedPlaylistFetcher.html
+++ b/docs/class/src/api/SharedPlaylistFetcher.js~SharedPlaylistFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists">https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#shared-playlists">https://docs-en.kkbox.codes/v1.1/reference#shared-playlists</a></span></li></ul></div>
 
   
 
@@ -348,7 +348,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id">https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id">https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -435,7 +435,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks">https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks">https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -571,7 +571,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id">https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id">https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/api/TrackFetcher.js~TrackFetcher.html
+++ b/docs/class/src/api/TrackFetcher.js~TrackFetcher.html
@@ -85,7 +85,7 @@
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/tracks">https://kkbox.gelato.io/docs/versions/1.1/resources/tracks</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#tracks">https://docs-en.kkbox.codes/v1.1/reference#tracks</a></span></li></ul></div>
 
   
 
@@ -320,7 +320,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id">https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id">https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id</a></span></li></ul></div>
   
 </div>
 <div class="detail" data-ice="detail">
@@ -456,7 +456,7 @@
 
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id">https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id">https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id</a></span></li></ul></div>
   
 </div>
 </div>

--- a/docs/class/src/auth/ClientCredentialsFlow.js~ClientCredentialsFlow.html
+++ b/docs/class/src/auth/ClientCredentialsFlow.js~ClientCredentialsFlow.html
@@ -86,7 +86,7 @@ user&apos;s personal data.</p>
 </div>
   
 
-  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://kkbox.gelato.io/docs/versions/1.1/authentication">https://kkbox.gelato.io/docs/versions/1.1/authentication</a></span></li></ul></div>
+  <div data-ice="see"><h4>See:</h4><ul><li><span><a href="https://docs-en.kkbox.codes/docs/getting-started">https://docs-en.kkbox.codes/docs/getting-started</a></span></li></ul></div>
 
   
 

--- a/docs/dump.json
+++ b/docs/dump.json
@@ -377,7 +377,7 @@
     "__docId__": 19,
     "kind": "file",
     "name": "src/api/AlbumFetcher.js",
-    "content": "import {ALBUMS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Fetch metadata and tracks of a album.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums\n */\nexport default class AlbumFetcher extends Fetcher {    \n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.album_id = undefined\n    }\n\n    /**\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     */\n    setAlbumID(album_id) {\n        this.album_id = album_id        \n        return this\n    }\n\n    /**\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.album_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.album_id}&type=album`\n    }\n\n    /**\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks\n     */\n    fetchTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.album_id + '/tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
+    "content": "import {ALBUMS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Fetch metadata and tracks of a album.\n * @see https://docs-en.kkbox.codes/v1.1/reference#albums\n */\nexport default class AlbumFetcher extends Fetcher {    \n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.album_id = undefined\n    }\n\n    /**\n     * Set the album fetcher.\n     *\n     * @param {string} album_id - The ID of an album.\n     * @return {AlbumFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     */\n    setAlbumID(album_id) {\n        this.album_id = album_id        \n        return this\n    }\n\n    /**\n     * Fetcy metadata of the album you create.\n     *\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.album_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the album.\n     * @example https://widget.kkbox.com/v1/?id=4qtXcj31wYJTRZbb23&type=album\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.album_id}&type=album`\n    }\n\n    /**\n     * Get tracks in an album. Result will be return with pagination.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks\n     */\n    fetchTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.album_id + '/tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/AlbumFetcher.js",
     "access": null,
@@ -397,7 +397,7 @@
     "importStyle": "AlbumFetcher",
     "description": "Fetch metadata and tracks of a album.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/albums"
+      "https://docs-en.kkbox.codes/v1.1/reference#albums"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -465,7 +465,7 @@
     "access": null,
     "description": "Set the album fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#albums-album_id"
     ],
     "lineNumber": 28,
     "params": [
@@ -527,7 +527,7 @@
       "api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#albums-album_id"
     ],
     "lineNumber": 40,
     "params": [],
@@ -580,7 +580,7 @@
       "api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks"
+      "https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks"
     ],
     "lineNumber": 62,
     "params": [
@@ -991,7 +991,7 @@
     "__docId__": 46,
     "kind": "file",
     "name": "src/api/ArtistFetcher.js",
-    "content": "import {ARTISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get artist metadata.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists\n */\nexport default class ArtistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.artist_id = undefined\n    }\n\n    /**\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     */\n    setArtistID(artist_id) {\n        this.artist_id = artist_id\n        return this\n    }\n\n    /**\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.artist_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums\n     */\n    fetchAlbums(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.artist_id + '/albums', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n\n    /**\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks\n     */\n    fetchTopTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.artist_id + '/top-tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
+    "content": "import {ARTISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get artist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#artists\n */\nexport default class ArtistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.artist_id = undefined\n    }\n\n    /**\n     * Init the artist object.\n     *\n     * @param {string} artist_id - The ID of an artist.\n     * @return {Artist}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     */\n    setArtistID(artist_id) {\n        this.artist_id = artist_id\n        return this\n    }\n\n    /**\n     * Fetch metadata of the artist you find.\n     *\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.artist_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch albums belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums\n     */\n    fetchAlbums(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.artist_id + '/albums', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n\n    /**\n     * Fetch top tracks belong to an artist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks\n     */\n    fetchTopTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.artist_id + '/top-tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/ArtistFetcher.js",
     "access": null,
@@ -1011,7 +1011,7 @@
     "importStyle": "ArtistFetcher",
     "description": "Get artist metadata.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/artists"
+      "https://docs-en.kkbox.codes/v1.1/reference#artists"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -1079,7 +1079,7 @@
     "access": null,
     "description": "Init the artist object.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id"
     ],
     "lineNumber": 28,
     "params": [
@@ -1141,7 +1141,7 @@
       "api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id"
     ],
     "lineNumber": 40,
     "params": [],
@@ -1169,7 +1169,7 @@
       "api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums"
+      "https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums"
     ],
     "lineNumber": 53,
     "params": [
@@ -1218,7 +1218,7 @@
       "api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks"
+      "https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks"
     ],
     "lineNumber": 70,
     "params": [
@@ -1256,7 +1256,7 @@
     "__docId__": 55,
     "kind": "file",
     "name": "src/api/ChartFetcher.js",
-    "content": "import {CHARTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * The fetcher that can fetch chart playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts\n */\nexport default class ChartFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory = 'TW')\n    }\n\n    /**\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts\n     */\n    fetchCharts() {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory\n        })\n    }\n}",
+    "content": "import {CHARTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * The fetcher that can fetch chart playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#charts\n */\nexport default class ChartFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory = 'TW')\n    }\n\n    /**\n     * Fetch chart playlists.\n     *\n     * @return {Promise}\n     * @example api.chartFetcher.fetchCharts()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1\n     */\n    fetchCharts() {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/ChartFetcher.js",
     "access": null,
@@ -1276,7 +1276,7 @@
     "importStyle": "ChartFetcher",
     "description": "The fetcher that can fetch chart playlists.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/charts"
+      "https://docs-en.kkbox.codes/v1.1/reference#charts"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -1330,7 +1330,7 @@
       "api.chartFetcher.fetchCharts()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts"
+      "https://docs-en.kkbox.codes/v1.1/reference#charts_1"
     ],
     "lineNumber": 23,
     "params": [],
@@ -1347,7 +1347,7 @@
     "__docId__": 59,
     "kind": "file",
     "name": "src/api/FeaturedPlaylistCategoryFetcher.js",
-    "content": "import {FEATURED_PLAYLISTS_CATEGORIES as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List featured playlist categories.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories\n */\nexport default class FeaturedPlaylistCategoryFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.category_id = undefined\n    }\n\n    /**\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories\n     */\n    fetchAllFeaturedPlaylistCategories() {\n        return this.http.get(ENDPOINT, {territory: this.territory})\n    }\n\n    /**\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     */\n    setCategoryID(category_id) {\n        this.category_id = category_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists\n     */\n    fetchPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.category_id + '/playlists', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
+    "content": "import {FEATURED_PLAYLISTS_CATEGORIES as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List featured playlist categories.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories\n */\nexport default class FeaturedPlaylistCategoryFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.category_id = undefined\n    }\n\n    /**\n     * Fetch all featured playlist categories.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories\n     */\n    fetchAllFeaturedPlaylistCategories() {\n        return this.http.get(ENDPOINT, {territory: this.territory})\n    }\n\n    /**\n     * Init the featured playlist category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {FeaturedPlaylistCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     */\n    setCategoryID(category_id) {\n        this.category_id = category_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the category you init.\n     *\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch featured playlists of the category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists\n     */\n    fetchPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.category_id + '/playlists', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/FeaturedPlaylistCategoryFetcher.js",
     "access": null,
@@ -1367,7 +1367,7 @@
     "importStyle": "FeaturedPlaylistCategoryFetcher",
     "description": "List featured playlist categories.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories"
+      "https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -1438,7 +1438,7 @@
       "api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories"
+      "https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories"
     ],
     "lineNumber": 28,
     "params": [],
@@ -1463,7 +1463,7 @@
     "access": null,
     "description": "Init the featured playlist category fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id"
     ],
     "lineNumber": 39,
     "params": [
@@ -1525,7 +1525,7 @@
       "api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id"
     ],
     "lineNumber": 51,
     "params": [],
@@ -1553,7 +1553,7 @@
       "api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists"
     ],
     "lineNumber": 64,
     "params": [
@@ -1591,7 +1591,7 @@
     "__docId__": 68,
     "kind": "file",
     "name": "src/api/FeaturedPlaylistFetcher.js",
-    "content": "import {FEATURED_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List all featured playlists.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists\n */\nexport default class FeaturedPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n    }\n\n    /**\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists\n     */\n    fetchAllFeaturedPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            limit: limit, \n            offset: offset, \n            territory: this.territory\n        })\n    }\n}",
+    "content": "import {FEATURED_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List all featured playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists\n */\nexport default class FeaturedPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n    }\n\n    /**\n     * Fetch all featured playlists. Result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists\n     */\n    fetchAllFeaturedPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            limit: limit, \n            offset: offset, \n            territory: this.territory\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/FeaturedPlaylistFetcher.js",
     "access": null,
@@ -1611,7 +1611,7 @@
     "importStyle": "FeaturedPlaylistFetcher",
     "description": "List all featured playlists.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#featured-playlists"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -1665,7 +1665,7 @@
       "api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists"
     ],
     "lineNumber": 25,
     "params": [
@@ -1925,7 +1925,7 @@
     "__docId__": 80,
     "kind": "file",
     "name": "src/api/GenreStationFetcher.js",
-    "content": "import {GENRE_STATIONS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get genre stations.\n * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations\n */\nexport default class GenreStationFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         *  @ignore\n         */\n        this.genre_station_id = undefined \n    }\n\n    /**\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations\n     */\n    fetchAllGenreStations(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory,\n            limit: limit,\n            offset: offset            \n        })\n    }\n\n    /**\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     */\n    setGenreStationID(genre_station_id) {\n        this.genre_station_id = genre_station_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.genre_station_id, {territory: this.territory})\n    }\n}",
+    "content": "import {GENRE_STATIONS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get genre stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations\n */\nexport default class GenreStationFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         *  @ignore\n         */\n        this.genre_station_id = undefined \n    }\n\n    /**\n     * Fetch all genre stations. The result will be paged.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.GenreStation.fetchAllGenreStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations\n     */\n    fetchAllGenreStations(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory,\n            limit: limit,\n            offset: offset            \n        })\n    }\n\n    /**\n     * Init the genre station fetcher.\n     *\n     * @param {string} genre_station_id - The ID of a genre station.\n     * @return {GenreStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     */\n    setGenreStationID(genre_station_id) {\n        this.genre_station_id = genre_station_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the genre station with the genre station fetcher.\n     *\n     * @return {Promise}\n     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.genre_station_id, {territory: this.territory})\n    }\n}",
     "static": true,
     "longname": "src/api/GenreStationFetcher.js",
     "access": null,
@@ -1945,7 +1945,7 @@
     "importStyle": "GenreStationFetcher",
     "description": "Get genre stations.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations"
+      "https://docs-en.kkbox.codes/v1.1/reference#genre-stations"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -2016,7 +2016,7 @@
       "api.GenreStation.fetchAllGenreStations()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations"
+      "https://docs-en.kkbox.codes/v1.1/reference#genrestations"
     ],
     "lineNumber": 30,
     "params": [
@@ -2062,7 +2062,7 @@
     "access": null,
     "description": "Init the genre station fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id"
     ],
     "lineNumber": 45,
     "params": [
@@ -2124,7 +2124,7 @@
       "api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id"
     ],
     "lineNumber": 57,
     "params": [],
@@ -2297,7 +2297,7 @@
     "__docId__": 94,
     "kind": "file",
     "name": "src/api/MoodStationFetcher.js",
-    "content": "import {MOOD_STATIONS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get mood stations.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations\n */\nexport default class MoodStationFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.mood_station_id = undefined\n    }\n\n    /**\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations\n     */\n    fetchAllMoodStations() {\n        return this.http.get(ENDPOINT, {territory: this.territory})\n    }\n\n    /**\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id\n     */\n    setMoodStationID(mood_station_id, territory = 'TW') {\n        this.mood_station_id = mood_station_id\n        this.territory = territory\n        return this\n    }\n\n    /**\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.mood_station_id, {territory: this.territory})\n    }\n}",
+    "content": "import {MOOD_STATIONS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get mood stations.\n * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations\n */\nexport default class MoodStationFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.mood_station_id = undefined\n    }\n\n    /**\n     * Fetch all mood stations.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.fetchAllMoodStations()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations\n     */\n    fetchAllMoodStations() {\n        return this.http.get(ENDPOINT, {territory: this.territory})\n    }\n\n    /**\n     * Init the mood station fetcher.\n     *\n     * @param {string} mood_station_id - The ID of a mood station.\n     * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.\n     * @return {MoodStation}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     */\n    setMoodStationID(mood_station_id, territory = 'TW') {\n        this.mood_station_id = mood_station_id\n        this.territory = territory\n        return this\n    }\n\n    /**\n     * Fetch the mood station's metadata.\n     *\n     * @return {Promise}\n     * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.mood_station_id, {territory: this.territory})\n    }\n}",
     "static": true,
     "longname": "src/api/MoodStationFetcher.js",
     "access": null,
@@ -2317,7 +2317,7 @@
     "importStyle": "MoodStationFetcher",
     "description": "Get mood stations.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations"
+      "https://docs-en.kkbox.codes/v1.1/reference#mood-stations"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -2388,7 +2388,7 @@
       "api.moodStationFetcher.fetchAllMoodStations()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations"
+      "https://docs-en.kkbox.codes/v1.1/reference#moodstations"
     ],
     "lineNumber": 28,
     "params": [],
@@ -2413,7 +2413,7 @@
     "access": null,
     "description": "Init the mood station fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id"
     ],
     "lineNumber": 40,
     "params": [
@@ -2509,7 +2509,10 @@
     "examples": [
       "api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()"
     ],
-    "lineNumber": 52,
+    "see": [
+      "https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id"
+    ],
+    "lineNumber": 53,
     "params": [],
     "return": {
       "nullable": null,
@@ -2524,7 +2527,7 @@
     "__docId__": 103,
     "kind": "file",
     "name": "src/api/NewHitsPlaylistFetcher.js",
-    "content": "import {NEW_HITS_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List new hits playlists.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists\n */\nexport default class NewHitsPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.playlist_id = undefined\n    }\n\n    /**\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists\n     */\n    fetchAllNewHitsPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory\n        })\n    }\n\n    /**\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     */\n    setPlaylistID(playlist_id) {\n        this.playlist_id = playlist_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})\n    }\n}",
+    "content": "import {NEW_HITS_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List new hits playlists.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists\n */\nexport default class NewHitsPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.playlist_id = undefined\n    }\n\n    /**\n     * Fetch all new hits playlists.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists\n     */\n    fetchAllNewHitsPlaylists(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            territory: this.territory\n        })\n    }\n\n    /**\n     * Init the new hits playlist fetcher.\n     *\n     * @param {string} playlist_id - The playlist ID.\n     * @return {NewHitsPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     */\n    setPlaylistID(playlist_id) {\n        this.playlist_id = playlist_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})\n    }\n}",
     "static": true,
     "longname": "src/api/NewHitsPlaylistFetcher.js",
     "access": null,
@@ -2544,7 +2547,7 @@
     "importStyle": "NewHitsPlaylistFetcher",
     "description": "List new hits playlists.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -2615,7 +2618,7 @@
       "api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists"
     ],
     "lineNumber": 30,
     "params": [
@@ -2661,7 +2664,7 @@
     "access": null,
     "description": "Init the new hits playlist fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id"
     ],
     "lineNumber": 43,
     "params": [
@@ -2723,7 +2726,7 @@
       "api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id"
     ],
     "lineNumber": 55,
     "params": [],
@@ -2740,7 +2743,7 @@
     "__docId__": 111,
     "kind": "file",
     "name": "src/api/NewReleaseCategoryFetcher.js",
-    "content": "import {NEW_RELEASE_CATEGORIES as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List categories of new release albums.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories\n */\nexport default class NewReleaseCategoryFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.category_id = undefined\n    }\n\n    /**\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories\n     */\n    fetchAllNewReleaseCategories(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            limit: limit,\n            offset: offset,\n            territory: this.territory\n        })\n    }\n\n    /**\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     */\n    setCategoryID(category_id) {\n        this.category_id = category_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums\n     */\n    fetchAlbums(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.category_id + '/albums', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
+    "content": "import {NEW_RELEASE_CATEGORIES as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * List categories of new release albums.\n * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories\n */\nexport default class NewReleaseCategoryFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.category_id = undefined\n    }\n\n    /**\n     * Fetch all new release categories.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories\n     */\n    fetchAllNewReleaseCategories(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            limit: limit,\n            offset: offset,\n            territory: this.territory\n        })\n    }\n\n    /**\n     * Init the new release category fetcher.\n     *\n     * @param {string} category_id - The category ID.\n     * @return {NewReleaseCategoryFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     */\n    setCategoryID(category_id) {\n        this.category_id = category_id        \n        return this\n    }\n\n    /**\n     * Fetch metadata of the new release category you set.\n     *\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})\n    }\n\n    /**\n     * Fetch albums of the new release category with the category fetcher you init. Result will be paged.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums\n     */\n    fetchAlbums(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.category_id + '/albums', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/NewReleaseCategoryFetcher.js",
     "access": null,
@@ -2760,7 +2763,7 @@
     "importStyle": "NewReleaseCategoryFetcher",
     "description": "List categories of new release albums.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories"
+      "https://docs-en.kkbox.codes/v1.1/reference#new-release-categories"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -2831,7 +2834,7 @@
       "api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories"
+      "https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories"
     ],
     "lineNumber": 30,
     "params": [
@@ -2877,7 +2880,7 @@
     "access": null,
     "description": "Init the new release category fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id"
     ],
     "lineNumber": 45,
     "params": [
@@ -2939,7 +2942,7 @@
       "api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id"
     ],
     "lineNumber": 57,
     "params": [],
@@ -2967,7 +2970,7 @@
       "api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums"
+      "https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums"
     ],
     "lineNumber": 70,
     "params": [
@@ -3005,7 +3008,7 @@
     "__docId__": 120,
     "kind": "file",
     "name": "src/api/SearchFetcher.js",
-    "content": "import {SEARCH as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Search API.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n */\nexport default class SearchFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.filterConditions = undefined\n\n        /**\n         * @ignore\n         */\n        this.q = undefined\n\n        /**\n         * @ignore\n         */\n        this.type = undefined\n    }\n\n    /**\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     */\n    filter(conditions = {\n        track = undefined,\n        album = undefined,\n        artist = undefined,\n        playlist = undefined,\n        available_territory = undefined\n    } = {}) {\n        this.filterConditions = conditions\n        return this\n    }\n\n    /**\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search\n     */\n    setSearchCriteria(q, type = undefined) {\n        this.q = q\n        this.type = type        \n        return this\n    }\n\n    /**\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search\n     */\n    fetchSearchResult(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            q: this.q,\n            type: this.type,\n            territory: this.territory,\n            limit: limit,\n            offset: offset            \n        }).then(doFilter.bind(this))\n    }\n}\n\nfunction doFilter(response) {\n    if (this.filterConditions !== undefined) {\n        const data = Object.keys(response.data).map(key => {\n            switch (key) {\n                case 'tracks':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(track => {\n                                    if (this.filterConditions.available_territory !== undefined &&\n                                        !track.available_territories.includes(this.filterConditions.available_territory)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.track !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.track + '.*').test(track.name)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.album !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.album + '.*').test(track.album.name)) {\n                                        return false\n                                    }\n                                    return !(this.filterConditions.artist !== undefined &&\n                                    !new RegExp('.*' + this.filterConditions.artist + '.*').test(track.album.artist.name))\n                                })\n                        })\n                    }                    \n                case 'albums':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(album => {\n                                    if (this.filterConditions.available_territory !== undefined &&\n                                        !album.available_territories.includes(this.filterConditions.available_territory)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.album !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.album + '.*').test(album.name)) {\n                                        return false\n                                    }\n                                    return !(this.filterConditions.artist !== undefined &&\n                                    !new RegExp('.*' + this.filterConditions.artist + '.*').test(album.artist.name))\n                                })\n                        })\n                    }                    \n                case 'artists':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(artist => {\n                                    if (this.filterConditions.artist === undefined) {\n                                        return true\n                                    } else {\n                                        return new RegExp('.*' + this.filterConditions.artist + '.*').test(artist.name)\n                                    }\n                                })\n                        })\n                    }                    \n                case 'playlists':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(playlist => {\n                                    if (this.filterConditions.playlist === undefined) {\n                                        return true\n                                    } else {\n                                        return new RegExp('.*' + this.filterConditions.playlist + '.*').test(playlist.title)\n                                    }\n                                })\n                        })\n                    }                    \n                default:\n                    return {[key]: response.data[key]}\n            }\n        })\n        return Object.assign(response, {data: Object.assign(...data)})\n    } else {\n        return response\n    }\n}",
+    "content": "import {SEARCH as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Search API.\n * @see https://docs-en.kkbox.codes/v1.1/reference#search\n */\nexport default class SearchFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.filterConditions = undefined\n\n        /**\n         * @ignore\n         */\n        this.q = undefined\n\n        /**\n         * @ignore\n         */\n        this.type = undefined\n    }\n\n    /**\n     * Filter what you don't want when search.\n     *\n     * @param {Object} [conditions] - search conditions.\n     * @param {string} conditions.track - track's name.\n     * @param {string} conditions.album - album's name.\n     * @param {string} conditions.artist - artist's name.\n     * @param {string} conditions.playlist - playlist's title.\n     * @param {string} conditions.available_territory - tracks and albums available territory.\n     * @return {Search}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').filter({artist: '五月天'}).fetchSearchResult()\n     */\n    filter(conditions = {\n        track = undefined,\n        album = undefined,\n        artist = undefined,\n        playlist = undefined,\n        available_territory = undefined\n    } = {}) {\n        this.filterConditions = conditions\n        return this\n    }\n\n    /**\n     * Init the search fetcher for the artist, album, track or playlist.\n     *\n     * @param {string} q - The keyword to be searched.\n     * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.\n     * @return {Search}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     */\n    setSearchCriteria(q, type = undefined) {\n        this.q = q\n        this.type = type        \n        return this\n    }\n\n    /**\n     * Fetch the search result.\n     *\n     * @param {number} [limit] - The size of one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1\n     */\n    fetchSearchResult(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT, {\n            q: this.q,\n            type: this.type,\n            territory: this.territory,\n            limit: limit,\n            offset: offset            \n        }).then(doFilter.bind(this))\n    }\n}\n\nfunction doFilter(response) {\n    if (this.filterConditions !== undefined) {\n        const data = Object.keys(response.data).map(key => {\n            switch (key) {\n                case 'tracks':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(track => {\n                                    if (this.filterConditions.available_territory !== undefined &&\n                                        !track.available_territories.includes(this.filterConditions.available_territory)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.track !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.track + '.*').test(track.name)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.album !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.album + '.*').test(track.album.name)) {\n                                        return false\n                                    }\n                                    return !(this.filterConditions.artist !== undefined &&\n                                    !new RegExp('.*' + this.filterConditions.artist + '.*').test(track.album.artist.name))\n                                })\n                        })\n                    }                    \n                case 'albums':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(album => {\n                                    if (this.filterConditions.available_territory !== undefined &&\n                                        !album.available_territories.includes(this.filterConditions.available_territory)) {\n                                        return false\n                                    }\n                                    if (this.filterConditions.album !== undefined &&\n                                        !new RegExp('.*' + this.filterConditions.album + '.*').test(album.name)) {\n                                        return false\n                                    }\n                                    return !(this.filterConditions.artist !== undefined &&\n                                    !new RegExp('.*' + this.filterConditions.artist + '.*').test(album.artist.name))\n                                })\n                        })\n                    }                    \n                case 'artists':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(artist => {\n                                    if (this.filterConditions.artist === undefined) {\n                                        return true\n                                    } else {\n                                        return new RegExp('.*' + this.filterConditions.artist + '.*').test(artist.name)\n                                    }\n                                })\n                        })\n                    }                    \n                case 'playlists':\n                    return {\n                        [key]: Object.assign(response.data[key], {\n                            data: response.data[key].data\n                                .filter(playlist => {\n                                    if (this.filterConditions.playlist === undefined) {\n                                        return true\n                                    } else {\n                                        return new RegExp('.*' + this.filterConditions.playlist + '.*').test(playlist.title)\n                                    }\n                                })\n                        })\n                    }                    \n                default:\n                    return {[key]: response.data[key]}\n            }\n        })\n        return Object.assign(response, {data: Object.assign(...data)})\n    } else {\n        return response\n    }\n}",
     "static": true,
     "longname": "src/api/SearchFetcher.js",
     "access": null,
@@ -3025,7 +3028,7 @@
     "importStyle": "SearchFetcher",
     "description": "Search API.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/search"
+      "https://docs-en.kkbox.codes/v1.1/reference#search"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -3236,7 +3239,7 @@
     "access": null,
     "description": "Init the search fetcher for the artist, album, track or playlist.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/search"
+      "https://docs-en.kkbox.codes/v1.1/reference#search_1"
     ],
     "lineNumber": 62,
     "params": [
@@ -3331,7 +3334,7 @@
       "api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search"
+      "https://docs-en.kkbox.codes/v1.1/reference#search_1"
     ],
     "lineNumber": 77,
     "params": [
@@ -3405,7 +3408,7 @@
     "__docId__": 133,
     "kind": "file",
     "name": "src/api/SharedPlaylistFetcher.js",
-    "content": "import {SHARED_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get playlist metadata.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists\n */\nexport default class SharedPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.playlist_id = undefined\n    }\n\n    /**\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     */\n    setPlaylistID(playlist_id) {\n        this.playlist_id = playlist_id\n        return this\n    }\n\n    /**\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.playlist_id}&type=playlist`\n    }\n\n    /**\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks\n     */\n    fetchTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.playlist_id + '/tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
+    "content": "import {SHARED_PLAYLISTS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get playlist metadata.\n * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists\n */\nexport default class SharedPlaylistFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.playlist_id = undefined\n    }\n\n    /**\n     * Init the shared playlist fetcher.\n     *\n     * @param {string} playlist_id - The ID of a playlist.\n     * @return {SharedPlaylistFetcher}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     */\n    setPlaylistID(playlist_id) {\n        this.playlist_id = playlist_id\n        return this\n    }\n\n    /**\n     * Fetch metadata of the shared playlist with the shared playlist fetcher.\n     *\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the playlist.\n     * @example https://widget.kkbox.com/v1/?id=KmjwNXizu5MxHFSloP&type=playlist\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.playlist_id}&type=playlist`\n    }\n\n    /**\n     * Fetch track list of a shared playlist.\n     *\n     * @param {number} [limit] - The size for one page.\n     * @param {number} [offset] - The offset index for first element.\n     * @return {Promise}\n     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks\n     */\n    fetchTracks(limit = undefined, offset = undefined) {\n        return this.http.get(ENDPOINT + this.playlist_id + '/tracks', {\n            territory: this.territory,\n            limit: limit,\n            offset: offset\n        })\n    }\n}",
     "static": true,
     "longname": "src/api/SharedPlaylistFetcher.js",
     "access": null,
@@ -3425,7 +3428,7 @@
     "importStyle": "SharedPlaylistFetcher",
     "description": "Get playlist metadata.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists"
+      "https://docs-en.kkbox.codes/v1.1/reference#shared-playlists"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -3493,7 +3496,7 @@
     "access": null,
     "description": "Init the shared playlist fetcher.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id"
     ],
     "lineNumber": 28,
     "params": [
@@ -3555,7 +3558,7 @@
       "api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id"
     ],
     "lineNumber": 40,
     "params": [],
@@ -3608,7 +3611,7 @@
       "api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks"
+      "https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks"
     ],
     "lineNumber": 62,
     "params": [
@@ -3646,7 +3649,7 @@
     "__docId__": 142,
     "kind": "file",
     "name": "src/api/TrackFetcher.js",
-    "content": "import {TRACKS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get metadata of a track.\n * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks\n */\nexport default class TrackFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.track_id = undefined\n    }\n\n    /**\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     */\n    setTrackID(track_id) {\n        this.track_id = track_id\n        return this\n    }\n\n    /**\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.track_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.track_id}&type=song`\n    }\n}",
+    "content": "import {TRACKS as ENDPOINT} from '../Endpoint'\nimport Fetcher from './Fetcher'\n\n/**\n * Get metadata of a track.\n * @see https://docs-en.kkbox.codes/v1.1/reference#tracks\n */\nexport default class TrackFetcher extends Fetcher {\n    /**\n     * @ignore\n     */\n    constructor(http, territory = 'TW') {\n        super(http, territory)\n\n        /**\n         * @ignore\n         */\n        this.track_id = undefined\n    }\n\n    /**\n     * Set the track fetcher's track ID.\n     *\n     * @param {string} track_id - The ID of a track.\n     * @return {Track}\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     */\n    setTrackID(track_id) {\n        this.track_id = track_id\n        return this\n    }\n\n    /**\n     * Get metadata of the track with the track fetcher.\n     *\n     * @return {Promise}\n     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()\n     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id\n     */\n    fetchMetadata() {\n        return this.http.get(ENDPOINT + this.track_id, {territory: this.territory})\n    }\n\n    /**\n     * Get KKBOX web widget uri of the track.\n     * @example https://widget.kkbox.com/v1/?id=8sD5pE4dV0Zqmmler6&type=song\n     * @return {string}\n     */\n    getWidgetUri(){\n        return `https://widget.kkbox.com/v1/?id=${this.track_id}&type=song`\n    }\n}",
     "static": true,
     "longname": "src/api/TrackFetcher.js",
     "access": null,
@@ -3666,7 +3669,7 @@
     "importStyle": "TrackFetcher",
     "description": "Get metadata of a track.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/tracks"
+      "https://docs-en.kkbox.codes/v1.1/reference#tracks"
     ],
     "lineNumber": 8,
     "interface": false,
@@ -3734,7 +3737,7 @@
     "access": null,
     "description": "Set the track fetcher's track ID.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id"
     ],
     "lineNumber": 28,
     "params": [
@@ -3796,7 +3799,7 @@
       "api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()"
     ],
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id"
+      "https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id"
     ],
     "lineNumber": 40,
     "params": [],
@@ -3940,7 +3943,7 @@
     "__docId__": 155,
     "kind": "file",
     "name": "src/auth/ClientCredentialsFlow.js",
-    "content": "/**\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://kkbox.gelato.io/docs/versions/1.1/authentication\n */\nexport default class ClientCredentialsFlow {\n    /**\n     * @ignore\n     */\n    constructor(token) {\n        /**\n         * @ignore\n         */\n        this.token = token\n    }\n\n    /**\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     */\n    fetchAccessToken() {\n        return this.token.fetchAccessToken({grant_type: 'client_credentials'})\n    }\n}",
+    "content": "/**\n * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\n * user's personal data.\n * @see https://docs-en.kkbox.codes/docs/getting-started\n */\nexport default class ClientCredentialsFlow {\n    /**\n     * @ignore\n     */\n    constructor(token) {\n        /**\n         * @ignore\n         */\n        this.token = token\n    }\n\n    /**\n     * Fetch access token.\n     *\n     * @return {Promise}\n     * @example auth.clientCredentialsFlow.fetchAccessToken()\n     */\n    fetchAccessToken() {\n        return this.token.fetchAccessToken({grant_type: 'client_credentials'})\n    }\n}",
     "static": true,
     "longname": "src/auth/ClientCredentialsFlow.js",
     "access": null,
@@ -3960,7 +3963,7 @@
     "importStyle": "ClientCredentialsFlow",
     "description": "Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX\nuser's personal data.",
     "see": [
-      "https://kkbox.gelato.io/docs/versions/1.1/authentication"
+      "https://docs-en.kkbox.codes/docs/getting-started"
     ],
     "lineNumber": 6,
     "interface": false

--- a/docs/file/src/api/AlbumFetcher.js.html
+++ b/docs/file/src/api/AlbumFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Fetch metadata and tracks of a album.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums
+ * @see https://docs-en.kkbox.codes/v1.1/reference#albums
  */
 export default class AlbumFetcher extends Fetcher {    
     /**
@@ -80,7 +80,7 @@ export default class AlbumFetcher extends Fetcher {
      *
      * @param {string} album_id - The ID of an album.
      * @return {AlbumFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id
      */
     setAlbumID(album_id) {
         this.album_id = album_id        
@@ -92,7 +92,7 @@ export default class AlbumFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.albumFetcher.setAlbumID(&apos;KmRKnW5qmUrTnGRuxF&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.album_id, {territory: this.territory})
@@ -114,7 +114,7 @@ export default class AlbumFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.albumFetcher.setAlbumID(&apos;KmRKnW5qmUrTnGRuxF&apos;).fetchTracks()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks
      */
     fetchTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.album_id + &apos;/tracks&apos;, {

--- a/docs/file/src/api/ArtistFetcher.js.html
+++ b/docs/file/src/api/ArtistFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Get artist metadata.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#artists
  */
 export default class ArtistFetcher extends Fetcher {
     /**
@@ -80,7 +80,7 @@ export default class ArtistFetcher extends Fetcher {
      *
      * @param {string} artist_id - The ID of an artist.
      * @return {Artist}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id
      */
     setArtistID(artist_id) {
         this.artist_id = artist_id
@@ -92,7 +92,7 @@ export default class ArtistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.Artist.setArtistID(&apos;Cnv_K6i5Ft4y41SxLy&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.artist_id, {territory: this.territory})
@@ -105,7 +105,7 @@ export default class ArtistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.artistFetcher.setArtistID(&apos;Cnv_K6i5Ft4y41SxLy&apos;).fetchAlbums()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums
      */
     fetchAlbums(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.artist_id + &apos;/albums&apos;, {
@@ -122,7 +122,7 @@ export default class ArtistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.Artist.setArtistID(&apos;Cnv_K6i5Ft4y41SxLy&apos;).fetchTopTracks()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks
      */
     fetchTopTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.artist_id + &apos;/top-tracks&apos;, {

--- a/docs/file/src/api/ChartFetcher.js.html
+++ b/docs/file/src/api/ChartFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * The fetcher that can fetch chart playlists.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts
+ * @see https://docs-en.kkbox.codes/v1.1/reference#charts
  */
 export default class ChartFetcher extends Fetcher {
     /**
@@ -75,7 +75,7 @@ export default class ChartFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.chartFetcher.fetchCharts()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts
+     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1
      */
     fetchCharts() {
         return this.http.get(ENDPOINT, {

--- a/docs/file/src/api/FeaturedPlaylistCategoryFetcher.js.html
+++ b/docs/file/src/api/FeaturedPlaylistCategoryFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * List featured playlist categories.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories
+ * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories
  */
 export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
     /**
@@ -80,7 +80,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories
      */
     fetchAllFeaturedPlaylistCategories() {
         return this.http.get(ENDPOINT, {territory: this.territory})
@@ -91,7 +91,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @param {string} category_id - The category ID.
      * @return {FeaturedPlaylistCategoryFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id
      */
     setCategoryID(category_id) {
         this.category_id = category_id        
@@ -103,7 +103,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.setCategoryID(&apos;LXUR688EBKRRZydAWb&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})
@@ -116,7 +116,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.setCategoryID(&apos;LXUR688EBKRRZydAWb&apos;).fetchPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists
      */
     fetchPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.category_id + &apos;/playlists&apos;, {

--- a/docs/file/src/api/FeaturedPlaylistFetcher.js.html
+++ b/docs/file/src/api/FeaturedPlaylistFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * List all featured playlists.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists
  */
 export default class FeaturedPlaylistFetcher extends Fetcher {
     /**
@@ -77,7 +77,7 @@ export default class FeaturedPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists
      */
     fetchAllFeaturedPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {

--- a/docs/file/src/api/GenreStationFetcher.js.html
+++ b/docs/file/src/api/GenreStationFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Get genre stations.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations
+ * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations
  */
 export default class GenreStationFetcher extends Fetcher {
     /**
@@ -82,7 +82,7 @@ export default class GenreStationFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.GenreStation.fetchAllGenreStations()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations
      */
     fetchAllGenreStations(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -97,7 +97,7 @@ export default class GenreStationFetcher extends Fetcher {
      *
      * @param {string} genre_station_id - The ID of a genre station.
      * @return {GenreStation}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id
      */
     setGenreStationID(genre_station_id) {
         this.genre_station_id = genre_station_id        
@@ -109,7 +109,7 @@ export default class GenreStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.GenreStation.setGenreStationID(&apos;TYq3EHFTl-1EOvJM5Y&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.genre_station_id, {territory: this.territory})

--- a/docs/file/src/api/MoodStationFetcher.js.html
+++ b/docs/file/src/api/MoodStationFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Get mood stations.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations
+ * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations
  */
 export default class MoodStationFetcher extends Fetcher {
     /**
@@ -80,7 +80,7 @@ export default class MoodStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.moodStationFetcher.fetchAllMoodStations()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations
      */
     fetchAllMoodStations() {
         return this.http.get(ENDPOINT, {territory: this.territory})
@@ -92,7 +92,7 @@ export default class MoodStationFetcher extends Fetcher {
      * @param {string} mood_station_id - The ID of a mood station.
      * @param {string} [territory = &apos;TW&apos;] - [&apos;TW&apos;, &apos;HK&apos;, &apos;SG&apos;, &apos;MY&apos;, &apos;JP&apos;] The territory of a mood station.
      * @return {MoodStation}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id
      */
     setMoodStationID(mood_station_id, territory = &apos;TW&apos;) {
         this.mood_station_id = mood_station_id
@@ -105,6 +105,7 @@ export default class MoodStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.moodStationFetcher.setMoodStationID(&apos;StGZp2ToWq92diPHS7&apos;).fetchMetadata()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.mood_station_id, {territory: this.territory})

--- a/docs/file/src/api/NewHitsPlaylistFetcher.js.html
+++ b/docs/file/src/api/NewHitsPlaylistFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * List new hits playlists.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists
  */
 export default class NewHitsPlaylistFetcher extends Fetcher {
     /**
@@ -82,7 +82,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists
      */
     fetchAllNewHitsPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -95,7 +95,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      *
      * @param {string} playlist_id - The playlist ID.
      * @return {NewHitsPlaylistFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id
      */
     setPlaylistID(playlist_id) {
         this.playlist_id = playlist_id        
@@ -107,7 +107,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.newHitsPlaylistFetcher.setPlaylistID(&apos;DZrC8m29ciOFY2JAm3&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})

--- a/docs/file/src/api/NewReleaseCategoryFetcher.js.html
+++ b/docs/file/src/api/NewReleaseCategoryFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * List categories of new release albums.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories
+ * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories
  */
 export default class NewReleaseCategoryFetcher extends Fetcher {
     /**
@@ -82,7 +82,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories
      */
     fetchAllNewReleaseCategories(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -97,7 +97,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      *
      * @param {string} category_id - The category ID.
      * @return {NewReleaseCategoryFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id
      */
     setCategoryID(category_id) {
         this.category_id = category_id        
@@ -109,7 +109,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.setCategoryID(&apos;Cng5IUIQhxb8w1cbsz&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})
@@ -122,7 +122,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.setCategoryID(&apos;Cng5IUIQhxb8w1cbsz&apos;).fetchAlbums()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums
      */
     fetchAlbums(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.category_id + &apos;/albums&apos;, {

--- a/docs/file/src/api/SearchFetcher.js.html
+++ b/docs/file/src/api/SearchFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Search API.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search
+ * @see https://docs-en.kkbox.codes/v1.1/reference#search
  */
 export default class SearchFetcher extends Fetcher {
     /**
@@ -114,7 +114,7 @@ export default class SearchFetcher extends Fetcher {
      * @param {string} q - The keyword to be searched.
      * @param {string} [type] - [&apos;artist&apos;, &apos;album&apos;, &apos;track&apos;, &apos;playlist&apos;] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use &apos;,&apos; to separate them.
      * @return {Search}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search
+     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1
      */
     setSearchCriteria(q, type = undefined) {
         this.q = q
@@ -129,7 +129,7 @@ export default class SearchFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.searchFetcher.setSearchCriteria(&apos;&#x4E94;&#x6708;&#x5929; &#x597D;&#x597D;&apos;).fetchSearchResult()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search
+     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1
      */
     fetchSearchResult(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {

--- a/docs/file/src/api/SharedPlaylistFetcher.js.html
+++ b/docs/file/src/api/SharedPlaylistFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Get playlist metadata.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists
  */
 export default class SharedPlaylistFetcher extends Fetcher {
     /**
@@ -80,7 +80,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      *
      * @param {string} playlist_id - The ID of a playlist.
      * @return {SharedPlaylistFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id
      */
     setPlaylistID(playlist_id) {
         this.playlist_id = playlist_id
@@ -92,7 +92,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.SharedPlaylistFetcher.setPlaylistID(&apos;4nUZM-TY2aVxZ2xaA-&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})
@@ -114,7 +114,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.SharedPlaylistFetcher.setPlaylistID(&apos;4nUZM-TY2aVxZ2xaA-&apos;).fetchTracks()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks
      */
     fetchTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.playlist_id + &apos;/tracks&apos;, {

--- a/docs/file/src/api/TrackFetcher.js.html
+++ b/docs/file/src/api/TrackFetcher.js.html
@@ -60,7 +60,7 @@ import Fetcher from &apos;./Fetcher&apos;
 
 /**
  * Get metadata of a track.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks
+ * @see https://docs-en.kkbox.codes/v1.1/reference#tracks
  */
 export default class TrackFetcher extends Fetcher {
     /**
@@ -80,7 +80,7 @@ export default class TrackFetcher extends Fetcher {
      *
      * @param {string} track_id - The ID of a track.
      * @return {Track}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id
      */
     setTrackID(track_id) {
         this.track_id = track_id
@@ -92,7 +92,7 @@ export default class TrackFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.Track.setTrackID(&apos;KpnEGVHEsGgkoB0MBk&apos;).fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.track_id, {territory: this.territory})

--- a/docs/file/src/auth/ClientCredentialsFlow.js.html
+++ b/docs/file/src/auth/ClientCredentialsFlow.js.html
@@ -58,7 +58,7 @@
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">/**
  * Implements the client credentials flow. Used for accessing APIs that don&apos;t need any KKBOX
  * user&apos;s personal data.
- * @see https://kkbox.gelato.io/docs/versions/1.1/authentication
+ * @see https://docs-en.kkbox.codes/docs/getting-started
  */
 export default class ClientCredentialsFlow {
     /**

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,7 @@ auth.clientCredentialsFlow.fetchAccessToken().then(response =&gt; {
 </code></pre><h3 id="generate-the-sdk-documentation">Generate the SDK Documentation</h3>
 <pre><code><code class="source-code prettyprint">npm run build-doc</code>
 </code></pre><p>Then open the the file <code>docs/index.html</code></p>
-<h3 id="-api-documentation-https-kkbox-gelato-io-"><a href="https://kkbox.gelato.io">API Documentation</a></h3>
+<h3 id="-api-documentation-https-docs-en-kkbox-codes-"><a href="https://docs-en.kkbox.codes/">API Documentation</a></h3>
 <h3 id="license">License</h3>
 <p>Copyright 2017 KKBOX Technologies Limited</p>
 <p>   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkbox/kkbox-js-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "KKBOX Open API developer SDK for JavaScript. Use it to easily access KKBOX open API to get various metadata about KKBOX's tracks, albums, artists, playlists and stations. ",
   "main": "./dist/SDK.js",
   "scripts": {

--- a/docs/source.html
+++ b/docs/source.html
@@ -75,7 +75,7 @@
       <td class="coverage"><span data-ice="coverage">-</span></td>
       <td style="display: none;" data-ice="size">1446 byte</td>
       <td style="display: none;" data-ice="lines">83</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/SDK.js.html">src/SDK.js</a></span></td>
@@ -83,15 +83,15 @@
       <td class="coverage"><span data-ice="coverage">-</span></td>
       <td style="display: none;" data-ice="size">84 byte</td>
       <td style="display: none;" data-ice="lines">1</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/AlbumFetcher.js.html">src/api/AlbumFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/AlbumFetcher.js~AlbumFetcher.html">AlbumFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">2105 byte</td>
+      <td style="display: none;" data-ice="size">2002 byte</td>
       <td style="display: none;" data-ice="lines">68</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 16:02:19 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/Api.js.html#errorLines=27,28">src/api/Api.js</a></span></td>
@@ -99,39 +99,39 @@
       <td class="coverage"><span data-ice="coverage">87 %</span><span data-ice="coverageCount" class="coverage-count">14/16</span></td>
       <td style="display: none;" data-ice="size">3101 byte</td>
       <td style="display: none;" data-ice="lines">95</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/ArtistFetcher.js.html">src/api/ArtistFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/ArtistFetcher.js~ArtistFetcher.html">ArtistFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">2448 byte</td>
+      <td style="display: none;" data-ice="size">2309 byte</td>
       <td style="display: none;" data-ice="lines">76</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:34:40 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/ChartFetcher.js.html">src/api/ChartFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/ChartFetcher.js~ChartFetcher.html">ChartFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
-      <td style="display: none;" data-ice="size">706 byte</td>
+      <td style="display: none;" data-ice="size">669 byte</td>
       <td style="display: none;" data-ice="lines">27</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:54:59 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/FeaturedPlaylistCategoryFetcher.js.html">src/api/FeaturedPlaylistCategoryFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/FeaturedPlaylistCategoryFetcher.js~FeaturedPlaylistCategoryFetcher.html">FeaturedPlaylistCategoryFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">2628 byte</td>
+      <td style="display: none;" data-ice="size">2398 byte</td>
       <td style="display: none;" data-ice="lines">70</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:38:21 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/FeaturedPlaylistFetcher.js.html">src/api/FeaturedPlaylistFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/FeaturedPlaylistFetcher.js~FeaturedPlaylistFetcher.html">FeaturedPlaylistFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
-      <td style="display: none;" data-ice="size">1032 byte</td>
+      <td style="display: none;" data-ice="size">978 byte</td>
       <td style="display: none;" data-ice="lines">31</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:38:53 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/Fetcher.js.html">src/api/Fetcher.js</a></span></td>
@@ -139,15 +139,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
       <td style="display: none;" data-ice="size">2959 byte</td>
       <td style="display: none;" data-ice="lines">87</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/GenreStationFetcher.js.html">src/api/GenreStationFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/GenreStationFetcher.js~GenreStationFetcher.html">GenreStationFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
-      <td style="display: none;" data-ice="size">1942 byte</td>
+      <td style="display: none;" data-ice="size">1812 byte</td>
       <td style="display: none;" data-ice="lines">59</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:39:43 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/HttpClient.js.html">src/api/HttpClient.js</a></span></td>
@@ -155,55 +155,55 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
       <td style="display: none;" data-ice="size">1202 byte</td>
       <td style="display: none;" data-ice="lines">47</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/MoodStationFetcher.js.html#errorLines=42">src/api/MoodStationFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/MoodStationFetcher.js~MoodStationFetcher.html">MoodStationFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">80 %</span><span data-ice="coverageCount" class="coverage-count">4/5</span></td>
-      <td style="display: none;" data-ice="size">1650 byte</td>
-      <td style="display: none;" data-ice="lines">54</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="size">1644 byte</td>
+      <td style="display: none;" data-ice="lines">55</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:40:37 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/NewHitsPlaylistFetcher.js.html">src/api/NewHitsPlaylistFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/NewHitsPlaylistFetcher.js~NewHitsPlaylistFetcher.html">NewHitsPlaylistFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
-      <td style="display: none;" data-ice="size">1865 byte</td>
+      <td style="display: none;" data-ice="size">1724 byte</td>
       <td style="display: none;" data-ice="lines">57</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:41:25 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/NewReleaseCategoryFetcher.js.html">src/api/NewReleaseCategoryFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/NewReleaseCategoryFetcher.js~NewReleaseCategoryFetcher.html">NewReleaseCategoryFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">2749 byte</td>
+      <td style="display: none;" data-ice="size">2548 byte</td>
       <td style="display: none;" data-ice="lines">76</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:43:19 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/SearchFetcher.js.html">src/api/SearchFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/SearchFetcher.js~SearchFetcher.html">SearchFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
-      <td style="display: none;" data-ice="size">7071 byte</td>
+      <td style="display: none;" data-ice="size">7027 byte</td>
       <td style="display: none;" data-ice="lines">165</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:45:22 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/SharedPlaylistFetcher.js.html">src/api/SharedPlaylistFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/SharedPlaylistFetcher.js~SharedPlaylistFetcher.html">SharedPlaylistFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">5/5</span></td>
-      <td style="display: none;" data-ice="size">2262 byte</td>
+      <td style="display: none;" data-ice="size">2130 byte</td>
       <td style="display: none;" data-ice="lines">68</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:46:21 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/api/TrackFetcher.js.html">src/api/TrackFetcher.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/api/TrackFetcher.js~TrackFetcher.html">TrackFetcher</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
-      <td style="display: none;" data-ice="size">1412 byte</td>
+      <td style="display: none;" data-ice="size">1343 byte</td>
       <td style="display: none;" data-ice="lines">51</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:51:31 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/auth/Auth.js.html">src/auth/Auth.js</a></span></td>
@@ -211,15 +211,15 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">4/4</span></td>
       <td style="display: none;" data-ice="size">736 byte</td>
       <td style="display: none;" data-ice="lines">25</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/auth/ClientCredentialsFlow.js.html">src/auth/ClientCredentialsFlow.js</a></span></td>
       <td data-ice="identifier" class="identifiers"><span><a href="class/src/auth/ClientCredentialsFlow.js~ClientCredentialsFlow.html">ClientCredentialsFlow</a></span></td>
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
-      <td style="display: none;" data-ice="size">617 byte</td>
+      <td style="display: none;" data-ice="size">609 byte</td>
       <td style="display: none;" data-ice="lines">25</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:53:25 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/auth/TokenFetcher.js.html">src/auth/TokenFetcher.js</a></span></td>
@@ -227,7 +227,7 @@
       <td class="coverage"><span data-ice="coverage">100 %</span><span data-ice="coverageCount" class="coverage-count">2/2</span></td>
       <td style="display: none;" data-ice="size">916 byte</td>
       <td style="display: none;" data-ice="lines">39</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 <tr data-ice="file">
       <td data-ice="filePath"><span><a href="file/src/catchError.js.html">src/catchError.js</a></span></td>
@@ -235,7 +235,7 @@
       <td class="coverage"><span data-ice="coverage">-</span></td>
       <td style="display: none;" data-ice="size">307 byte</td>
       <td style="display: none;" data-ice="lines">16</td>
-      <td style="display: none;" data-ice="updated">2017-10-05 10:30:30 (UTC)</td>
+      <td style="display: none;" data-ice="updated">2017-12-06 15:13:12 (UTC)</td>
     </tr>
 </tbody>
 </table>

--- a/src/api/AlbumFetcher.js
+++ b/src/api/AlbumFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Fetch metadata and tracks of a album.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums
+ * @see https://docs-en.kkbox.codes/v1.1/reference#albums
  */
 export default class AlbumFetcher extends Fetcher {    
     /**
@@ -23,7 +23,7 @@ export default class AlbumFetcher extends Fetcher {
      *
      * @param {string} album_id - The ID of an album.
      * @return {AlbumFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id
      */
     setAlbumID(album_id) {
         this.album_id = album_id        
@@ -35,7 +35,7 @@ export default class AlbumFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.album_id, {territory: this.territory})
@@ -57,7 +57,7 @@ export default class AlbumFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.albumFetcher.setAlbumID('KmRKnW5qmUrTnGRuxF').fetchTracks()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/albums/endpoints/get-albums-album_id-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#albums-album_id-tracks
      */
     fetchTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.album_id + '/tracks', {

--- a/src/api/ArtistFetcher.js
+++ b/src/api/ArtistFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Get artist metadata.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#artists
  */
 export default class ArtistFetcher extends Fetcher {
     /**
@@ -23,7 +23,7 @@ export default class ArtistFetcher extends Fetcher {
      *
      * @param {string} artist_id - The ID of an artist.
      * @return {Artist}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id
      */
     setArtistID(artist_id) {
         this.artist_id = artist_id
@@ -35,7 +35,7 @@ export default class ArtistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.artist_id, {territory: this.territory})
@@ -48,7 +48,7 @@ export default class ArtistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchAlbums()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-albums
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-albums
      */
     fetchAlbums(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.artist_id + '/albums', {
@@ -65,7 +65,7 @@ export default class ArtistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-toptracks
      */
     fetchTopTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.artist_id + '/top-tracks', {

--- a/src/api/ChartFetcher.js
+++ b/src/api/ChartFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * The fetcher that can fetch chart playlists.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts
+ * @see https://docs-en.kkbox.codes/v1.1/reference#charts
  */
 export default class ChartFetcher extends Fetcher {
     /**
@@ -18,7 +18,7 @@ export default class ChartFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.chartFetcher.fetchCharts()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/charts/endpoints/get-charts
+     * @see https://docs-en.kkbox.codes/v1.1/reference#charts_1
      */
     fetchCharts() {
         return this.http.get(ENDPOINT, {

--- a/src/api/FeaturedPlaylistCategoryFetcher.js
+++ b/src/api/FeaturedPlaylistCategoryFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * List featured playlist categories.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories
+ * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlist-categories
  */
 export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
     /**
@@ -23,7 +23,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.fetchAllFeaturedPlaylistCategories()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories
      */
     fetchAllFeaturedPlaylistCategories() {
         return this.http.get(ENDPOINT, {territory: this.territory})
@@ -34,7 +34,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @param {string} category_id - The category ID.
      * @return {FeaturedPlaylistCategoryFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id
      */
     setCategoryID(category_id) {
         this.category_id = category_id        
@@ -46,7 +46,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})
@@ -59,7 +59,7 @@ export default class FeaturedPlaylistCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.featuredPlaylistCategoryFetcher.setCategoryID('LXUR688EBKRRZydAWb').fetchPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlist-categories/endpoints/get-featured-playlist-categories-category_id-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylistcategories-category_id-playlists
      */
     fetchPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.category_id + '/playlists', {

--- a/src/api/FeaturedPlaylistFetcher.js
+++ b/src/api/FeaturedPlaylistFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * List all featured playlists.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#featured-playlists
  */
 export default class FeaturedPlaylistFetcher extends Fetcher {
     /**
@@ -20,7 +20,7 @@ export default class FeaturedPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.featuredPlaylistFetcher.fetchAllFeaturedPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/featured-playlists/endpoints/get-featured-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#featuredplaylists
      */
     fetchAllFeaturedPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {

--- a/src/api/GenreStationFetcher.js
+++ b/src/api/GenreStationFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Get genre stations.
- * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations
+ * @see https://docs-en.kkbox.codes/v1.1/reference#genre-stations
  */
 export default class GenreStationFetcher extends Fetcher {
     /**
@@ -25,7 +25,7 @@ export default class GenreStationFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.GenreStation.fetchAllGenreStations()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations
      */
     fetchAllGenreStations(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -40,7 +40,7 @@ export default class GenreStationFetcher extends Fetcher {
      *
      * @param {string} genre_station_id - The ID of a genre station.
      * @return {GenreStation}
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id
      */
     setGenreStationID(genre_station_id) {
         this.genre_station_id = genre_station_id        
@@ -52,7 +52,7 @@ export default class GenreStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#genrestations-station_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.genre_station_id, {territory: this.territory})

--- a/src/api/MoodStationFetcher.js
+++ b/src/api/MoodStationFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Get mood stations.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations
+ * @see https://docs-en.kkbox.codes/v1.1/reference#mood-stations
  */
 export default class MoodStationFetcher extends Fetcher {
     /**
@@ -23,7 +23,7 @@ export default class MoodStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.moodStationFetcher.fetchAllMoodStations()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations
      */
     fetchAllMoodStations() {
         return this.http.get(ENDPOINT, {territory: this.territory})
@@ -35,7 +35,7 @@ export default class MoodStationFetcher extends Fetcher {
      * @param {string} mood_station_id - The ID of a mood station.
      * @param {string} [territory = 'TW'] - ['TW', 'HK', 'SG', 'MY', 'JP'] The territory of a mood station.
      * @return {MoodStation}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/mood-stations/endpoints/get-mood-stations-station_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id
      */
     setMoodStationID(mood_station_id, territory = 'TW') {
         this.mood_station_id = mood_station_id
@@ -48,6 +48,7 @@ export default class MoodStationFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.moodStationFetcher.setMoodStationID('StGZp2ToWq92diPHS7').fetchMetadata()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#moodstations-station_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.mood_station_id, {territory: this.territory})

--- a/src/api/NewHitsPlaylistFetcher.js
+++ b/src/api/NewHitsPlaylistFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * List new hits playlists.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#new-hits-playlists
  */
 export default class NewHitsPlaylistFetcher extends Fetcher {
     /**
@@ -25,7 +25,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists
      */
     fetchAllNewHitsPlaylists(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -38,7 +38,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      *
      * @param {string} playlist_id - The playlist ID.
      * @return {NewHitsPlaylistFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id
      */
     setPlaylistID(playlist_id) {
         this.playlist_id = playlist_id        
@@ -50,7 +50,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-hits-playlists/endpoints/get-new-hits-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})

--- a/src/api/NewReleaseCategoryFetcher.js
+++ b/src/api/NewReleaseCategoryFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * List categories of new release albums.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories
+ * @see https://docs-en.kkbox.codes/v1.1/reference#new-release-categories
  */
 export default class NewReleaseCategoryFetcher extends Fetcher {
     /**
@@ -25,7 +25,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.fetchAllNewReleaseCategories()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories
      */
     fetchAllNewReleaseCategories(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {
@@ -40,7 +40,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      *
      * @param {string} category_id - The category ID.
      * @return {NewReleaseCategoryFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id
      */
     setCategoryID(category_id) {
         this.category_id = category_id        
@@ -52,7 +52,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.category_id, {territory: this.territory})
@@ -65,7 +65,7 @@ export default class NewReleaseCategoryFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.newReleaseCategoryFetcher.setCategoryID('Cng5IUIQhxb8w1cbsz').fetchAlbums()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/new-release-categories/endpoints/get-new-release-categories-category_id-albums
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newreleasecategories-category_id-albums
      */
     fetchAlbums(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.category_id + '/albums', {

--- a/src/api/SearchFetcher.js
+++ b/src/api/SearchFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Search API.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search
+ * @see https://docs-en.kkbox.codes/v1.1/reference#search
  */
 export default class SearchFetcher extends Fetcher {
     /**
@@ -57,7 +57,7 @@ export default class SearchFetcher extends Fetcher {
      * @param {string} q - The keyword to be searched.
      * @param {string} [type] - ['artist', 'album', 'track', 'playlist'] The type of search. Default to search all types. If you want to use multiple type at the same time, you may use ',' to separate them.
      * @return {Search}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search
+     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1
      */
     setSearchCriteria(q, type = undefined) {
         this.q = q
@@ -72,7 +72,7 @@ export default class SearchFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.searchFetcher.setSearchCriteria('五月天 好好').fetchSearchResult()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/search/endpoints/get-search
+     * @see https://docs-en.kkbox.codes/v1.1/reference#search_1
      */
     fetchSearchResult(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT, {

--- a/src/api/SharedPlaylistFetcher.js
+++ b/src/api/SharedPlaylistFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Get playlist metadata.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists
+ * @see https://docs-en.kkbox.codes/v1.1/reference#shared-playlists
  */
 export default class SharedPlaylistFetcher extends Fetcher {
     /**
@@ -23,7 +23,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      *
      * @param {string} playlist_id - The ID of a playlist.
      * @return {SharedPlaylistFetcher}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id
      */
     setPlaylistID(playlist_id) {
         this.playlist_id = playlist_id
@@ -35,7 +35,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})
@@ -57,7 +57,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
      * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks
+     * @see https://docs-en.kkbox.codes/v1.1/reference#sharedplaylists-playlist_id-tracks
      */
     fetchTracks(limit = undefined, offset = undefined) {
         return this.http.get(ENDPOINT + this.playlist_id + '/tracks', {

--- a/src/api/TrackFetcher.js
+++ b/src/api/TrackFetcher.js
@@ -3,7 +3,7 @@ import Fetcher from './Fetcher'
 
 /**
  * Get metadata of a track.
- * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks
+ * @see https://docs-en.kkbox.codes/v1.1/reference#tracks
  */
 export default class TrackFetcher extends Fetcher {
     /**
@@ -23,7 +23,7 @@ export default class TrackFetcher extends Fetcher {
      *
      * @param {string} track_id - The ID of a track.
      * @return {Track}
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id
      */
     setTrackID(track_id) {
         this.track_id = track_id
@@ -35,7 +35,7 @@ export default class TrackFetcher extends Fetcher {
      *
      * @return {Promise}
      * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()
-     * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id
+     * @see https://docs-en.kkbox.codes/v1.1/reference#tracks-track_id
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.track_id, {territory: this.territory})

--- a/src/auth/ClientCredentialsFlow.js
+++ b/src/auth/ClientCredentialsFlow.js
@@ -1,7 +1,7 @@
 /**
  * Implements the client credentials flow. Used for accessing APIs that don't need any KKBOX
  * user's personal data.
- * @see https://kkbox.gelato.io/docs/versions/1.1/authentication
+ * @see https://docs-en.kkbox.codes/docs/getting-started
  */
 export default class ClientCredentialsFlow {
     /**


### PR DESCRIPTION
Since the KKBOX Open API reference has been moved from https://kkbox.gelato.io/docs/versions/1.1 to https://docs-en.kkbox.codes/docs. 

Those links in document should be updated as well.