### PR TITLE
Fill up the `SharedPlaylistFetcher` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkbox/kkbox-js-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "KKBOX Open API developer SDK for JavaScript. Use it to easily access KKBOX open API to get various metadata about KKBOX's tracks, albums, artists, playlists and stations. ",
   "main": "./dist/SDK.js",
   "scripts": {

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -10,6 +10,7 @@ import NewHitsPlaylistFetcher from './NewHitsPlaylistFetcher'
 import GenreStationFetcher from './GenreStationFetcher'
 import MoodStationFetcher from './MoodStationFetcher'
 import ChartFetcher from './ChartFetcher'
+import SharedPlaylistFetcher from './SharedPlaylistFetcher'
 
 /**
  * Fetch KKBOX resources.
@@ -91,6 +92,11 @@ export default class Api {
         /**
          * @type {ChartFetcher}
          */
-        this.chartFetcher = new ChartFetcher(this.httpClient, this.territory)        
+        this.chartFetcher = new ChartFetcher(this.httpClient, this.territory)
+        
+        /**
+         * @type {SharedPlaylistFetcher}
+         */
+        this.sharedPlaylistFetcher = new SharedPlaylistFetcher(this.httpClient, this.territory)
     }
 }

--- a/test/sdktest.js
+++ b/test/sdktest.js
@@ -101,6 +101,15 @@ describe('SDK Begin to Test', () => {
                             return api.newHitsPlaylistFetcher.fetchAllNewHitsPlaylists().then(response => response.status.should.be.exactly(200))
                         })
                     })
+
+                    describe('Shared Playlist', () => {
+                        it('should response status 200', () => {
+                            return api.sharedPlaylistFetcher.setPlaylistID('KsOjSf4whgbL45hRfl').fetchMetadata().then(response => response.status.should.be.exactly(200))
+                        })
+                        it('should response status 200', () => {
+                            return api.sharedPlaylistFetcher.setPlaylistID('KsOjSf4whgbL45hRfl').fetchTracks().then(response => response.status.should.be.exactly(200))
+                        })
+                    })
                 })
             })
         })


### PR DESCRIPTION
It seems that `SharedPlaylistFetcher` was accidentally missing to expose with the `api` object.

So I filled it up and bump the minor version to `1.1.0` (Adding a new backwards-compatible API).