### PR TITLE
Enable cache for node_modules on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
   - "8"
   - "9"
   - "10"
+cache:
+  directories:
+    - node_modules
 before_script:
   - |
     echo -e "{\"kkbox_sdk\": {\"client_id\": \"$CLIENT_ID\", \"client_secret\": \"$CLIENT_SECRET\"}}" > client_secrets.json


### PR DESCRIPTION
This will speed up Travis CI in future builds.