### PR TITLE
Fix unchangeable territory value on ChartFetcher

### DIFF
--- a/src/api/ChartFetcher.js
+++ b/src/api/ChartFetcher.js
@@ -10,8 +10,8 @@ export default class ChartFetcher extends Fetcher {
      * @ignore
      */
     constructor(http, territory = 'TW') {
-        super(http, territory = 'TW')
-
+        super(http, territory)
+        
         /**
          * @ignore
          */


### PR DESCRIPTION
Fix the unchangeable territory value on `ChartFetcher` by removing the wrong assignment.