### PR TITLE
Fill up some of missing endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkbox/kkbox-js-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkbox/kkbox-js-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "KKBOX Open API developer SDK for JavaScript. Use it to easily access KKBOX open API to get various metadata about KKBOX's tracks, albums, artists, playlists and stations. ",
   "main": "./dist/SDK.js",
   "scripts": {

--- a/src/api/ArtistFetcher.js
+++ b/src/api/ArtistFetcher.js
@@ -74,4 +74,21 @@ export default class ArtistFetcher extends Fetcher {
             offset: offset
         })
     }
+
+    /**
+     * Fetch related artists
+     *
+     * @param {number} [limit] - The size for one page.
+     * @param {number} [offset] - The offset index for first element.
+     * @return {Promise}
+     * @example api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchRelatedArtists()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-relatedartists
+     */
+    fetchRelatedArtists(limit = undefined, offset = undefined) {
+        return this.http.get(ENDPOINT + this.artist_id + '/related-artists', {
+            territory: this.territory,
+            limit: limit,
+            offset: offset
+        })
+    }
 }

--- a/src/api/ChartFetcher.js
+++ b/src/api/ChartFetcher.js
@@ -11,6 +11,11 @@ export default class ChartFetcher extends Fetcher {
      */
     constructor(http, territory = 'TW') {
         super(http, territory = 'TW')
+
+        /**
+         * @ignore
+         */
+        this.playlist_id = undefined
     }
 
     /**
@@ -23,6 +28,46 @@ export default class ChartFetcher extends Fetcher {
     fetchCharts() {
         return this.http.get(ENDPOINT, {
             territory: this.territory
+        })
+    }
+
+    /**
+     * Init the chart fetcher.
+     *
+     * @param {string} playlist_id - The playlist ID.
+     * @return {ChartFetcher}
+     * @see https://docs-en.kkbox.codes/v1.1/reference#charts-playlist_id
+     */
+    setPlaylistID(playlist_id) {
+        this.playlist_id = playlist_id        
+        return this
+    }
+
+    /**
+     * Fetch playlist of the chart you set.
+     *
+     * @return {Promise}
+     * @example api.chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchMetadata()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#charts-playlist_id
+     */
+    fetchMetadata() {
+        return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})
+    }
+
+    /**
+     * Fetch tracks of the playlist with the chart fetcher you init. Result will be paged.
+     *
+     * @param {number} [limit] - The size of one page.
+     * @param {number} [offset] - The offset index for first element.
+     * @return {Promise}
+     * @example api.chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchTracks()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#charts-playlist_id-tracks
+     */
+    fetchTracks(limit = undefined, offset = undefined) {
+        return this.http.get(ENDPOINT + this.playlist_id + '/tracks', {
+            territory: this.territory,
+            limit: limit,
+            offset: offset
         })
     }
 }

--- a/src/api/NewHitsPlaylistFetcher.js
+++ b/src/api/NewHitsPlaylistFetcher.js
@@ -46,7 +46,7 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
     }
 
     /**
-     * Fetch metadata of the new release category you set.
+     * Fetch metadata of the new hits playlist you set.
      *
      * @return {Promise}
      * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchMetadata()
@@ -54,5 +54,22 @@ export default class NewHitsPlaylistFetcher extends Fetcher {
      */
     fetchMetadata() {
         return this.http.get(ENDPOINT + this.playlist_id, {territory: this.territory})
+    }
+
+    /**
+     * Fetch tracks of the new hits playlist you set. Result will be paged.
+     *
+     * @param {number} [limit] - The size of one page.
+     * @param {number} [offset] - The offset index for first element.
+     * @return {Promise}
+     * @example api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchTracks()
+     * @see https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id-tracks
+     */
+    fetchTracks(limit = undefined, offset = undefined) {
+        return this.http.get(ENDPOINT + this.playlist_id + '/tracks', {
+            territory: this.territory,
+            limit: limit,
+            offset: offset
+        })
     }
 }

--- a/test/apitest.js
+++ b/test/apitest.js
@@ -419,7 +419,13 @@ describe('Api Begin to Test', () => {
                                 return f.fetchMetadata().then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject)).catch(error => should.not.exsits(error))
                             })
                         })
-                    })                    
+
+                        describe('#fetchTracks()', () => {
+                            it('should succeed', () => {
+                                return f.fetchTracks().then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject)).catch(error => should.not.exsits(error))
+                            })
+                        })
+                    })
                 }, reject => should.not.exists(reject))
             })
         })

--- a/test/apitest.js
+++ b/test/apitest.js
@@ -358,6 +358,20 @@ describe('Api Begin to Test', () => {
                                 })
                             })
                         })
+
+                        describe('#fetchMetadata()', () => {
+                            it('should succeed', (done) => {
+                                chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchMetadata()
+                                    .then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject))
+                            })
+                        })
+
+                        describe('#fetchTracks()', () => {
+                            it('should succeed', (done) => {
+                                chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchTracks()
+                                    .then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject))
+                            })
+                        })
                     })
                     
                     describe('New Release Category', () => {

--- a/test/apitest.js
+++ b/test/apitest.js
@@ -218,6 +218,12 @@ describe('Api Begin to Test', () => {
                                 artistFetcher.fetchTopTracks().then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject))
                             })
                         })
+
+                        describe('#fetchRelatedArtists()', () => {
+                            it('should response status 200', (done) => {
+                                artistFetcher.fetchRelatedArtists().then(response => response.status.should.be.exactly(200), reject => should.not.exists(reject))
+                            })
+                        })
                     })
 
                     describe('Artist fetch album tests', () => {


### PR DESCRIPTION
Compare to the [latest reference](https://docs-en.kkbox.codes/v1.1/reference) of KKBOX Open API, it seems that some of endpoints were missing; So I filled it up and bump the minor version, and here's the list of endpoints that I added:

1. ArtistFetcher
  * `api.artistFetcher.setArtistID('Cnv_K6i5Ft4y41SxLy').fetchRelatedArtists()`
    * Ref: https://docs-en.kkbox.codes/v1.1/reference#artists-artist_id-relatedartists

2. NewHitsPlaylistFetcher
  * `api.newHitsPlaylistFetcher.setPlaylistID('DZrC8m29ciOFY2JAm3').fetchTracks()`
    * Ref: https://docs-en.kkbox.codes/v1.1/reference#newhitsplaylists-playlist_id-tracks

3. ChartFetcher
  * `api.chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchMetadata()`
    * Ref: https://docs-en.kkbox.codes/v1.1/reference#charts-playlist_id
  * `api.chartFetcher.setPlaylistID('4mJSYXvueA8t0odsny').fetchTracks()`
    * Ref: https://docs-en.kkbox.codes/v1.1/reference#charts-playlist_id-tracks