### PR TITLE
docs: Correct the reference names in example code

### DIFF
--- a/src/api/ArtistFetcher.js
+++ b/src/api/ArtistFetcher.js
@@ -34,7 +34,7 @@ export default class ArtistFetcher extends Fetcher {
      * Fetch metadata of the artist you find.
      *
      * @return {Promise}
-     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()
+     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchMetadata()
      * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id
      */
     fetchMetadata() {
@@ -64,7 +64,7 @@ export default class ArtistFetcher extends Fetcher {
      * @param {number} [limit] - The size for one page.
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
-     * @example api.Artist.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()
+     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchTopTracks()
      * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/artists/endpoints/get-artists-artist_id-top-tracks
      */
     fetchTopTracks(limit = undefined, offset = undefined) {

--- a/src/api/GenreStationFetcher.js
+++ b/src/api/GenreStationFetcher.js
@@ -24,7 +24,7 @@ export default class GenreStationFetcher extends Fetcher {
      * @param {number} [limit] - The size for one page.
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
-     * @example api.GenreStation.fetchAllGenreStations()
+     * @example api.genreStationFetcher.fetchAllGenreStations()
      * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations
      */
     fetchAllGenreStations(limit = undefined, offset = undefined) {
@@ -51,7 +51,7 @@ export default class GenreStationFetcher extends Fetcher {
      * Fetch metadata of the genre station with the genre station fetcher.
      *
      * @return {Promise}
-     * @example api.GenreStation.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()
+     * @example api.genreStationFetcher.setGenreStationID('TYq3EHFTl-1EOvJM5Y').fetchMetadata()
      * @see https://kkbox.gelato.io/docs/versions/v1.1/resources/genre-stations/endpoints/get-genre-stations-station_id
      */
     fetchMetadata() {

--- a/src/api/SharedPlaylistFetcher.js
+++ b/src/api/SharedPlaylistFetcher.js
@@ -34,7 +34,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      * Fetch metadata of the shared playlist with the shared playlist fetcher.
      *
      * @return {Promise}
-     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()
+     * @example api.sharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchMetadata()
      * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id
      */
     fetchMetadata() {
@@ -56,7 +56,7 @@ export default class SharedPlaylistFetcher extends Fetcher {
      * @param {number} [limit] - The size for one page.
      * @param {number} [offset] - The offset index for first element.
      * @return {Promise}
-     * @example api.SharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()
+     * @example api.sharedPlaylistFetcher.setPlaylistID('4nUZM-TY2aVxZ2xaA-').fetchTracks()
      * @see https://kkbox.gelato.io/docs/versions/1.1/resources/shared-playlists/endpoints/get-shared-playlists-playlist_id-tracks
      */
     fetchTracks(limit = undefined, offset = undefined) {

--- a/src/api/TrackFetcher.js
+++ b/src/api/TrackFetcher.js
@@ -34,7 +34,7 @@ export default class TrackFetcher extends Fetcher {
      * Get metadata of the track with the track fetcher.
      *
      * @return {Promise}
-     * @example api.Track.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()
+     * @example api.trackFetcher.setTrackID('KpnEGVHEsGgkoB0MBk').fetchMetadata()
      * @see https://kkbox.gelato.io/docs/versions/1.1/resources/tracks/endpoints/get-tracks-track_id
      */
     fetchMetadata() {


### PR DESCRIPTION
I found some problem (typo?) with reference names in example which could lead misunderstanding about how to use the JS SDK.

So I correct several false reference names.