### PR TITLE
Make sure tests on Travis CI have colorized output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+env:
+  - FORCE_COLOR=true
 node_js:
   - "6"
   - "7"


### PR DESCRIPTION
Set `FORCE_COLOR=true` in `.travis.yml` to make sure tests output colorized,
which is easier to debug and more user friendly.